### PR TITLE
Revert directory_watcher to 1.4.x to fix regneration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ group :development do
   gem 'rb-fsevent', '~> 0.9'
   gem 'stringex', '~> 1.4.0'
   gem 'liquid', '~> 2.3.0'
+  gem 'directory_watcher', '~> 1.4.0'
 end
 
 gem 'sinatra', '~> 1.3.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,7 +12,7 @@ GEM
       chunky_png (~> 1.2)
       fssm (>= 0.2.7)
       sass (~> 3.1)
-    directory_watcher (1.5.1)
+    directory_watcher (1.4.1)
     fast-stemmer (1.0.2)
     ffi (1.0.11)
     fssm (0.2.10)
@@ -56,6 +56,7 @@ PLATFORMS
 DEPENDENCIES
   RedCloth (~> 4.2.9)
   compass (~> 0.12.1)
+  directory_watcher (~> 1.4.0)
   haml (~> 3.1.6)
   jekyll (~> 0.11.2)
   liquid (~> 2.3.0)


### PR DESCRIPTION
See http://stackoverflow.com/questions/15591000/jekylls-auto-doesnt-work

This seems to improve or fix it for me, it's been terribly unreliable before now on 1.5.
