### PR TITLE
Fix discovery new features styling

### DIFF
--- a/plugins/foreman_discovery/2.0/index.md
+++ b/plugins/foreman_discovery/2.0/index.md
@@ -31,6 +31,7 @@ configure this mode which is not recommended.
 ### 1.1.1 Foreman Discovery plugin
 
 **2.0**: New features:
+
 * automatic provisioning
 * ZIP-based extensions
 * indirect communication via foreman proxy plugin


### PR DESCRIPTION
An extra space is needed so that jekyll parses it as a list of bulletpoints. Currently it just prints all points in a line separated by *s
