### PR TITLE
[do not merge] Per-OS installation instructions

### DIFF
--- a/_includes/manuals/1.6/2.1_quickstart_installation.md
+++ b/_includes/manuals/1.6/2.1_quickstart_installation.md
@@ -1,30 +1,259 @@
-[The Foreman installer](/manuals/{{page.version}}/index.html#3.2ForemanInstaller) uses Puppet to install Foreman. This guide assumes that you have a newly installed operating system, on which the installer will setup Foreman, a puppet master with Passenger and the [Smart Proxy](/manuals/{{page.version}}/index.html#4.3SmartProxies) by default.
+[The Foreman installer](/manuals/{{page.version}}/index.html#3.2ForemanInstaller) uses Puppet to install Foreman. This guide assumes that you have a newly installed operating system, on which the installer will setup Foreman, a Puppet master with Passenger and the [Smart Proxy](/manuals/{{page.version}}/index.html#4.3SmartProxies) by default.
 
-#### Downloading the installer
+#### Select operating system
 
-For **Red Hat variants**, run this (replace 'el6' with 'el7' if on RHEL 7, or 'f19' on Fedora 19):
+<script type="text/javascript">
+function update_quickstart_os(select) {
+  var os = select.value;
+  $(".quickstart_os").hide();
+  if (os && os != 'none') {
+    $(".quickstart_os_"+os).show();
+  } else {
+    $(".quickstart_os_none").show();
+  }
+}
+</script>
+
+To provide specific installation instructions, please select your operating system:
+<select onChange="update_quickstart_os(this);">
+  <option value="none">-- select operating system --</option>
+  <option value="el6">CentOS or Scientific Linux 6</option>
+  <option value="el7">CentOS or Scientific Linux 7</option>
+  <option value="debian6">Debian 6 (Squeeze)</option>
+  <option value="debian7">Debian 7 (Wheezy)</option>
+  <option value="fedora19">Fedora 19</option>
+  <option value="rhel6">Red Hat Enterprise Linux 6</option>
+  <option value="rhel7">Red Hat Enterprise Linux 7</option>
+  <option value="ubuntu1204">Ubuntu 12.04 (Precise)</option>
+  <option value="ubuntu1404">Ubuntu 14.04 (Trusty)</option>
+</select>
+
+#### Repositories
+
+<div class="quickstart_os quickstart_os_none">
+  <i>No operating system selected.</i>
+</div>
+
+<div class="quickstart_os quickstart_os_rhel6">
+  <p>First, enable the RHEL Optional and RHSCL repos:</p>
 
 {% highlight bash %}
-yum -y install http://yum.theforeman.org/releases/{{page.version}}/el6/x86_64/foreman-release.rpm
-yum -y install foreman-installer
+yum-config-manager --enable rhel-6-server-optional-rpms rhel-server-rhscl-6-rpms
 {% endhighlight %}
 
-For **Debian variants**, run this (replace 'wheezy' with 'trusty' if on Ubuntu 14.04, 'precise' if on Ubuntu 12.04, or 'squeeze' for Debian 6):
+  <p>
+    Check the repositories are enabled with <code>yum repolist</code> after running the above command, as it can silently fail when subscription does not provide it.
+    More information about accessing RH Software Collections (RHSCL) is available from the <a href="https://access.redhat.com/solutions/472793">Customer Portal</a>.
+  </p>
+
+  <p>If you're using RH Satellite 5, you should instead sync and enable the channels there.</p>
+</div>
+
+<div class="quickstart_os quickstart_os_rhel7">
+  <p>First, enable the RHEL Optional and RHSCL repos:</p>
+
+{% highlight bash %}
+yum-config-manager --enable rhel-7-server-optional-rpms rhel-server-rhscl-7-rpms
+{% endhighlight %}
+
+  <p>
+    Check the repositories are enabled with <code>yum repolist</code> after running the above command, as it can silently fail when subscription does not provide it.
+    More information about accessing RH Software Collections (RHSCL) is available from the <a href="https://access.redhat.com/solutions/472793">Customer Portal</a>.
+  </p>
+
+  <p>If you're using RH Satellite 5, you should instead sync and enable the channels there.</p>
+</div>
+
+<div class="quickstart_os quickstart_os_debian6">
+  <div class="alert alert-info">
+    Foreman 1.6 is the last release that will support Debian 6 (Squeeze).  Please consider using Debian 7 (Wheezy) instead.
+  </div>
+
+  <p>Backports are providing some required dependencies and a slightly more recent version of Puppet. To enable backports, run:</p>
+
+{% highlight bash %}
+echo "deb http://http.debian.net/debian-backports squeeze-backports main" > /etc/apt/sources.list.d/backports.list
+{% endhighlight %}
+</div>
+
+<div class="quickstart_os quickstart_os_fedora19 alert alert-info">
+  Foreman on Fedora 19 has some known issues, and we'd recommend using a different distro instead.
+</div>
+
+<div class="quickstart_os quickstart_os_rhel6 quickstart_os_el6">
+  <p>
+    Using a recent version of Puppet is recommended, which is available from the Puppet Labs repository.
+    You may skip this and use the older version from EPEL without a problem, however it has reduced community support.
+  </p>
+
+{% highlight bash %}
+rpm -ivh http://yum.puppetlabs.com/puppetlabs-release-el-6.noarch.rpm
+{% endhighlight %}
+
+  <p>Enable the EPEL (Extra Packages for Enterprise Linux) and the Foreman repo:</p>
+
+{% highlight bash %}
+rpm -ivh http://dl.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm
+yum -y install http://yum.theforeman.org/releases/{{page.version}}/el6/x86_64/foreman-release.rpm
+{% endhighlight %}
+</div>
+
+<div class="quickstart_os quickstart_os_rhel7 quickstart_os_el7">
+  <p>
+    Using a recent version of Puppet is recommended, which is available from the Puppet Labs repository.
+    You may skip this and use the older version from EPEL without a problem, however it has reduced community support.
+  </p>
+
+{% highlight bash %}
+rpm -ivh http://yum.puppetlabs.com/puppetlabs-release-el-7.noarch.rpm
+{% endhighlight %}
+
+  <p>Enable the EPEL (Extra Packages for Enterprise Linux) and the Foreman repo:</p>
+
+{% highlight bash %}
+rpm -ivh http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-2.noarch.rpm
+yum -y install http://yum.theforeman.org/releases/{{page.version}}/el7/x86_64/foreman-release.rpm
+{% endhighlight %}
+</div>
+
+<div class="quickstart_os quickstart_os_el7">
+  <p>Due to late-added support for EL7, configure the SCL repositories with:</p>
+
+{% highlight bash %}
+yum -y --nogpgcheck install foreman-release-scl
+{% endhighlight %}
+</div>
+
+<div class="quickstart_os quickstart_os_fedora19">
+  <p>
+    You may optionally use the latest available version of Puppet from the Puppet Labs repositories, which is
+    a bit newer than that provided by Fedora itself.
+  </p>
+
+{% highlight bash %}
+rpm -ivh http://yum.puppetlabs.com/puppetlabs-release-fedora-19.noarch.rpm
+{% endhighlight %}
+
+  <p>Enable the Foreman repo:</p>
+
+{% highlight bash %}
+yum -y install http://yum.theforeman.org/releases/{{page.version}}/f19/x86_64/foreman-release.rpm
+{% endhighlight %}
+</div>
+
+<div class="quickstart_os quickstart_os_debian6">
+  <p>
+    Using a recent version of Puppet is recommended, which is available from the Puppet Labs repository.
+    You may skip this and use the older version from Debian Backports without a problem, however it has reduced community support.
+  </p>
+
+{% highlight bash %}
+wget https://apt.puppetlabs.com/puppetlabs-release-squeeze.deb
+dpkg -i puppetlabs-release-squeeze.deb
+{% endhighlight %}
+
+  <p>Enable the Foreman repo:</p>
+
+{% highlight bash %}
+echo "deb http://deb.theforeman.org/ squeeze {{page.version}}" > /etc/apt/sources.list.d/foreman.list
+echo "deb http://deb.theforeman.org/ plugins {{page.version}}" >> /etc/apt/sources.list.d/foreman.list
+wget -q http://deb.theforeman.org/pubkey.gpg -O- | apt-key add -
+{% endhighlight %}
+</div>
+
+<div class="quickstart_os quickstart_os_debian7">
+  <p>
+    Using a recent version of Puppet is recommended, which is available from the Puppet Labs repository.
+    You may skip this and use the older version from Debian without a problem, however it has reduced community support.
+  </p>
+
+{% highlight bash %}
+wget https://apt.puppetlabs.com/puppetlabs-release-wheezy.deb
+dpkg -i puppetlabs-release-wheezy.deb
+{% endhighlight %}
+
+  <p>Enable the Foreman repo:</p>
 
 {% highlight bash %}
 echo "deb http://deb.theforeman.org/ wheezy {{page.version}}" > /etc/apt/sources.list.d/foreman.list
 echo "deb http://deb.theforeman.org/ plugins {{page.version}}" >> /etc/apt/sources.list.d/foreman.list
 wget -q http://deb.theforeman.org/pubkey.gpg -O- | apt-key add -
+{% endhighlight %}
+</div>
+
+<div class="quickstart_os quickstart_os_ubuntu1204">
+  <p>
+    Using a recent version of Puppet is recommended, which is available from the Puppet Labs repository.
+    You may skip this and use the older version from Ubuntu without a problem, however it has reduced community support.
+  </p>
+
+{% highlight bash %}
+wget https://apt.puppetlabs.com/puppetlabs-release-precise.deb
+dpkg -i puppetlabs-release-precise.deb
+{% endhighlight %}
+
+  <p>Enable the Foreman repo:</p>
+
+{% highlight bash %}
+echo "deb http://deb.theforeman.org/ precise {{page.version}}" > /etc/apt/sources.list.d/foreman.list
+echo "deb http://deb.theforeman.org/ plugins {{page.version}}" >> /etc/apt/sources.list.d/foreman.list
+wget -q http://deb.theforeman.org/pubkey.gpg -O- | apt-key add -
+{% endhighlight %}
+</div>
+
+<div class="quickstart_os quickstart_os_ubuntu1404">
+  <p>
+    You may optionally use the latest available version of Puppet from the Puppet Labs repositories, which is
+    a bit newer than that provided by Ubuntu itself.
+  </p>
+
+{% highlight bash %}
+wget https://apt.puppetlabs.com/puppetlabs-release-trusty.deb
+dpkg -i puppetlabs-release-trusty.deb
+{% endhighlight %}
+
+  <p>Enable the Foreman repo:</p>
+
+{% highlight bash %}
+echo "deb http://deb.theforeman.org/ trusty {{page.version}}" > /etc/apt/sources.list.d/foreman.list
+echo "deb http://deb.theforeman.org/ plugins {{page.version}}" >> /etc/apt/sources.list.d/foreman.list
+wget -q http://deb.theforeman.org/pubkey.gpg -O- | apt-key add -
+{% endhighlight %}
+</div>
+
+#### Downloading the installer
+
+<div class="quickstart_os quickstart_os_none">
+  <i>No operating system selected.</i>
+</div>
+
+<div class="quickstart_os quickstart_os_rhel6 quickstart_os_el6 quickstart_os_rhel7 quickstart_os_el7 quickstart_os_fedora19">
+{% highlight bash %}
+yum -y install foreman-installer
+{% endhighlight %}
+</div>
+
+<div class="quickstart_os quickstart_os_debian6 quickstart_os_debian7 quickstart_os_ubuntu1204 quickstart_os_ubuntu1404">
+{% highlight bash %}
 apt-get update && apt-get install foreman-installer
 {% endhighlight %}
+</div>
 
 #### Running the installer
 
 The installation run is non-interactive, but the configuration can be customized by supplying any of the options listed in `foreman-installer --help`, or by running `foreman-installer -i` for interactive mode.  More examples are given in the [Installation Options](/manuals/{{page.version}}/index.html#3.2.2InstallerOptions) section.  Adding `-v` will disable the progress bar and display all changes.  To run the installer, execute:
 
+<div class="quickstart_os quickstart_os_none quickstart_os_el6 quickstart_os_rhel6 quickstart_os_rhel7 quickstart_os_debian6 quickstart_os_debian7 quickstart_os_ubuntu1204 quickstart_os_ubuntu1404">
 {% highlight bash %}
 foreman-installer
 {% endhighlight %}
+</div>
+
+<div class="quickstart_os quickstart_os_el7">
+{% highlight bash %}
+foreman-installer --foreman-configure-scl-repo=false
+{% endhighlight %}
+</div>
 
 After it completes, the installer will print some details about where to find Foreman and the Smart Proxy and Puppet master if they were installed along Foreman. Output should be similar to this:
 

--- a/_includes/manuals/1.6/2_quickstart_guide.md
+++ b/_includes/manuals/1.6/2_quickstart_guide.md
@@ -4,18 +4,10 @@ The Foreman installer is a collection of Puppet modules that installs everything
 Components include the Foreman web UI, Smart Proxy, Passenger (for the puppet master and Foreman itself), and optionally TFTP, DNS and DHCP servers.  It is configurable and the Puppet modules can be read or run in "no-op" mode to see what changes it will make.
 
 #### Supported platforms
-* Red Hat Enterprise Linux 6 or 7
-  * [EPEL](http://fedoraproject.org/wiki/EPEL/FAQ#How_can_I_install_the_packages_from_the_EPEL_software_repository.3F) is required
-  * Enable the Optional and RHSCL 1 repositories/channels:
-    * `yum-config-manager --enable rhel-6-server-optional-rpms rhel-server-rhscl-6-rpms`
-    * check the above repositories because the command can silently fail when subscription does not provide it: `yum repolist`
-* CentOS or Scientific Linux 6
-  * [EPEL](http://fedoraproject.org/wiki/EPEL/FAQ#How_can_I_install_the_packages_from_the_EPEL_software_repository.3F) is required
-  * Version 7 will be supported when SCL becomes available
+* CentOS or Scientific Linux 6 or 7
+* Debian 6 (Squeeze) or 7 (Wheezy)
 * Fedora 19
-* Debian 7 (Wheezy)
-* Debian 6 (Squeeze) (update Puppet [from backports](http://backports.debian.org/Instructions/))
-* Ubuntu 14.04 (Trusty)
-* Ubuntu 12.04 (Precise)
+* Red Hat Enterprise Linux 6 or 7
+* Ubuntu 12.04 (Precise) or 14.04 (Trusty)
 
 Other operating systems will need to use alternative installation methods (see the manual).

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -256,3 +256,6 @@ iframe:not([allowtransparency]){
     padding: 50px 0;
 }
 
+.quickstart_os:not(.quickstart_os_none) {
+  display: none;
+}


### PR DESCRIPTION
Fixes various things like CentOS 7 SCL instructions, per-Debian/Ubuntu release
sources, more detailed instructions for RHEL channels and explicit Puppet Labs
repo instructions.

TODO before merging: tidy up default view, empty pre-reqs section, line-break issues

Opening in case anybody was interested (@mmoll perhaps).
