### PR TITLE
Update 5.2.4_cr_gce.md

### DIFF
--- a/_includes/manuals/1.4/5.2.4_cr_gce.md
+++ b/_includes/manuals/1.4/5.2.4_cr_gce.md
@@ -1,5 +1,4 @@
-
-* Requires client e-mail address and p12 certificate file to access
+* Requires client e-mail address of an authorised google cloud console client ID is entered in the new compute resource screen and its associated .p12 private key file is manually transferred to the foreman server in a location the foreman user account has permission to read. Specify the location on the foreman server as the certificate path value 
 * Ensure images are associated under the *Images* tab on the compute resource.
 * Add a provisioning template of type *finish* which will be executed over SSH on the new image.
 * Ensure the finish template is associated to the OS (on the *Associations* tab) and is set as the default for the operating system too.


### PR DESCRIPTION
Clarified the need for the user to currently transfer the private key for GCE to foreman outside of the UI
