### PR TITLE
Baseurl and release fixes

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -6,6 +6,7 @@ description: Through deep integration with configuration management, DHCP, DNS, 
 
 production_url : http://theforeman.org
 url: http://theforeman.org
+baseurl: /
 
 safe:        false
 auto:        false
@@ -16,12 +17,12 @@ markdown:    rdiscount
 
 navigation:
 - text: Manual
-  url: /manuals/1.1/index.html
+  url: manuals/1.1/index.html
 - text: Screenshots & Screencasts
-  url: /media.html
+  url: media.html
 - text: Contribute
-  url: /contribute.html
+  url: contribute.html
 - text: Support
-  url: /support.html
+  url: support.html
 - text: API
-  url: /api.html
+  url: api.html

--- a/_includes/configuration.html
+++ b/_includes/configuration.html
@@ -1,4 +1,4 @@
 
-<img class="homepage-img" src="static/images/configuration.png">
+<img class="homepage-img" src="{{ site.baseurl }}static/images/configuration.png">
 <h2>Configuration.</h2>
 <p>A complete configuration management solution including an ENC for Puppet, built-in support for parameterized classes and hierarchical parameter storage.</p>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -13,3 +13,6 @@
       var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
   })();
 </script>
+
+</body>
+</html>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,20 +1,33 @@
 <!doctype html>
 <html itemscope itemtype="http://schema.org/Organization" lang="en">
+  <head>
+    <base href="{{ site.baseurl }}">
+    {% if page.sitename != nil %}
+    {% assign sitename = page.sitename %}
+    {% else %}
+    {% assign sitename = site.sitename %}
+    {% endif %}
 
-  <title>{{ site.sitename }}</title>
-  <script type="text/javascript" src="/static/js/jquery.js"></script>
-  <script type="text/javascript" src="/static/js/bootstrap.min.js"></script>
-  <script type="text/javascript" src="/static/js/jquery-ui-1.9.2.custom.min.js"></script>
-  <script type="text/javascript" src="/static/js/jquery.tocify.min.js"></script>
+    {% if page.pagename != nil %}
+    {% assign pagename = true %}
+    {% endif %}
+  <title>{{ sitename }}{% if pagename %} :: {{ page.pagename }}{% endif %}</title>
 
-  <link rel="stylesheet" media="all" href="/static/css/bootstrap.min.css"/>
-  <link rel="stylesheet" media="all" href="/static/css/bootstrap-responsive.min.css"/>
-  <link rel="stylesheet" media="all" href="/static/css/jquery.tocify.css"/>
-  <link rel="stylesheet" media="all" href="/static/css/syntax.css" />
-  <link rel="stylesheet" media="all" href="/static/css/style.css"/>
+  <script type="text/javascript" src="{{ site.baseurl }}static/js/jquery.js"></script>
+  <script type="text/javascript" src="{{ site.baseurl }}static/js/bootstrap.min.js"></script>
+  <script type="text/javascript" src="{{ site.baseurl }}static/js/jquery-ui-1.9.2.custom.min.js"></script>
+  <script type="text/javascript" src="{{ site.baseurl }}static/js/jquery.tocify.min.js"></script>
+
+  <link rel="stylesheet" media="all" href="{{ site.baseurl }}static/css/bootstrap.min.css"/>
+  <link rel="stylesheet" media="all" href="{{ site.baseurl }}static/css/bootstrap-responsive.min.css"/>
+  <link rel="stylesheet" media="all" href="{{ site.baseurl }}static/css/jquery.tocify.css"/>
+  <link rel="stylesheet" media="all" href="{{ site.baseurl }}static/css/syntax.css" />
+  <link rel="stylesheet" media="all" href="{{ site.baseurl }}static/css/style.css"/>
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="viewport" content="user-scalable=no, width=device-width, initial-scale=1.0, maximum-scale=1.0;" />
+</head>
 
+<body>
   <div class="navbar navbar-inverse navbar-fixed-top">
       <div class="navbar-inner">
           <div class="container">
@@ -23,7 +36,7 @@
                   <span class="icon-bar"></span>
                   <span class="icon-bar"></span>
               </button>
-              {% if page.url != "/index.html" %}<img alt="Foreman" class="logo" src="/static/images/foreman.png" />{% endif %}<a class="brand" href="/">Foreman</a>
+              {% if page.url != "/index.html" %}<img alt="Foreman" class="logo" src="{{ site.baseurl }}static/images/foreman.png" />{% endif %}<a class="brand" href="/">Foreman</a>
               <div class="nav-collapse collapse">
                   <ul class="nav">
                       {% for link in site.navigation %}
@@ -31,7 +44,7 @@
                       {% if page.url == link.url or page.layout == link.layout %}
                       {% assign active = 'active' %}
                       {% endif %}
-                      <li class="{{ active }}"><a href="{{ link.url }}"> {{ link.text }} </a></li>
+                      <li class="{{ active }}"><a href="{{ site.baseurl}}{{ link.url }}"> {{ link.text }} </a></li>
                       {% endfor %}
                   </ul>
               </div>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -46,7 +46,8 @@
                       {% endif %}
                       <li class="{{ active }}"><a href="{{ site.baseurl}}{{ link.url }}"> {{ link.text }} </a></li>
                       {% endfor %}
-                  </ul>
+                    </ul>
+                    {% include releasesplash.html %}
               </div>
           </div>
       </div>

--- a/_includes/monitoring.html
+++ b/_includes/monitoring.html
@@ -1,3 +1,3 @@
-<img class="homepage-img" src="static/images/monitoring.png">
+<img class="homepage-img" src="{{ site.baseurl }}static/images/monitoring.png">
 <h2>Monitoring.</h2>
 <p>Collect Puppet reports and facts. Monitor host configuration. Report status, distribution and trends.</p>

--- a/_includes/provisioning.html
+++ b/_includes/provisioning.html
@@ -1,3 +1,3 @@
-<img class="homepage-img" src="static/images/provisioning.png">
+<img class="homepage-img" src="{{ site.baseurl }}static/images/provisioning.png">
 <h2>Provisioning.</h2>
 <p>Provision on bare-metal & public or private clouds all from one place with one simple process.</p>

--- a/_includes/releasesplash.html
+++ b/_includes/releasesplash.html
@@ -1,0 +1,3 @@
+<!-- releasesplash.html -->
+  <a class="btn btn-success btn-small" title="1.1 release notes" href="http://projects.theforeman.org/wiki/foreman/ReleaseNotes#11-stable">Stable: 1.1</a>
+  <a class="btn btn-primary btn-small" title="1.1RC5 release notes" href="http://projects.theforeman.org/wiki/foreman/ReleaseNotes#Release-notes-for-11RC5">Unstable: 1.1RC5</a>

--- a/_layouts/api.html
+++ b/_layouts/api.html
@@ -1,12 +1,13 @@
+---
+pagename: API
+---
 {% include header.html %}
 
-<body>
   <div id="main">
     <div id="content" class="container">
       <iframe src="api/apidoc.html" frameborder="0" width="100%" height="7675px" ></iframe>
     </div>
   </div>
-</body>
 
 <script type="text/javascript">
 $(function (){

--- a/_layouts/contribute.html
+++ b/_layouts/contribute.html
@@ -1,6 +1,8 @@
+---
+pagename: Contribute
+---
 {% include header.html %}
 
-<body>
   <div id="main">
     <div id="content" class="container">
       <a href="https://github.com/theforeman" target="_blank" id="fork-me" class='hidden-tablet hidden-phone'><img style="position: fixed;top: 0; right: 0; border: 0;z-index:999999;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_green_007200.png" alt="Fork me on GitHub"></a>
@@ -13,7 +15,7 @@
       </div>
     </div>
   </div>
-</body>
+
  <script type="text/javascript">
 $(function() {
 //Calls the tocify method on your HTML div.

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,11 +1,9 @@
 {% include header.html %}
 
-<body>
   <div id="main">
     <div id="content" class="container">
       {{ content }}
     </div>
   </div>
-</body>
 
 {% include footer.html %}

--- a/_layouts/homepage.html
+++ b/_layouts/homepage.html
@@ -1,11 +1,10 @@
 {% include header.html %}
 
-<body>
   <div id="main">
     <div id="content" class="container">
       <div class="hero-unit">
         <p>{{ site.tagline }}</p>
-        <img src="/static/images/foreman_large.png" class="homepage-primary-img"/>
+        <img src="{{ site.baseurl }}static/images/foreman_large.png" class="homepage-primary-img"/>
         <p>
           {{ site.description }}
         </p>
@@ -27,6 +26,5 @@
       </div>
     </div>
   </div>
-</body>
 
 {% include footer.html %}

--- a/_layouts/homepage.html
+++ b/_layouts/homepage.html
@@ -3,7 +3,7 @@
   <div id="main">
     <div id="content" class="container">
       <div class="hero-unit">
-        <p>{{ site.tagline }}</p>
+        <p class="tagline">{{ site.tagline }}</p>
         <img src="{{ site.baseurl }}static/images/foreman_large.png" class="homepage-primary-img"/>
         <p>
           {{ site.description }}

--- a/_layouts/manual.html
+++ b/_layouts/manual.html
@@ -1,6 +1,8 @@
+---
+pagename: Manual
+---
 {% include header.html %}
 
-<body>
   <div id="main">
     <div id="content" class="container">
       <div class="row">
@@ -12,7 +14,7 @@
       </div>
     </div>
   </div>
-</body>
+
  <script type="text/javascript">
 $(function() {
 //Calls the tocify method on your HTML div.

--- a/_layouts/media.html
+++ b/_layouts/media.html
@@ -1,6 +1,8 @@
+---
+pagename: Media
+---
 {% include header.html %}
 
-<body>
 <div id="main">
   <div id="content" class="container">
     <div class="tabbable tabs-left">
@@ -14,35 +16,35 @@
           <div id="myCarousel" class="carousel slide">
             <div class="carousel-inner">
                 <div class="item">
-                    <img src="static/images/screenshots/dashboard.png" alt="">
+                  <img src="{{ site.baseurl }}static/images/screenshots/dashboard.png" alt="">
                     <div class="carousel-caption">
                         <h4>The Foreman landing page and dashboard</h4>
                         <p>An instant view into the overall health of your hosts, including a sweeping overview of changes, run distribution, and quickly find hosts using search.</p>
                     </div>
                 </div>
                 <div class="item">
-                    <img src="static/images/screenshots/host_listing.png" alt="">
+                  <img src="{{ site.baseurl }}static/images/screenshots/host_listing.png" alt="">
                     <div class="carousel-caption">
                         <h4>The host listing page</h4>
                         <p>Get a quick overview of your hosts, including their hostname, operating system, and most recent Puppet run.</p>
                     </div>
                 </div>
                 <div class="item">
-                    <img src="static/images/screenshots/hosteditpage.png" alt="">
+                  <img src="{{ site.baseurl }}static/images/screenshots/hosteditpage.png" alt="">
                     <div class="carousel-caption">
                         <h4>Host edit page</h4>
                         <p>Manage the network, operating system, parameters, and other vital information relevant to a specific host.</p>
                     </div>
                 </div>
                 <div class="item">
-                    <img src="static/images/screenshots/reportview.png" alt="">
+                  <img src="{{ site.baseurl }}static/images/screenshots/reportview.png" alt="">
                     <div class="carousel-caption">
                         <h4>The report viewer page</h4>
                         <p>See the exact changes that took place as part of the most recent Puppet agent run on a specific host and view metrics about that run.</p>
                     </div>
                 </div>
                 <div class="item active">
-                    <img src="static/images/screenshots/hostpage.png" alt="">
+                  <img src="{{ site.baseurl }}static/images/screenshots/hostpage.png" alt="">
                     <div class="carousel-caption">
                         <h4>The individual host page</h4>
                         <p>View the status of a single host, including information about the machine, run time, and access to the console for direct access to the host.</p>
@@ -74,7 +76,6 @@
     </div>
   </div>
 </div>
-</body>
 
 <script type="text/javascript">
 // AJAX load Iframe

--- a/_layouts/support.html
+++ b/_layouts/support.html
@@ -1,6 +1,8 @@
+---
+pagename: Support
+---
 {% include header.html %}
 
-<body>
   <div id="main">
     <div id="content" class="container">
       <div class="row">
@@ -12,7 +14,6 @@
       </div>
     </div>
   </div>
-</body>
  <script type="text/javascript">
 $(function() {
 //Calls the tocify method on your HTML div.

--- a/manuals/1.0/1.1_architecture.md
+++ b/manuals/1.0/1.1_architecture.md
@@ -18,4 +18,4 @@ Puppet CA.
 
 A [[Smart-Proxy:Wiki|Smart Proxy]] is located on or near a machine that performs a specific function and helps foreman orchestrate the process of commissioning a new host. Placing the proxy on or near to the actual service will also help reduce latencies in large distributed organizations.
 
-![Foreman Architecture](/static/images/foreman_architecture.png)
+![Foreman Architecture]({{ site.baseurl}}static/images/foreman_architecture.png)

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -71,10 +71,16 @@ border-radius: 4px;
 /* Website specific bootstrap customizations */
 #content .hero-unit {
   padding: 30px;
+  overflow: auto;
+}
+
+p.tagline {
+  font-weight: bold;
 }
 
 .hero-unit img {
   margin-bottom: 20px;
+  float: right;
 }
 
 #content h1 {


### PR DESCRIPTION
For Amos - prepared code to make it easier for hosting in non-root installations (for example personal clones on github). Also added example release version splash to header. Pretty much the only way I could make it fit without ruining the layout.

I don't necessarily like having the versions hardcoded in that html file like that, but wanted to submit for review anyway.
