### PR TITLE
Update 7.1_novnc.md -- new Chrome workaround

### DIFF
--- a/_includes/manuals/1.9/7.1_novnc.md
+++ b/_includes/manuals/1.9/7.1_novnc.md
@@ -20,7 +20,7 @@ For VNC only, encrypted connections are the default on new installations.  If yo
 * SPICE connections are not encrypted.
 * For encrypted connections, you will need to trust the Foreman CA. This is typically stored in /var/lib/puppet/ssl/certs/ca.pem, you may wish to copy this to something like /var/www/html/pub/ca.crt so that users may easily find it.
 * Keyboard mappings are currently fixed to English only.
-* When using Firefox, if you use Foreman via HTTPS, Firefox might block the connection. To fix it, go to `about:config` and enable `network.websocket.allowInsecureFromHTTPS`. Same goes for Chrome, to fix it, go to `chrome://flags/` and enable Allow insecure WebSocket from https origin
+* When using Firefox, if you use Foreman via HTTPS, Firefox might block the connection. To fix it, go to `about:config` and enable `network.websocket.allowInsecureFromHTTPS`. Same goes for Chrome, to fix it, go to `chrome://flags/` and enable allow-insecure-websocket-from-https-origin.  Recent versions of Chrome (e.g. 44) have removed the flag.  An alternative workaround is to launch Chrome with a command-line argument like this "[user@workstation ~]$ google-chrome-stable --allow-running-insecure-content &"
 
 ### Troubleshooting Steps
 


### PR DESCRIPTION
Chrome has changed their security policy, which conflicts with the troubleshooting instructions on this page.  I've suggested another workaround using CLI options when launching Chrome.

The Chrome bug was discussed at https://code.google.com/p/chromium/issues/detail?id=367149
