### PR TITLE
Add section on search syntax and usage

### DIFF
--- a/_includes/manuals/1.6/4.1.5_searching.md
+++ b/_includes/manuals/1.6/4.1.5_searching.md
@@ -1,0 +1,76 @@
+
+Each page in Foreman has its own search functionality, which is centred around the resources that it manages, allowing searching based on attributes of the resources in the list or resources that they're associated to.  The search box also features powerful auto-completion to help build up search queries and free text search on many pages.  The search functionality can also be used in the API when listing resources, see [Customize JSON Responses](/manuals/{{page.version}}/index.html#5.1.4CustomizeJSONResponses) for details.
+
+#### General usage
+
+Searching is through "field = value" or free text queries, which can be combined with logical operators (and, or, not) and parentheses to handle more complex logic.  To give some examples:
+
+* `name = client.example.com` on the host list would show the host(s) whose hostname is client.example.com
+* `hostgroup = "Web servers" and domain != lon.example.com` would show hosts in the Web servers host group, but not in the lon.example.com domain
+* `Web servers` would show all hosts with that text anywhere, e.g. as their host group name or in the comment field
+
+The fields available depend on the type of resource that's being searched, and the names of the attributes vary depending on the context.  The "name" field on the host groups list is equivalent to the "hostgroup" field on the hosts list.  Requests to add additional searchable fields are welcome, and may be filed in the "Search" category [in the bug tracker](http://projects.theforeman.org/projects/foreman/issues/new).
+
+The search engine is provided by the scoped_search library, which maps search queries directly to SQL queries.  The [Query Language](https://github.com/wvanbergen/scoped_search/wiki/Query-language) documentation provides A more complete specification of the syntax available.
+
+#### Bookmarks
+
+Foreman supports the ability to make search bookmarks, allows users to quickly jump to predefined search conditions.  Available bookmarks can be selected from the dropdown menu to the right of the search box, or managed from *Administer > Bookmarks*.
+
+Some of the bookmarks are provided by default, e.g. to search for active or inactive hosts, or to only view reports with events.
+
+To save a query, Use the dropdown menu to the right of the search box and click "Bookmark this search".  When saving, the bookmark can be labeled as public, so all other users are able to see and use it too.
+
+#### Free text search
+
+If you ignore the auto-completer and just enter text in the search field, Foreman will try searching for that text across multiple fields.
+
+For example, if you just enter `12` in the the hosts search box, the results will include all hosts with 12 in their IP address, MAC address or name.  In general the fields used for free text search are kept to a minimumfor performance and accuracy reasons.  It's preferable to search using a specific field, e.g. when searching for an IP address, use `ip ~ 12` instead of `12`.
+
+####  Searching for present/empty values
+
+The "has" operator matches values that are present, e.g. to search for hosts that are on a compute resource, use `has compute_resource`.
+
+Similarly, this can be negated, so to search for hosts without host groups, you can use `not has hostgroup`.
+
+#### Case sensitivity
+
+When querying using `=` and `!=` operators then exact, case sensitive matches will be returned.  When running `~` (like) and `!~` (unlike) operators, the matching is case insensitive.
+
+#### Quoting
+
+In search queries, white spaces are used as a delimiter. Here are some examples of the way a query will be interpreted:
+
+* `description ~ "created successfully"`: list all notifications that contain "created successfully"
+* `description ~ created successfully`: list all notifications that contain "created" and at least one of its text fields contains "successfully"
+* `description !~ created successfully`:  list all notifications that doesn't contain "created" and at least one of its text fields contains "successfully"
+
+In the second and third example, "successfully" is an additional term that is interpreted as a free text search
+
+#### Wildcards ('_', '%', '*')
+
+The `~` and `!~` search operators are translated to the `LIKE` and `NOT LIKE` SQL queries respectively, which support two basic wildcards, `_` and `%`.
+
+`_` is a wildcard for a single character replacement. For example, the search `name ~ fo_` will match both "foo" and "for".
+
+The `%` and `*` wildcard will replace zero or more characters. For example, the search `name ~ corp%` will match both "corp" and "corporation". The more common ‘*’ wildcard is not a SQL wildcard but may be used instead.
+
+When the `~` or `!~` search is processed, a ‘%’ wildcard is automatically added at the beginning and end of the value if no wildcard is used, so it will by default match at any location inside a string.  For example, the search `name ~ foo` is equivalent to `name ~ %foo%` and the search `name ~ foo%` will only match "foo" at the beginning of the value.
+
+####  Date-time search query syntax
+
+Many date and time formats are accepted in search queries.  Here are some examples:
+
+* "30 minutes ago", "1 hour ago", "2 hours ago", Today, Yesterday
+* "3 weeks ago", "1 month ago", "6 days ago", "July 10,2011"
+
+The date can have different separators, "10-July-2011" will be interpreted in the same way as "10/July/2010" or "10 July 2011" Month names may be the full English name or a three letter abbreviation, e.g. "Jan" will be interpreted as "January".  Many other formats are also acceptable, however it is not recommended to use ambiguous formats such as "3/4/2011"
+
+The valid date time operators are ‘=’, ‘<’ and ‘>’ which are interpreted as ‘at’, ‘before’ and ‘after’ respectively. This is how the search term interpeted:
+
+The right hand part of a date-time condition is parsed and translated into a specific date-time, "30 minutes ago" is translated to "now - 30 minutes".
+
+* `last_report > "2011-07-01 12:57:18 EDT"` should be read as created after this time
+* In the same way, `last_report > "30 minutes ago"` should be read as "created after 30 minutes ago" and not "created more then 30 minutes ago"
+
+A search query like `installed_at = Yesterday` is translated into a period query, it will be translated at runtime to match a range of date-times. For example, if running on Jan 1, it would be translated into "(installed_at >= Jan 1,2012 00:00) and (installed_at < Dec 31,2011 00:00)".

--- a/_includes/manuals/1.6/5.1.4_api_customize.md
+++ b/_includes/manuals/1.6/5.1.4_api_customize.md
@@ -49,7 +49,9 @@ This will return all the objects in one request since 27 is less than the `per_p
 
 #### Custom Search of Collections Per Response
 
-Foreman uses the gem scoped_search for searching and filtering which allows all query search parameters to be specified in one string.  To filter results of a collection, pass `search=` as a URL parameter. See example below:
+Foreman uses the scoped_search library for searching and filtering which allows all query search parameters to be specified in one string.  The syntax is described in the [Searching](/manuals/{{page.version}}/index.html#4.1.5Searching) section, and matches exactly the syntax used for the web UI search boxes.  This allows you use of the auto-completer and to test a query in the UI before reusing it in the API.
+
+To filter results of a collection, pass `search=` as a URL parameter, ensuring that it is fully URL-escaped to prevent search operators being misinterpreted as URL separators. See example below:
 
     $ curl -k -u admin:changeme -H "Accept: version=2,application/json" \
         https://foreman.example.com/api/domains?search=name%3Dexample.com

--- a/manuals/1.6/index.md
+++ b/manuals/1.6/index.md
@@ -71,6 +71,8 @@ version: 1.6
 {%include manuals/1.6/4.1.3_trends.md %}
 ### 4.1.4 Auditing
 {%include manuals/1.6/4.1.4_auditing.md %}
+### 4.1.5 Searching
+{%include manuals/1.6/4.1.5_searching.md %}
 
 ## 4.2 Managing Puppet
 {%include manuals/1.6/4.2_managing_puppet.md %}


### PR DESCRIPTION
Copied from http://blog.theforeman.org/2012/01/advance-search-tips-in-foreman.html
with small alterations.
