### PR TITLE
Make puppet_provider feature links point to config

### DIFF
--- a/_includes/manuals/1.8/4.3.7_smartproxy_puppet.md
+++ b/_includes/manuals/1.8/4.3.7_smartproxy_puppet.md
@@ -4,7 +4,7 @@ Activate the Puppet management module within the Smart Proxy instance.  This mod
 * reads the Puppet modules and manifests on the Puppet master, reporting the environments and classes that are declared, used when importing classes into Foreman
 * optionally triggers immediate Puppet runs on clients using one of a number of implementations
 
-It should be activated on Puppet masters that have the environments and modules available to import data from.  To use the Puppet run functionality, it also needs to be capable of executing *puppetrun* or equivalent implementation listed in the section below.  This works independently of the Puppet CA functionality, which may only be one of many Puppet masters in the environment.
+It should be activated on Puppet masters that have the environments and modules available to import data from.  To use the Puppet run functionality, it also needs to be capable of executing *puppetrun* or equivalent implementation listed in the section below.  This works independently of the Puppet CA functionality, which may only be one of many Puppet masters in the environment. To enable this, make sure these lines are present in `/etc/foreman-proxy/settings.d/puppet.yml`:
 
 <pre>
 :enabled: true
@@ -23,7 +23,7 @@ More information on configuring them is available in the [Puppet environment doc
 
 Directory environments are enabled by adding "environmentpath" to puppet.conf.  When the proxy finds this setting, it uses this mode too.  The `:puppet_use_environment_api` proxy setting can be used to force this mode on or off, but when unset, it follows the presence of environmentpath (the default).  More information on configuring directory environments is available [in the Puppet docs](http://docs.puppetlabs.com/puppet/latest/reference/environments.html).
 
-To get a list of environments and module paths, the proxy queries the Puppet master on its own API.  Typically the defaults will suffice, but the URL and settings used for the proxy to Puppet master API query can be controlled with the following settings:
+To get a list of environments and module paths, the proxy queries the Puppet master on its own API.  Typically the defaults will suffice, but the URL and settings used for the proxy to Puppet master API query can be controlled with the following settings in `/etc/foreman-proxy/settings.d/puppet.yml`:
 
 <pre>
 # URL of the puppet master itself for API requests
@@ -44,7 +44,7 @@ allow *
 
 ##### Puppet run providers
 
-For the optional Puppet run functionality, one of a number of implementations can be chosen in the config file.
+For the optional Puppet run functionality, one of a number of implementations can be chosen in `/etc/foreman-proxy/settings.d/puppet.yml`.
 
 <pre>
 :puppet_provider: puppetrun
@@ -87,7 +87,7 @@ The `:puppet_user` setting controls which user to sudo to, which on some install
 
 ##### MCollective
 
-The proxy can trigger Puppet runs using the MCollective "puppet" agent.  To enable this, add this line to settings.yml:
+The proxy can trigger Puppet runs using the MCollective "puppet" agent.  To enable this, add this line to `/etc/foreman-proxy/settings.d/puppet.yml`:
 
     :puppet_provider: mcollective
 
@@ -100,7 +100,7 @@ The `:puppet_user` setting applies in the same way as noted above for puppetrun.
 
 ##### puppetssh
 
-The puppetssh provider uses SSH to connect to the client using SSH keys and run the Puppet agent command directly.  It is controlled by the following settings:
+The puppetssh provider uses SSH to connect to the client using SSH keys and run the Puppet agent command directly.  It is controlled by the following settings in `/etc/foreman-proxy/settings.d/puppet.yml`:
 
 <pre>
 # whether to use sudo before the ssh command
@@ -118,7 +118,7 @@ The salt provider uses Salt for remote execution, by executing the puppet module
 
 ##### customrun
 
-The customrun provider allows configuration of a script that implements the Puppet run action in any way you require.
+The customrun provider allows configuration of a script that implements the Puppet run action in any way you require. Set the following configuration in `/etc/foreman-proxy/settings.d/puppet.yml`:
 
 <pre>
 # Set :customrun_cmd to the full path of the script you want to run, instead of /bin/false


### PR DESCRIPTION
Currently section 4.3.7 of the manual goes over how to set up the configuration, but never 'where' to set it up. As a new user, I think reading this can be a head scratching moment if you don't know at all where to configure this.
