### PR TITLE
Workaround for 1.0 users who have stealthymonkey packages with epoch=1

### DIFF
--- a/_includes/manuals/1.2/3.3.1_rpm_packages.md
+++ b/_includes/manuals/1.2/3.3.1_rpm_packages.md
@@ -88,9 +88,19 @@ Next upgrade all Foreman packages and migrate the database:
     yum upgrade foreman\*
     sudo -u foreman /usr/share/foreman/extras/dbmigrate
 
-If you use Apache and Passenger (the default installer configuration), additional changes are required to support SCL:
+If you use Apache and Passenger (the default installer configuration), additional changes are required to support SCL.  First run `rpm -q passenger-release` to work out if the system has a Passenger package from upstream or EPEL.
+
+If you have passenger-release installed:
+
+    rpm -e passenger-release
+    yum downgrade mod_passenger-4.0.5 rubygem-passenger-4.0.5 rubygem-passenger-native-4.0.5 rubygem-passenger-native-libs-4.0.5
+
+or if you don't have passenger-release:
 
     yum upgrade \*passenger\*
+
+Next, configure the new version of Passenger:
+
     yum install ruby193-rubygem-passenger-native
     sed -i.bak '/RackAutoDetect/d' /etc/httpd/conf.d/puppet.conf
     sed -i.bak 's|RailsAutoDetect.*|PassengerRuby /usr/bin/ruby193-ruby|' /etc/httpd/conf.d/foreman.conf


### PR DESCRIPTION
Irritatingly their package has an epoch of 1, while EPEL and ours have a default epoch of 0, so it's not possible to upgrade to our package.  I don't really want to set an epoch of 1 on our package, or users won't be able to upgrade to EPEL later.

Only 1.0 users (like me) will hit this due to the installer, 1.1 users got the EPEL version instead.
