### PR TITLE
Update the example configuration with the correct :dns_key: setting

### DIFF
--- a/_includes/manuals/1.5/4.3.6_gsstsig.md
+++ b/_includes/manuals/1.5/4.3.6_gsstsig.md
@@ -58,3 +58,4 @@ Next, update the proxy configuration file (`/etc/foreman-proxy/settings.yml`) wi
     :dns_provider: nsupdate_gss
     :dns_tsig_keytab: /etc/foreman-proxy/dns.keytab
     :dns_tsig_principal: foremanproxy/proxy.example.com@EXAMPLE.COM
+    :dns_key: false


### PR DESCRIPTION
This is in relation to b5bfbe063cd0029fbc60fcc331e91469bb5cb709 and theforeman/theforeman.org#225
It extends the documentation to also list the relevant option (**dns_key** set to **false**) in the documentation example.
