### PR TITLE
update jekyll command

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,6 @@ To start Jekyll server locally.
 2. Clone the fork.
 3. Run `bundle install` in the root of the freshly cloned repo. This
    will install Jekyll, the tool we use to build the site.
-4. Run `jekyll --server --auto` and open your browser to http://localhost:4000.
+4. Run `jekyll serve --watch` and open your browser to http://localhost:4000.
 5. Make some changes, refresh your browser to preview them.
 6. Submit a pull request.


### PR DESCRIPTION
Updated to start Jekyll without deprecation notices:
  Deprecation: The --server command has been replaced by the 'serve' subcommand.
  Deprecation: The switch '--auto' has been replaced with '--watch'.
