### PR TITLE
Smart proxies only require port 8443.

### DIFF
--- a/_includes/manuals/1.6/3.1.3_firewall_configuration.md
+++ b/_includes/manuals/1.6/3.1.3_firewall_configuration.md
@@ -9,17 +9,17 @@ Protect your Foreman environment by blocking all unnecessary and unused ports.
   <tr>
     <td>53</td>
     <td>TCP & UDP</td>
-    <td>DNS Smart Proxies</td>
+    <td>DNS Server</td>
   </tr>
   <tr>
     <td>67, 68</td>
     <td>UDP</td>
-    <td>DHCP Smart Proxies</td>
+    <td>DHCP Server</td>
   </tr>
   <tr>
     <td>69</td>
     <td>UDP</td>
-    <td><span class='footnote'>*</span> TFTP Smart Proxies</td>
+    <td><span class='footnote'>*</span> TFTP Server</td>
   </tr>
   <tr>
     <td>80, 443</td>


### PR DESCRIPTION
DNS smart proxy is only port 8443, but if you installed the DNS server on that host too, then you need the port open.  Changed wording to reflect this since if your DNS smart proxy points to a remote host, you don't need the DNS ports open.
