### PR TITLE
Wrong Link Syntax

### DIFF
--- a/_includes/manuals/1.8/4.3.10_smartproxy_tftp.md
+++ b/_includes/manuals/1.8/4.3.10_smartproxy_tftp.md
@@ -39,7 +39,7 @@ The setup is very simple, and may be performed manually if desired.
 
 ##### Setting Up Foreman
 
-In most cases, the default templates should work fine.  You do, however, need to make sure that a PXELinux or iPXE template is associated with your hosts.  See [[Foreman:Unattended_installations|Unattended Installations]] for details.  The template will be used to define the PXE configuration file when a host is enabled for build.
+In most cases, the default templates should work fine.  You do, however, need to make sure that a PXELinux or iPXE template is associated with your hosts.  See [Unattended Installations](http://projects.theforeman.org/projects/foreman/wiki/Unattended_installations) for details.  The template will be used to define the PXE configuration file when a host is enabled for build.
 
 ##### Workflow
 


### PR DESCRIPTION
This shoud be an copy from Foreman Wiki. I changed the syntax to Markdown link and provided the reference of the Wikipage : http://projects.theforeman.org/projects/foreman/wiki/Unattended_installations
