### PR TITLE
Add NOPASSWD to sudoers example for running virsh

### DIFF
--- a/_includes/manuals/1.4/4.3.9_smartproxy_libvirt.md
+++ b/_includes/manuals/1.4/4.3.9_smartproxy_libvirt.md
@@ -67,11 +67,11 @@ commands available and password is not required for virsh command. Also make
 sure sudo does not require tty. An example `/etc/sudoers` configuration:
 
     Defaults !requiretty
-    foreman-proxy ALL=/usr/bin/virsh
+    foreman-proxy ALL = NOPASSWD : /usr/bin/virsh
 
 Or for those who are running foreman-proxy under different user:
 
-    %users ALL=/usr/bin/virsh
+    %users ALL = NOPASSWD : /usr/bin/virsh
 
 Foreman is now configured for libvirt provisioning, this is the recommended
 setup for git development checkouts. There is one limitation though, reverse


### PR DESCRIPTION
Without the NOPASSWD tag, smart-proxy fails
to run virsh and the following error is logged:

ERROR -- : DHCP virsh provider error: unable
to retrive virsh info: DNS virsh provider error:
virsh call failed (pid 569 exit 1) - sudo: no tty
present and no askpass program specified
