### PR TITLE
delete now invalid smart proxy test

### DIFF
--- a/_includes/manuals/1.7/4.3.5.2_isc_dhcp.md
+++ b/_includes/manuals/1.7/4.3.5.2_isc_dhcp.md
@@ -41,10 +41,6 @@ cat Komapi_key.+*.private |grep ^Key|cut -d ' ' -f2-
 
 **NOTE**: if you don't see DHCP in Smart Proxies Features, choose "Refresh features" from drop-down menu.
 
-##### Testing
-
-If everything works, you could browse your dhcp server data if you goto http://proxy:8443/dhcp
-
 The next step is to set up appropriate Subnets in Foreman from the settings menu.
 
 ##### Sample dhcpd.conf

--- a/_includes/manuals/1.8/4.3.5.2_isc_dhcp.md
+++ b/_includes/manuals/1.8/4.3.5.2_isc_dhcp.md
@@ -41,10 +41,6 @@ cat Komapi_key.+*.private |grep ^Key|cut -d ' ' -f2-
 
 **NOTE**: if you don't see DHCP in Smart Proxies Features, choose "Refresh features" from drop-down menu.
 
-##### Testing
-
-If everything works, you could browse your dhcp server data if you goto http://proxy:8443/dhcp
-
 The next step is to set up appropriate Subnets in Foreman from the settings menu.
 
 ##### Sample dhcpd.conf


### PR DESCRIPTION
Not very nice but OK as a quick fix not to direct people to the proxy URL which won't work without client certificate now.
