### PR TITLE
Added info about DHCP ranges

### DIFF
--- a/_includes/manuals/1.8/3.2.3_installation_scenarios.md
+++ b/_includes/manuals/1.8/3.2.3_installation_scenarios.md
@@ -142,7 +142,10 @@ foreman-installer \
   --foreman-proxy-oauth-consumer-secret=<secret here>
 {% endhighlight %}
 
-Ensure the dns-interface argument is updated with the correct network interface name for the DNS server to listen on.
+Ensure the dns-interface argument is updated with the correct network
+interface name for the DNS server to listen on. After configuration, make sure
+to create Subnet in Foreman under *Infrastructure > Subnets* for the
+particular Smart Proxy which registers automatically.
 
 Command line arguments for a smart proxy configured with just ISC DHCP and a single DHCP subnet:
 
@@ -160,7 +163,7 @@ foreman-installer \
   --foreman-proxy-dhcp=true \
   --foreman-proxy-dhcp-interface=eth0 \
   --foreman-proxy-dhcp-gateway=10.0.0.1 \
-  --foreman-proxy-dhcp-range="10.0.0.50 10.0.0.200" \
+  --foreman-proxy-dhcp-range="10.0.0.100 10.0.0.200" \
   --foreman-proxy-dhcp-nameservers="10.0.1.2,10.0.1.3" \
   --foreman-proxy-foreman-base-url=https://foreman.example.com \
   --foreman-proxy-trusted-hosts=foreman.example.com \
@@ -168,4 +171,16 @@ foreman-installer \
   --foreman-proxy-oauth-consumer-secret=<secret here>
 {% endhighlight %}
 
-Also ensure here that the dhcp-interface argument is updated for the interface to run DHCP on.
+Also ensure here that the dhcp-interface argument is updated for the interface
+to run DHCP on. After configuration, make sure to create a new Subnet (or
+import from existing) in the Foreman interface.
+
+While it is possible to define the same DHCP range in Foreman, it's usually
+good practice to select a range from outside the pool defined in the
+installer, but still in the subnet. For the example above, it is recommended
+to define the DHCP range from 10.0.0.1 to 10.0.0.99 in the Foreman UI which
+gives the following IP address distribution:
+
+* 10.0.0.1 - 10.0.0.99 - addresses reserved during bare-metal provisioning by Foreman
+* 10.0.0.100 - 10.0.200 - addresses for dynamic clients in the subnet
+  (discovered hosts, unmanaged hosts)

--- a/plugins/foreman_discovery/3.0/index.md
+++ b/plugins/foreman_discovery/3.0/index.md
@@ -386,6 +386,11 @@ click on *Refresh features* button and it will appear immediately.
 In *Infrastructure > Subnets* select the desired *Discovery Proxy* for each
 appropriate Subnet.
 
+Make sure that lease pool (defined in ISC DHCP configuration) and reservation
+pool (defined in *Infrastructure > Subnets*) are disjoint. More on that topic
+in the [installation scenarios]({{site.baseurl}}manuals/latest/index.html#3.2.3InstallationScenarios)
+section.
+
 ## 3.3 Hammer CLI Foreman Discovery plugin
 
 The plugin must be enabled in ```cli.modules.d/foreman_discovery.yml```


### PR DESCRIPTION
What we do by default (same range in both ISC DHCP configs and Subnet in
Foreman) causes this:

```
May 07 09:57:34 foreman.corp.xxx.com dhcpd[32511]: Dynamic and static leases present for 90.131.26.206.
May 07 09:57:34 foreman.corp.xxx.com dhcpd[32511]: Remove host declaration zzz.corp.xxx.com or remove 90.131.26.206
May 07 09:57:34 foreman.corp.xxx.com dhcpd[32511]: from the dynamic address pool for 90.131.26.192/28
```

It looks like this is harmless, but it's filling logs on every DHCP request.

More info: https://groups.google.com/forum/#!topic/foreman-users/DWcHKPYJRJo
