### PR TITLE
Fixed links to foreman-dev google group in troubleshooting section

### DIFF
--- a/_includes/manuals/1.1/6_troubleshooting.md
+++ b/_includes/manuals/1.1/6_troubleshooting.md
@@ -8,4 +8,4 @@ We work on the [irc.freenode.net](http://webchat.freenode.net/) servers. You can
 Mailing lists are available via Google Groups. Much like IRC, we have a general users (support, Q/A, etc) lists and a development list:
 
 * [foreman-users](https://groups.google.com/forum/?fromgroups#!forum/foreman-users)
-* [foreman-dev](https://groups.google.com/forum/?fromgroups#!forum/foreman-users)
+* [foreman-dev](https://groups.google.com/forum/?fromgroups#!forum/foreman-dev)

--- a/manuals/1.0/5_troubleshooting.md
+++ b/manuals/1.0/5_troubleshooting.md
@@ -12,4 +12,4 @@ We work on the [irc.freenode.net](http://webchat.freenode.net/) servers. You can
 Mailing lists are available via Google Groups. Much like IRC, we have a general users (support, Q/A, etc) lists and a development list:
 
 * [foreman-users](https://groups.google.com/forum/?fromgroups#!forum/foreman-users)
-* [foreman-dev](https://groups.google.com/forum/?fromgroups#!forum/foreman-users)
+* [foreman-dev](https://groups.google.com/forum/?fromgroups#!forum/foreman-dev)


### PR DESCRIPTION
Fixed broken link; foreman-dev links in troubleshooting sections where pointing to the foreman-users google group before
