### PR TITLE
Adding a note for connection refused error

### DIFF
--- a/_includes/manuals/1.7/3.6_upgrade.md
+++ b/_includes/manuals/1.7/3.6_upgrade.md
@@ -158,6 +158,8 @@ To see what would happen
 
     foreman-installer --noop --dont-save-answers --verbose
 
+You may see ERRORS such as `/Stage[main]/Foreman_proxy::Register/Foreman_smartproxy[foreman-hostname.domain]:` `Could not evaluate: Connection refused - connect(2)` due to httpd / apache2 service being stopped.  These can be safely ignored.
+
 To apply these changes, run the installer again without options
 
     foreman-installer


### PR DESCRIPTION
While upgrading and https / apache2 service is down, you will get an error of evaluation of foreman_smartproxy, So we adding a note for the user not to panic
