### PR TITLE
Remove installation info duplicity

### DIFF
--- a/_includes/manuals/1.8/3.2.1_installation.md
+++ b/_includes/manuals/1.8/3.2.1_installation.md
@@ -1,23 +1,7 @@
 
-[The Foreman installer](https://github.com/theforeman/foreman-installer) uses Puppet to install Foreman. This guide assumes that you have a newly installed operating system, on which the installer will setup Foreman, a puppet master with Passenger and the [Smart Proxy](/manuals/{{page.version}}/index.html#4.3SmartProxies) by default.
-
 #### Downloading the installer
 
-For **Red Hat variants**, run this (replace 'el6' with 'el7' if on RHEL 7, or 'f19' on Fedora 19):
-
-{% highlight bash %}
-yum -y install http://yum.theforeman.org/releases/{{page.version}}/el6/x86_64/foreman-release.rpm
-yum -y install foreman-installer
-{% endhighlight %}
-
-For **Debian variants**, run this (replace 'wheezy' with 'trusty' if on Ubuntu 14.04, or 'precise' if on Ubuntu 12.04):
-
-{% highlight bash %}
-echo "deb http://deb.theforeman.org/ wheezy {{page.version}}" > /etc/apt/sources.list.d/foreman.list
-echo "deb http://deb.theforeman.org/ plugins {{page.version}}" >> /etc/apt/sources.list.d/foreman.list
-wget -q http://deb.theforeman.org/pubkey.gpg -O- | apt-key add -
-apt-get update && apt-get install foreman-installer
-{% endhighlight %}
+Follow the instructions in section [2.1 Quickstart installation](/manuals/{{page.version}}/index.html#2.1Installation)
 
 #### Running the installer
 


### PR DESCRIPTION
Currently section 3.2.1 does not tell the user to set up EPEL, Puppet repositories, and it's a bit unfriendly compared to the quickstart installation page. In addition to that we have to maintain both sections for no benefit. I think linking to Quickstart installation should work well (or moving that to 3.2.1 and linking from Quickstart to that).
