### PR TITLE
minor updates to apt instructions

### DIFF
--- a/_includes/manuals/1.6/2.1_quickstart_installation.md
+++ b/_includes/manuals/1.6/2.1_quickstart_installation.md
@@ -148,6 +148,7 @@ yum -y install http://yum.theforeman.org/releases/{{page.version}}/f19/x86_64/fo
   </p>
 
 {% highlight bash %}
+apt-get -y install ca-certificates
 wget https://apt.puppetlabs.com/puppetlabs-release-squeeze.deb
 dpkg -i puppetlabs-release-squeeze.deb
 {% endhighlight %}
@@ -168,6 +169,7 @@ wget -q http://deb.theforeman.org/pubkey.gpg -O- | apt-key add -
   </p>
 
 {% highlight bash %}
+apt-get -y install ca-certificates
 wget https://apt.puppetlabs.com/puppetlabs-release-wheezy.deb
 dpkg -i puppetlabs-release-wheezy.deb
 {% endhighlight %}
@@ -188,6 +190,7 @@ wget -q http://deb.theforeman.org/pubkey.gpg -O- | apt-key add -
   </p>
 
 {% highlight bash %}
+apt-get -y install ca-certificates
 wget https://apt.puppetlabs.com/puppetlabs-release-precise.deb
 dpkg -i puppetlabs-release-precise.deb
 {% endhighlight %}
@@ -208,6 +211,7 @@ wget -q http://deb.theforeman.org/pubkey.gpg -O- | apt-key add -
   </p>
 
 {% highlight bash %}
+apt-get -y install ca-certificates
 wget https://apt.puppetlabs.com/puppetlabs-release-trusty.deb
 dpkg -i puppetlabs-release-trusty.deb
 {% endhighlight %}
@@ -235,7 +239,7 @@ yum -y install foreman-installer
 
 <div class="quickstart_os quickstart_os_debian6 quickstart_os_debian7 quickstart_os_ubuntu1204 quickstart_os_ubuntu1404">
 {% highlight bash %}
-apt-get update && apt-get install foreman-installer
+apt-get update && apt-get -y install foreman-installer
 {% endhighlight %}
 </div>
 


### PR DESCRIPTION
- ca-certificates are needed for the wget of a https URL to work
- pass -y to the foreman-installer installation
