### PR TITLE
Email Settings Documentation 

### DIFF
--- a/_includes/manuals/1.6/3.5.2_configuration_options.md
+++ b/_includes/manuals/1.6/3.5.2_configuration_options.md
@@ -44,6 +44,65 @@ This boolean options configures whether Foreman will provide support for the Jav
 :support_jsonp: false
 </pre>
 
+#### The 'config/email.yaml' file
+
+An example settings file can be found at **config/email.yaml.example**, copy this file to **config/email.yaml**
+
+##### Configuration Directives
+
+###### authentication
+The type of authentication method expected by your service provider.
+
+Valid settings:
+```
+:login
+:none
+```
+
+*(note: if you set this to :none, you must not include the user_name and password settings)*
+
+###### delivery_method
+The mail transport method to be used.
+
+Valid settings:
+```
+:smtp
+:sendmail
+```
+
+##### Example email.yml Configurations
+
+###### Simple Login Authentication (default settings)
+```YAML
+production:
+  delivery_method: :smtp
+  smtp_settings:
+    address: smtp.example.net
+    port: 25
+    domain: example.net
+    authentication: :login
+    user_name: foreman@example.net
+    password: foreman
+```
+    
+###### No Authentication
+Example for an SMTP service provider with no authentication. Note the colon before none.
+
+```YAML
+production:
+  delivery_method: :smtp
+  smtp_settings:
+    address: smtp.nowhere.net
+    port: 25
+    domain: nowhere.com
+    authentication: :none
+```
+###### Using sendmail command
+Example for a unix system that uses the /usr/sbin/sendmail command.
+```YAML
+production:
+  delivery_method: :sendmail
+```
 
 #### The 'Administer/Settings' page
 


### PR DESCRIPTION
Email settings documentation pulled from 
http://projects.theforeman.org/projects/foreman/wiki/Email_configuration

and formatted in MarkDown.  I put it in Section 3.5 after settings/config.yml
