### PR TITLE
Correction of two minor issues in the DHCP chapter

### DIFF
--- a/_includes/manuals/1.8/4.3.5.2_isc_dhcp.md
+++ b/_includes/manuals/1.8/4.3.5.2_isc_dhcp.md
@@ -35,7 +35,7 @@ cat Komapi_key.+*.private |grep ^Key|cut -d ' ' -f2-
     omapi-key omapi_key;
     </pre>
 
-2. Make sure you also add the omapi_key to your proxy's [dns.yml](/manuals/{{page.version}}/index.html#4.3.5DHCP)
+2. Make sure you also add the omapi_key to your proxy's [dhcp.yml](/manuals/{{page.version}}/index.html#4.3.5DHCP)
 
 3. Restart the dhcpd and foreman-proxy services
 

--- a/_includes/manuals/1.8/4.3.5_smartproxy_dhcp.md
+++ b/_includes/manuals/1.8/4.3.5_smartproxy_dhcp.md
@@ -14,7 +14,7 @@ If the proxy is managing a Microsoft DHCP server then set **dhcp_vendor** to **n
 
 The DHCP component needs access to the DHCP configuration file as well as the currently allocated leases.  For a Red Hat or Fedora-based host, the following values are typical:
 <pre>
-:dhcp_config: /etc/dhcpd.conf
+:dhcp_config: /etc/dhcp/dhcpd.conf
 :dhcp_leases: /var/lib/dhcpd/dhcpd.leases
 </pre>
 


### PR DESCRIPTION
#### Two minor corrections in the DHCP chapter:
1. Chapter 4.3.5.1 dhcp.yml says that the dhcpd.conf file on redhat systems is located at /etc/dhcpd.conf. But actuall it is /etc/dhcp/dhcpd.conf (at least on rhel-6, rhel-7 and fedora-21).
2. Chapter 4.3.5.2 ISC DHCP refers to the omapi_key of the proxy's dns.yml. It should be the dhcp.yml (even the link is ok pointing to the chapter 4.3.5.1 dhcp.yml).
