### PR TITLE
quickinfo about needed umask setting

### DIFF
--- a/_includes/manuals/1.7/3.2.1_installation.md
+++ b/_includes/manuals/1.7/3.2.1_installation.md
@@ -1,6 +1,7 @@
 
 [The Foreman installer](https://github.com/theforeman/foreman-installer) uses Puppet to install Foreman. This guide assumes that you have a newly installed operating system, on which the installer will setup Foreman, a puppet master with Passenger and the [Smart Proxy](/manuals/{{page.version}}/index.html#4.3SmartProxies) by default.
 
+
 #### Downloading the installer
 
 For **Red Hat variants**, run this (replace 'el6' with 'el7' if on RHEL 7, or 'f19' on Fedora 19):
@@ -20,6 +21,12 @@ apt-get update && apt-get install foreman-installer
 {% endhighlight %}
 
 #### Running the installer
+
+**Important:** Please make sure that you have set a standard umask of '0022' before running the installer!
+                                                                                                                                        
+{% highlight bash %}                                                                                     
+umask 0022
+{% endhighlight %}
 
 The installation run is non-interactive, but the configuration can be customized by supplying any of the options listed in `foreman-installer --help`, or by running `foreman-installer -i` for interactive mode.  More examples are given in the [Installation Options](/manuals/{{page.version}}/index.html#3.2.2InstallerOptions) section.  Adding `-v` will disable the progress bar and display all changes, while `--noop` will run without making any changes.  To run the installer, execute:
 

--- a/_includes/manuals/1.8/3.2.1_installation.md
+++ b/_includes/manuals/1.8/3.2.1_installation.md
@@ -5,6 +5,12 @@ Follow the instructions in section [2.1 Quickstart installation](/manuals/{{page
 
 #### Running the installer
 
+**Important:** Please make sure that you have set a standard umask of '0022' before running the installer!
+
+{% highlight bash %}                                                                                     
+umask 0022
+{% endhighlight %} 
+
 The installation run is non-interactive, but the configuration can be customized by supplying any of the options listed in `foreman-installer --help`, or by running `foreman-installer -i` for interactive mode.  More examples are given in the [Installation Options](/manuals/{{page.version}}/index.html#3.2.2InstallerOptions) section.  Adding `-v` will disable the progress bar and display all changes, while `--noop` will run without making any changes.  To run the installer, execute:
 
 {% highlight bash %}


### PR DESCRIPTION
Added a quickinfo about the supported umask when using foreman-installer for 1.7/1.8
