### PR TITLE
Database config doc tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,6 @@ to learn and to become rapidly productive!
 2. Clone the fork.
 3. Run `bundle install` in the root of the freshly cloned repo. This
    will install Jekyll, the tool we use to build the site.
-4. Make some changes.
-5. Run `jekyll --server` and open your browser to http://localhost:4000
-   to see the changes.
+4. Run `jekyll --server --auto` and open your browser to http://localhost:4000.
+5. Make some changes, refresh your browser to preview them.
+6. Submit a pull request.

--- a/_includes/manuals/1.1/3.5.3_database_setup.md
+++ b/_includes/manuals/1.1/3.5.3_database_setup.md
@@ -1,11 +1,27 @@
 
-By default, Foreman will use sqlite3 as a database, its configuration can be found at 
-<pre>config/database.yml</pre>
-By default, the  database can be found at the db subdirectory.
-Foreman is a rails application, therefor, anything that is supported under RAILS (sqlite, mysql, postgresql, ...) can be used.
-At this time, Oracle DB is known to not work. Patches are welcome!
+Foreman is a rails application. Therefore, anything that is supported under RAILS (sqlite, mysql, postgresql, ...) can be used. See <a href="#3.3InstallFromPackages">3.3 Install From Packages</a> for a list of packages for connecting foreman to the databse of your choice. At this time, Oracle DB is known to not work. Patches are welcome!
+
+The database configuration file can be found at:
+
+<pre>/etc/foreman/config/database.yml</pre>
+
+#### SQLite (default)
+
+<div class="alert alert-info">When using SQLite, you can install the foreman-sqlite package. See <a href="#3.3InstallFromPackages">3.3 Install From Packages</a>.</div>
+
+By default, the database will be created in the db subdirectory.
+
+{% highlight ruby %}
+production:
+  adapter: sqlite3
+  database: db/production.sqlite3
+  pool: 5
+  timeout: 5000
+{% endhighlight %}
 
 #### MySQL
+
+<div class="alert alert-info">When using MySQL, you can install the foreman-mysql package. See <a href="#3.3InstallFromPackages">3.3 Install From Packages</a>.</div>
 
 Edit your config/database.yml and modify:
 {% highlight ruby %}
@@ -24,6 +40,8 @@ Afterwards you would need to re-populate your database, simply execute extras/db
 
 #### PostGreSQL
 
+<div class="alert alert-info">When using PostgreSQL, you can install the foreman-postgresql package. See <a href="#3.3InstallFromPackages">3.3 Install From Packages</a>.</div>
+
 Edit your config/database.yml and modify:
 {% highlight ruby %}
 production:
@@ -34,7 +52,7 @@ production:
   host: localhost
 {% endhighlight %}
 
-#### Switching from SQlite to Mysql/Psql and maintain my data
+#### Switching from SQLite to MySQL/PostgreSQL while maintaining existing data
 
 We have a rake task for this. First setup your database.yml to have the sqlite db as production and the mysql/psql db as dev:
 
@@ -85,4 +103,4 @@ psql -f temp foreman
 rm temp reset.sql
 {% endhighlight %}
 
-(big thanks to http://wiki.postgresql.org/wiki/Fixing_Sequences for the fix)
+(big thanks to [Fixing Sequences](http://wiki.postgresql.org/wiki/Fixing_Sequences) for the fix)


### PR DESCRIPTION
Updated the database config section to let users know about the foreman-\* packages available for each database type. Also updated the README to note the --auto flag to the jekyll command.

![db-docs-update](https://f.cloud.github.com/assets/34866/107898/fb05aba6-6a3b-11e2-994f-4d4efac74941.png)
