### PR TITLE
Prod site has no title

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html itemscope itemtype="http://schema.org/Organization" lang="en">
 
-  <title>{{ page.sitename }}</title>
+  <title>{{ site.sitename }}</title>
   <script type="text/javascript" src="/static/js/jquery.js"></script>
   <script type="text/javascript" src="/static/js/bootstrap.min.js"></script>
   <script type="text/javascript" src="/static/js/jquery-ui-1.9.2.custom.min.js"></script>


### PR DESCRIPTION
 Fixed site not having a site-wide title. For page-specific titles see: https://github.com/mojombo/jekyll/wiki/Template-Data

If accepted, will patch with page-specific meta tags if requested.
