### PR TITLE
Default CA bundle name changed from 1.7 to 1.8

### DIFF
--- a/_includes/manuals/1.8/4.1.1_authentication.md
+++ b/_includes/manuals/1.8/4.1.1_authentication.md
@@ -33,6 +33,8 @@ On Red Hat based OSes:
 {% highlight bash %}
 cp example.crt /etc/pki/tls/certs/
 ln -s example.crt /etc/pki/tls/certs/$(openssl x509 -noout -hash -in /etc/pki/tls/certs/example.crt).0
+unlink /etc/pki/tls/certs/ca-bundle.crt
+ln -s /etc/pki/tls/certs/ca-bundle.crt /etc/pki/tls/certs/$(openssl x509 -noout -hash -in /etc/pki/tls/certs/example.crt).0
 {% endhighlight %}
 
 On Debian or Ubuntu, also ensure the file has a .crt extension:


### PR DESCRIPTION
Tested on 1.8.2

Started PUT "/auth_source_ldaps/3******_" for 10.169.230.42 at 2015-08-07 17:55:12 +0000
2015-08-07 17:55:12 [I] Processing by AuthSourceLdapsController#update as HTML
2015-08-07 17:55:12 [I]   Parameters: {"utf8"=>"✓", "authenticity_token"=>"jn+gUw25uy4NNTUrNcfksXMy8idZkKjayG+0KuI7Fcw=", "auth_source_ldap"=>{"name"=>"LDAPS", "host"=>"myldaps.com", "tls"=>"1", "port"=>"3269", "server_type"=>"active_directory", "account"=>"ad\user", "account_password"=>"[FILTERED]", "base_dn"=>"DC=myldaps,DC=com", "groups_base"=>,DC=myldaps,DC=com", "ldap_filter"=>"memberOf=CN=Foremen_Svc_devOps,OU=Security Groups,OU=Corporate,DC=myldaps,DC=com", "onthefly_register"=>"1", "usergroup_sync"=>"0", "attr_login"=>"sAMAccountName", "attr_firstname"=>"givenName", "attr_lastname"=>"sn", "attr_mail"=>"mail", "attr_photo"=>""}, "id"=>"3-**_*******"}
2015-08-07 17:55:12 [I]
