### PR TITLE
Update 7.1_novnc.md

### DIFF
--- a/_includes/manuals/1.5/7.1_novnc.md
+++ b/_includes/manuals/1.5/7.1_novnc.md
@@ -9,7 +9,7 @@ Foreman uses the excellent javascript VNC library [noVNC](http://kanaka.github.c
 
 * Currently only unencrypted connections are possible, even if you connect to Foreman via HTTPS.
 * Keyboard mappings are currently fixed to English only.
-* When using Firefox, if you use Foreman via HTTPS, Firefox might block the connection. To fix it, go to about:config and enable network.websocket.allowInsecureFromHTTPS
+* When using Firefox, if you use Foreman via HTTPS, Firefox might block the connection. To fix it, go to about:config and enable network.websocket.allowInsecureFromHTTPS. Same goes for Chrome, to fix it, go to chrome://flags/ and enable Allow insecure WebSocket from https origin
 
 ### Troubleshooting Steps
 


### PR DESCRIPTION
add workaround for google chrome https websocket issue (https://codereview.chromium.org/248863003/)
