### PR TITLE
Change DNS Section to show correct dns_key option

### DIFF
--- a/_includes/manuals/1.5/4.3.2_smartproxy_settings.md
+++ b/_includes/manuals/1.5/4.3.2_smartproxy_settings.md
@@ -59,7 +59,7 @@ Activate the DNS management module within the Smart-Proxy instance.
 
 The DNS module can manipulate any DNS server that complies with the ISC Dynamic DNS Update standard and can therefore be used to manage both Microsoft and Bind servers.  Updates can also be done using GSS-TSIG, see the [documentation](manuals/{{page.version}}/index.html#4.3.6GSS-TSIGDNS).
 
-The **dns_key** specifies a file containing a shared secret used to generate a signature for the update request (TSIG record). This option should not be used if you plan to use Kerberos/GSS-TSIG (for example for DNS servers shipped with FreeIPA or Microsoft AD).
+The **dns_key** specifies a file containing a shared secret used to generate a signature for the update request (TSIG record). This option should be set to **false** if you plan to use Kerberos/GSS-TSIG (for example for DNS servers shipped with FreeIPA or Microsoft AD).
 
 If neither the **dns_key** or GSS-TSIG is used then the update request is sent without any signature. Unsigned update requests are considered insecure. Some DNS servers can be configured to accept only signed signatures.
 


### PR DESCRIPTION
The documentation states that "[...] This option should not be used if you plan to use Kerberos/GSS-TSIG [...]" which is a bit confusing, as you have to set this option to 'false' in order to avoid connection errors.
