### PR TITLE
Fix typos, add additional step

### DIFF
--- a/_includes/manuals/1.4/4.3.6_gsstsig.md
+++ b/_includes/manuals/1.4/4.3.6_gsstsig.md
@@ -45,11 +45,11 @@ Then fetch the keytab, e.g. `ipa-getkeytab -p foremanproxy/proxy.example.com@EXA
 
 Store the keytab at `/etc/foreman-proxy/dns.keytab`, ensure permissions are 0600 and the owner is `foreman-proxy`.
 
-The ACL on updates to the DNS zone then needs to permit the service principal.  In the FreeIPA web UI, under the DNS zone, go to the Settings tab and add to the BIND update policy a new grant:
+The ACL on updates to the DNS zone then needs to permit the service principal.  In the FreeIPA web UI, under the DNS zone, go to the Settings tab, verify that "Dynamic update" for that zone is set to "True", and add to the BIND update policy a new grant:
 
-    grant foremanproxy\047ipa.example.com@EXAMPLE.COM wildcard * ANY;
+    grant foremanproxy\047proxy.example.com@EXAMPLE.COM wildcard * ANY;
 
-Note the `\047` is written verbatim, and don't forget the semicolon.
+Note the `\047` is written verbatim, and don't forget the semicolon.  ACLs should be updated for both forward and reverse zones as desired.
 
 #### Proxy configuration
 
@@ -57,4 +57,4 @@ Next, update the proxy configuration file (`/etc/foreman-proxy/settings.yml`) wi
 
     :dns_provider: nsupdate_gss
     :dns_tsig_keytab: /etc/foreman-proxy/dns.keytab
-    :dns_tsig_principal: foremanproxy/ipa.example.com@EXAMPLE.COM
+    :dns_tsig_principal: foremanproxy/proxy.example.com@EXAMPLE.COM


### PR DESCRIPTION
- service principal name in the grant statement was inconsistent with above
- service principal name in the Smart Proxy configuration was inconsistent with above
- added step to verify that "Dynamic Update" is enabled for the zone.
- added a statement to update both forward and reverse zones, as desired
