### PR TITLE
Update 3.5.4_puppet_reports.md

### DIFF
--- a/_includes/manuals/1.5/3.5.4_puppet_reports.md
+++ b/_includes/manuals/1.5/3.5.4_puppet_reports.md
@@ -13,7 +13,7 @@ Without it, no reports will be sent.
 
 ##### puppetmaster
 
-1. copy [https://raw.github.com/theforeman/puppet-foreman/master/templates/foreman-report_v2.rb.erb](https://raw.github.com/theforeman/puppet-foreman/master/templates/foreman-report_v2.rb.erb) to your report directory
+1. copy [https://raw.github.com/theforeman/puppet-foreman/2.1-stable/templates/foreman-report_v2.rb.erb](https://raw.github.com/theforeman/puppet-foreman/2.1-stable/templates/foreman-report_v2.rb.erb) to your report directory
 2. e.g. /usr/lib/ruby/1.8/puppet/reports/foreman.rb,
 /usr/lib/ruby/site_ruby/1.8/puppet/reports/foreman.rb,
 /var/lib/gems/1.8/gems/puppet-2.6.4/lib/puppet/reports/foreman.rb or


### PR DESCRIPTION
Change the foreman-report_v2.rb.erb url to the one at 2.1_stable branch.
Puppet-foreman's master has no longer the file foreman-report_v2.rb.erb.

See more here:
https://groups.google.com/forum/#!topic/foreman-dev/XA2tXbNlPq8
