### PR TITLE
Add db:seed instructions to source install

### DIFF
--- a/_includes/manuals/1.3/3.4_install_from_source.md
+++ b/_includes/manuals/1.3/3.4_install_from_source.md
@@ -41,7 +41,8 @@ gem install bundler
 # (we are assuming sqlite to be configured)
 bundle install --without mysql mysql2 pg test --path vendor # or postgresql
 # set up database schema, precompile assets and locales
-RAILS_ENV=production bundle exec rake db:migrate assets:precompile locale:pack
+RAILS_ENV=production bundle exec rake db:migrate
+RAILS_ENV=production bundle exec rake db:seed assets:precompile locale:pack
 {% endhighlight %}
 
 You can run Foreman with the command *"./script/rails s -e production"*


### PR DESCRIPTION
I'll update the 1.4 branch too for package installs, upgrades etc.  I'm only updating the 1.3 manual as it contains source install instructions for develop.
