### PR TITLE
An archiever tool is a build dependency of nokogiri

### DIFF
--- a/_includes/manuals/1.4/3.4_install_from_source.md
+++ b/_includes/manuals/1.4/3.4_install_from_source.md
@@ -24,7 +24,7 @@ required packages:
     yum -y install gcc-c++ git ruby ruby-devel rubygems \
         libvirt-devel mysql-devel postgresql-devel openssl-devel \
         libxml2-devel sqlite-devel libxslt-devel zlib-devel \
-        readline-devel
+        readline-devel tar
 
 Additionally, it is important that `config/database.yml` is set to use
 the correct database in the "production" block. Rails (and subsequently


### PR DESCRIPTION
On Fedora 20 minimal installation there is no tar package installed
by default. That causes `gem install nokogiri -v '1.6.1'` fail with:

   Extracting libxml2-2.8.0.tar.gz into tmp/x86_64-redhat-linux/ports/libxml2/2.8.0... '''--'''ERROR
   sh: zxf: command not found
   **\* extconf.rb failed ***
   Could not create Makefile due to some reason, probably lack of necessary
