### PR TITLE
XVNC port range increase + tips/tricks

### DIFF
--- a/_includes/manuals/1.7/5.2.9_cr_vmware.md
+++ b/_includes/manuals/1.7/5.2.9_cr_vmware.md
@@ -12,7 +12,7 @@ Image based provisioning can be used by provisioning a new VM from a template an
 
 #### Console access
 
-Consoles are provided using VNC connections from Foreman to the ESX server, which requires a firewall change to open the respective ports (TCP 5910 to 5930)
+Consoles are provided using VNC connections from Foreman to the ESX server, which requires a firewall change to open the respective ports (TCP 5901 to 6001)
 
 {% highlight bash %}
 ssh root@esx-srv
@@ -30,8 +30,8 @@ Add the following file content:
   <protocol>tcp</protocol>
   <porttype>dst</porttype>
   <port>
-   <begin>5910</begin>
-   <end>5930</end>
+   <begin>5901</begin>
+   <end>6001</end>
   </port>
  </rule>
  <enabled>true</enabled>
@@ -68,6 +68,13 @@ cp /vmfs/volumes/datastore1/vnc.xml /etc/vmware/firewall/
 esxcli network firewall refresh
 {% endhighlight %}
 
+If permanent shared storage is available (direct-attach SAN, etc): rather than doing a file copy on each server, use a symlink instead.  Once it's changed on the shared storage, run a loop to refresh the firewall services. The local.sh file still needs to be created. 
+ 
+Example:
+
+{% highlight bash %}
+ln -s /vmfs/volumes/\{uuid of shared storage\}/firewall.rules/vnc.xml /etc/vmware/firewall/vnc.xml
+{% endhighlight %}
 
 * The account that foreman uses to communicate with VCenter is assumed to have the ability to traverse the entire inventory in order to locate a given datacenter.  A patch is required to instruct foreman to navigate directly to the appropriate datacenter to avoid permission issues ([#5006](http://projects.theforeman.org/issues/5006)).
 * Reference in the [VMWare KB 2043564](http://kb.vmware.com/selfservice/microsites/search.do?cmd=displayKC&docType=kc&externalId=2043564&sliceId=1&docTypeID=DT_KB_1_1&dialogID=458724081&stateId=1%200%20458722496).


### PR DESCRIPTION
The port range in this document is no longer correct - at present, Foreman will try to connect as high as 5999.  Console was failing all over the place in my environment until I made this change.
Also, rather than keeping a copy of the firewall rule local to every system, it's more efficient to store it on shared storage and symlink.  This allows for quick rule updates and easy rule refreshing.
