### PR TITLE
SPNEGO authentication and REMOTE_USER_MAIL #3528

### DIFF
--- a/_includes/manuals/1.4/5.7.1_populate_attributes.md
+++ b/_includes/manuals/1.4/5.7.1_populate_attributes.md
@@ -1,0 +1,69 @@
+#### IPA server, enroll Foreman machine, setup mod_auth_kerb
+Follow [Section 5.7](/manuals/{{page.version}}/index.html#5.7SPNEGOauthentication) to enable Kerberos authentication and autopopulation of users in Foreman.
+
+#### Configure sssd-dbus and mod_lookup_identity
+Enable Jakub Hrozek's repository which has the builds of sssd-dbus and mod_lookup_identity. At http://copr-fe.cloud.fedoraproject.org/coprs/jhrozek/identity_demo/ choose the correct .repo file. For example, for Foreman on RHEL 6,
+{% highlight bash %}
+wget -O /etc/yum.repos.d/jhrozek-identity_demo.repo \
+  http://copr-fe.cloud.fedoraproject.org/coprs/jhrozek/identity_demo/repo/epel-6-i386/
+{% endhighlight %}
+
+Install the packages:
+{% highlight bash %}
+yum install -y sssd-dbus mod_lookup_identity
+{% endhighlight %}
+
+Update /etc/sssd/sssd.conf to enable the Infopipe feature of sssd.
+
+{% highlight bash %}
+--- /etc/sssd/sssd.conf.orig    2013-12-10 03:09:20.751552952 -0500
++++ /etc/sssd/sssd.conf    2013-12-12 00:52:30.791240631 -0500
+@@ -11,8 +11,10 @@
+ chpass_provider = ipa
+ ipa_server = _srv_, ipa.example.com
+ dns_discovery_domain = example.com
++ldap_user_extra_attrs = mail, givenname, sn
++
+ [sssd]
+-services = nss, pam, ssh
++services = nss, pam, ssh, ifp
+ config_file_version = 2
+
+ domains = example.com
+@@ -28,3 +30,7 @@
+
+ [pac]
+
++[ifp]
++allowed_uids = 48, 0
++user_attributes = +mail, +givenname, +sn
++
+{% endhighlight %}
+
+Set SELinux to permissive. This is bad but it's a temporary workaround before the sssd-dbus feature settles in completely:
+{% highlight bash %}
+setenforce 0
+{% endhighlight %}
+
+Configure mod_lookup_identity -- for example, edit /etc/httpd/conf.d/lookup_identity.conf to have the following in it:
+{% highlight bash %}
+# cat >> /etc/httpd/conf.d/lookup_identity.conf <<EOF
+LoadModule lookup_identity_module modules/mod_lookup_identity.so
+
+<Location /users/extlogin>
+LookupUserAttr mail REMOTE_USER_EMAIL " "
+LookupUserAttr givenname REMOTE_USER_FIRSTNAME
+LookupUserAttr sn REMOTE_USER_LASTNAME
+</Location>
+EOF
+{% endhighlight %}
+
+Restart sssd and Apache:
+{% highlight bash %}
+service sssd restart
+service httpd restart
+{% endhighlight %}
+
+As admin, remove any previously autopopulated users from Foreman, so they can be created again, now with attributes.
+
+Now, when you use Kerberos obtained from the IPA server to log in to Foreman, you should see the full name of the user instead of the login name in the top right corner of the screen, and if you inspect user's details, the email address should be there as well.

--- a/_includes/manuals/1.4/5.7_spnego_authentication.md
+++ b/_includes/manuals/1.4/5.7_spnego_authentication.md
@@ -1,0 +1,78 @@
+
+Foreman 1.4 supports SPNEGO authentication. The following tutorial explains how to set up authentication with mod_auth_kerb and any IPA server. We will use an external IPA server and install mod_auth_kerb in the Foreman machines.
+
+We assume the Foreman machine is IPA-enrolled:
+{% highlight bash %}
+ipa-client-install
+{% endhighlight %}
+
+On the IPA server, we create the service:
+{% highlight bash %}
+ipa service-add HTTP/<the-foreman-hostname>
+{% endhighlight %}
+
+On the Foreman machine, we get the keytab for the service:
+{% highlight bash %}
+ipa-getkeytab -s ipa.example.com -k /etc/http.keytab -p HTTP/$( hostname )
+chown apache /etc/http.keytab
+chmod 600 /etc/http.keytab
+{% endhighlight %}
+
+On the Foreman machine, we install mod_auth_kerb:
+{% highlight bash %}
+yum install -y mod_auth_kerb
+{% endhighlight %}
+
+On the Foreman machine, we configure it to be used by Apache:
+
+{% highlight bash %}
+# add to /etc/httpd/conf.d/auth_kerb.conf
+<Location /users/extlogin>
+ AuthType Kerberos
+ AuthName "Kerberos Login"
+ KrbMethodNegotiate On
+ KrbMethodK5Passwd Off
+ KrbAuthRealms EXAMPLE.COM
+ Krb5KeyTab /etc/http.keytab
+ KrbLocalUserMapping On
+ require valid-user
+ ErrorDocument 401 '<html><meta http-equiv="refresh" content="0; URL=/users/login"><body>Kerberos authentication did not pass.</body></html>'
+ # The following is needed as a workaround for https://bugzilla.redhat.com/show_bug.cgi?id=1020087
+ ErrorDocument 500 '<html><meta http-equiv="refresh" content="0; URL=/users/login"><body>Kerberos authentication did not pass.</body></html>'
+</Location>
+{% endhighlight %}
+
+On the Foreman machine, we tell Foreman that it is OK to trust the authentication done by Apache:
+{% highlight yaml %}
+# add /etc/foreman/settings.yaml to
+:authorize_login_delegation: true
+:authorize_login_delegation_auth_source_user_autocreate: External
+{% endhighlight %}
+
+On Foreman machine, restart Apache:
+{% highlight bash %}
+service httpd restart
+{% endhighlight %}
+
+Now in your browser, if you ```kinit``` to obtain a ticket, accessing Foreman's WebUI should not ask for login/password and should display the authenticated dashboard directly. If the user was just created, page asking for the email address of this new user will be shown.
+
+#### Disabling auto-creation of externally authentication users
+If only already existing users should be allowed to log in, remove/comment out these lines
+{% highlight yaml %}
+:authorize_login_delegation: true
+:authorize_login_delegation_auth_source_user_autocreate: External
+{% endhighlight %}
+from /etc/foreman/settings.yaml.
+
+#### Namespace separation
+If clear namespace separation of internally and externally authenticated users is desired, the KrbLocalUserMapping should be off:
+
+{% highlight bash %}
+# in /etc/httpd/conf.d/auth_kerb.conf
+<Location /users/extlogin>
+ AuthType Kerberos
+ ...
+ KrbLocalUserMapping Off
+</Location>
+{% endhighlight %}
+Then the @REALM would be part of the username and it would be clear that bob is INTERNAL-authenticated and bob@EXAMPLE.COM is different user, EXTERNAL-authenticated. The admin then can manually create another admin@EXAMPLE.COM user (with administrator privileges) and even the admin can use Kerberos.

--- a/_includes/manuals/1.4/5.7_spnego_authentication.md
+++ b/_includes/manuals/1.4/5.7_spnego_authentication.md
@@ -1,5 +1,5 @@
 
-Foreman 1.4 supports SPNEGO authentication. The following tutorial explains how to set up authentication with mod_auth_kerb and any IPA server. We will use an external IPA server and install mod_auth_kerb in the Foreman machines.
+The following tutorial explains how to set up authentication with mod_auth_kerb and any IPA server. We will use an external IPA server and install mod_auth_kerb in the Foreman machines.
 
 We assume the Foreman machine is IPA-enrolled:
 {% highlight bash %}
@@ -46,7 +46,6 @@ On the Foreman machine, we tell Foreman that it is OK to trust the authenticatio
 {% highlight yaml %}
 # add /etc/foreman/settings.yaml to
 :authorize_login_delegation: true
-:authorize_login_delegation_auth_source_user_autocreate: External
 {% endhighlight %}
 
 On Foreman machine, restart Apache:
@@ -54,12 +53,12 @@ On Foreman machine, restart Apache:
 service httpd restart
 {% endhighlight %}
 
-Now in your browser, if you ```kinit``` to obtain a ticket, accessing Foreman's WebUI should not ask for login/password and should display the authenticated dashboard directly. If the user was just created, page asking for the email address of this new user will be shown.
+Now in your browser, if you ```kinit``` to obtain a ticket, accessing Foreman's WebUI should not ask for login/password and should display the authenticated dashboard directly.
 
-#### Disabling auto-creation of externally authentication users
-If only already existing users should be allowed to log in, remove/comment out these lines
+#### Enable auto-creation of externally authentication users
+Foreman can auto create users already existing in your IPA server. When a new user is created on login, a page asking for the email address of this user will be shown.
+To enable this feature put:
 {% highlight yaml %}
-:authorize_login_delegation: true
 :authorize_login_delegation_auth_source_user_autocreate: External
 {% endhighlight %}
 from /etc/foreman/settings.yaml.

--- a/manuals/1.4/index.md
+++ b/manuals/1.4/index.md
@@ -182,6 +182,11 @@ version: 1.4
 ## 5.6 Rails Console
 {%include manuals/1.4/5.6_rails_console.md %}
 
+## 5.7 SPNEGO authentication
+{%include manuals/1.4/5.7_spnego_authentication.md %}
+### 5.7.1 Populate attributes for externally authenticated users
+{%include manuals/1.4/5.7.1_populate_attributes.md %}
+
 # 6. Plugins
 {%include manuals/1.4/6_plugins.md %}
 


### PR DESCRIPTION
This is meant to address #3528 REMOTE_USER attributes and the setup required for that using mod_auth_kerb. https://github.com/theforeman/theforeman.org/issues/141
