### PR TITLE
Update 4.3.5.2_isc_dhcp.md

### DIFF
--- a/_includes/manuals/1.7/4.3.5.2_isc_dhcp.md
+++ b/_includes/manuals/1.7/4.3.5.2_isc_dhcp.md
@@ -19,7 +19,7 @@ The dhcpd api server will listen to any host. You might need to add a omapi_key 
 
 Example generating a key (on CentOS):
 <pre>
-yum install bind97
+yum install bind
 dnssec-keygen -r /dev/urandom -a HMAC-MD5 -b 512 -n HOST omapi_key
 cat Komapi_key.+*.private |grep ^Key|cut -d ' ' -f2-
 </pre>


### PR DESCRIPTION
Removing bind97 version, using bind instead
