### PR TITLE
Use foreman-rake for backup/import

### DIFF
--- a/_includes/manuals/1.8/5.5.1_backup.md
+++ b/_includes/manuals/1.8/5.5.1_backup.md
@@ -4,28 +4,12 @@ instance.
 
 ### Database
 
-#### PostgreSQL
+#### PostgreSQL, MySQL, SQLite
 
-The `pg_dump` command can be used to backup the contents of a PostgreSQL
-database to a text file. The most reliable way of backing up PostgreSQL
-database is:
+Run ```foreman-rake db:dump```. It will print a message when it finishes with the dump
+file location relative to the Foreman root.
 
-    su postgres -c "pg_dump -Fc foreman > foreman.dump"
-
-#### MySQL database
-
-The `mysqldump` command can be used to backup the contents of your MySQL
-database to a text file.
-
-    mysqldump --opt foreman > foreman.sql
-
-Please follow MySQL documentation about other options for doing backups.
-
-#### SQLite database
-
-To backup SQLite database perform this simple step:
-
-    sqlite3 /path/to/foreman/db/production.db .dump > foreman.dump
+##### SQLite disclaimer
 
 SQLite databases are all contained in a single file, so you can back them up
 by copying the file to another location, but it is recommended to shut down

--- a/_includes/manuals/1.8/5.5.2_recovery.md
+++ b/_includes/manuals/1.8/5.5.2_recovery.md
@@ -7,30 +7,14 @@ beginning of this chapter.
 
 Note: Foreman instance must be stopped before proceeding.
 
-#### PostgreSQL
+#### PostgreSQL, MySQL, SQLite
 
-The `pg_restore` command can be used to recover contents of your PostgreSQL
-database from the database dump. The most reliable way PostgreSQL
-database is:
+Run ```foreman-rake db:import_dump file=/your/db/dump/location```. This will load your
+dump into the current database for your environment. It will print a message
+to notify you when it has finished importing the dump.
 
-    su postgres -c "pg_restore -C -d postgres foreman.dump"
-
-#### MySQL database
-
-The `mysql` command can be used to recover contents of your MySQL database
-from the database dump in SQL format.
-
-    mysql < dump.sql
-
-Please follow MySQL documentation about other options for data recovery.
-
-#### SQLite database
-
-To recover from SQLite dump perform this simple step:
-
-    sqlite3 /path/to/foreman/db/production.db < foreman.dump
-
-It is possible just to copy db file, but Foreman instance must be stopped.
+Remember to stop the Foreman instance and any other process consuming data from the
+database temporarily during the import and turn it back on after it ends.
 
 ### Configuration
 


### PR DESCRIPTION
Unless I'm missing some reason, users should leverage https://github.com/theforeman/foreman/blob/develop/lib/tasks/backup.rake rather than manually backing up their databases, at least for simple dumps.
