### PR TITLE
Fixing documentation for creating a hashed root password.

### DIFF
--- a/_includes/manuals/1.2/3.5.2_configuration_options.md
+++ b/_includes/manuals/1.2/3.5.2_configuration_options.md
@@ -120,7 +120,7 @@ Default: false
 
 If a root password is not provided whilst configuring a host then this encrypted password is used when building the machine. The plain text password "123123" has been encrypted to produce the default value.
 Default: xybxa6JUkz63w
-(To generate a new one you should use: *openssl passwd "your_password"* )
+(To generate a new one you should use: *openssl passwd -1 "your_password"* )
 
 
 ##### safemode_render


### PR DESCRIPTION
Here's the change to the 1.2 docs discussed in IRC. 
