### PR TITLE
Fixed formatting mistake

### DIFF
--- a/_includes/manuals/1.6/3.5.2_configuration_options.md
+++ b/_includes/manuals/1.6/3.5.2_configuration_options.md
@@ -54,10 +54,10 @@ An example settings file can be found at **config/email.yaml.example**, copy thi
 The type of authentication method expected by your service provider.
 
 Valid settings:
-```
+<pre>
 :login
 :none
-```
+</pre>
 
 *(note: if you set this to :none, you must not include the user_name and password settings)*
 
@@ -65,15 +65,15 @@ Valid settings:
 The mail transport method to be used.
 
 Valid settings:
-```
+<pre>
 :smtp
 :sendmail
-```
+</pre>
 
 ##### Example email.yml Configurations
 
 ###### Simple Login Authentication (default settings)
-```YAML
+<pre>
 production:
   delivery_method: :smtp
   smtp_settings:
@@ -83,12 +83,12 @@ production:
     authentication: :login
     user_name: foreman@example.net
     password: foreman
-```
+</pre>
     
 ###### No Authentication
 Example for an SMTP service provider with no authentication. Note the colon before none.
 
-```YAML
+<pre>
 production:
   delivery_method: :smtp
   smtp_settings:
@@ -96,13 +96,13 @@ production:
     port: 25
     domain: nowhere.com
     authentication: :none
-```
+</pre>
 ###### Using sendmail command
 Example for a unix system that uses the /usr/sbin/sendmail command.
-```YAML
+<pre>
 production:
   delivery_method: :sendmail
-```
+</pre>
 
 #### The 'Administer/Settings' page
 


### PR DESCRIPTION
I used the wrong version of MarkDown, broke the live manual's formatting.
