### PR TITLE
Clarify smart-proxy DNS update configuration

### DIFF
--- a/_includes/manuals/1.2/4.3.2_smartproxy_settings.md
+++ b/_includes/manuals/1.2/4.3.2_smartproxy_settings.md
@@ -1,4 +1,3 @@
-
 The configuration for Smart-Proxy is held in the */etc/foreman-proxy/settings.yml* or *config/settings.yml* file.
 
 #### YAML start
@@ -60,7 +59,10 @@ Activate the DNS management module within the Smart-Proxy instance.
 
 The DNS module can manipulate any DNS server that complies with the ISC Dynamic DNS Update standard and can therefore be used to manage both Microsoft and Bind servers.  Updates can also be done using GSS-TSIG, see the [documentation](manuals/1.2/index.html#4.3.6GSS-TSIGDNS).
 
-The **dns_key** is used to validate the client request. If it is not present then the update operation is performed without peer verification, (not recommended.)
+The **dns_key** specifies file with shared secret used to generate signature for the update request (TSIG record). This option should not be used if you plan to use Kerberos/GSS-TSIG (for example for DNS servers shipped with FreeIPA or Microsoft AD).
+
+If neither the **dns_key** or GSS-TSIG is used then the update request is sent without any signature. Unsigned update requests are considered insecure. Some DNS servers can be configured to accept only signed signatures.
+
 The **dns_server** option is used if the Smart-Proxy is not located on the same physical host as the DNS server. If it is not specified then localhost is presumed.
 <pre>
 :dns: true

--- a/_includes/manuals/1.2/4.3.6_gsstsig.md
+++ b/_includes/manuals/1.2/4.3.6_gsstsig.md
@@ -1,4 +1,3 @@
-
 Both BIND as configured in FreeIPA and Microsoft AD DNS servers can accept DNS updates using GSS-TSIG authentication.  This uses Kerberos principals to authenticate to the DNS server.  Under Microsoft AD, this is known as "Secure Dynamic Update".
 
 #### Pre-requisites
@@ -8,15 +7,17 @@ Both BIND as configured in FreeIPA and Microsoft AD DNS servers can accept DNS u
 
 #### FreeIPA configuration
 
-A service principal is required for the Smart Proxy, e.g. `host/proxy.example.com@EXAMPLE.COM`.  If the proxy is installed on the FreeIPA server, it can use the DNS principal from the host itself (e.g. `DNS/ipa.example.com@EXAMPLE.COM`).
+A service principal is required for the Smart Proxy, e.g. `foremanproxy/proxy.example.com@EXAMPLE.COM`.
 
-If using a new service principal, use `ipa-getkeytab` to fetch the keytab.  If using FreeIPA's existing DNS keytab, it's important to copy the existing one from `/etc/named.keytab` as requesting a new one will cause the serial number to increment and the existing one to be invalid.
+First of all, create a new principal (FreeIPA service) for Foreman, e.g. `ipa service-add foremanproxy/proxy.example.com@EXAMPLE.COM`.
 
-Copy the keytab to `/etc/foreman-proxy/dns.keytab` and ensure permissions are 0600 and the owner is `foreman-proxy`.
+Then you can fetch the keytab, e.g. `ipa-getkeytab -p foremanproxy/proxy.example.com@EXAMPLE.COM -s ipa-server.example.com -k /etc/foreman-proxy/dns.keytab`.
+    
+Store the keytab to `/etc/foreman-proxy/dns.keytab` and ensure permissions are 0600 and the owner is `foreman-proxy`.
 
 The ACL on updates to the DNS zone then needs to permit the service principal.  In the FreeIPA web UI, under the DNS zone, go to the Settings tab and add to the BIND update policy a new grant:
 
-    grant DNS\047ipa.example.com@EXAMPLE.COM wildcard * ANY;
+    grant foremanproxy\047ipa.example.com@EXAMPLE.COM wildcard * ANY;
 
 Note the `\047` is written verbatim, and don't forget the semicolon.
 


### PR DESCRIPTION
I tried to clarify how option dns_key interacts with GSS-TSIG. Also, the procedure how to configure DNS updates with FreeIPA was modified because the old procedure was insecure.

I'm not native English speaker, so the text will require some corrections.

You can contact me on IRC: pspacek @ #freeipa @ FreeNode
