### PR TITLE
Change wording on Upgrade instructions to explicitly indicate upgrade path

### DIFF
--- a/_includes/manuals/1.3/3.6_upgrade.md
+++ b/_includes/manuals/1.3/3.6_upgrade.md
@@ -10,7 +10,7 @@ aware of or additional steps:
 
 When upgrading across more than one version it is recommended to upgrade to each
 intermediate version and follow all upgrade instructions for the previous versions
-before updating to {{page.version}}
+before updating to {{page.version}}.
 
 #### Step 1 - Backup
 

--- a/_includes/manuals/1.3/3.6_upgrade.md
+++ b/_includes/manuals/1.3/3.6_upgrade.md
@@ -8,9 +8,9 @@ aware of or additional steps:
 
 * [Foreman {{page.version}} Upgrade Notes](manuals/{{page.version}}/index.html#Upgradenotes)
 
-If you are upgrading across more than one version, check upgrading
-instructions for all the versions for possible additional steps which may be
-necessary.
+When upgrading across more than one version it is recommended to upgrade to each
+intermediate version and follow all upgrade instructions for the previous versions
+before updating to {{page.version}}
 
 #### Step 1 - Backup
 

--- a/_includes/manuals/1.4/3.6_upgrade.md
+++ b/_includes/manuals/1.4/3.6_upgrade.md
@@ -7,9 +7,9 @@ aware of or additional steps:
 
 * [Foreman {{page.version}} Upgrade Notes](manuals/{{page.version}}/index.html#Upgradenotes)
 
-If you are upgrading across more than one version, check upgrading
-instructions for all the versions for possible additional steps which may be
-necessary.
+When upgrading across more than one version it is recommended to upgrade to each
+intermediate version and follow all upgrade instructions for the previous versions
+before updating to {{page.version}}
 
 #### Step 1 - Backup
 

--- a/_includes/manuals/1.4/3.6_upgrade.md
+++ b/_includes/manuals/1.4/3.6_upgrade.md
@@ -9,7 +9,7 @@ aware of or additional steps:
 
 When upgrading across more than one version it is recommended to upgrade to each
 intermediate version and follow all upgrade instructions for the previous versions
-before updating to {{page.version}}
+before updating to {{page.version}}.
 
 #### Step 1 - Backup
 

--- a/_includes/manuals/1.5/3.6_upgrade.md
+++ b/_includes/manuals/1.5/3.6_upgrade.md
@@ -23,7 +23,7 @@ Please check the following notes for this release:
 
 When upgrading across more than one version it is recommended to upgrade to each
 intermediate version and follow all upgrade instructions for the previous versions
-before updating to {{page.version}}
+before updating to {{page.version}}.
 
 
 #### Step 1 - Backup

--- a/_includes/manuals/1.5/3.6_upgrade.md
+++ b/_includes/manuals/1.5/3.6_upgrade.md
@@ -21,9 +21,10 @@ Please check the following notes for this release:
   upgrading, and restore the files inside to `/etc/foreman/plugins/` after
   the upgrade has finished.
 
-If you are upgrading across more than one version, check upgrade
-instructions for all previous versions for additional steps which may be
-necessary.
+When upgrading across more than one version it is recommended to upgrade to each
+intermediate version and follow all upgrade instructions for the previous versions
+before updating to {{page.version}}
+
 
 #### Step 1 - Backup
 

--- a/_includes/manuals/1.6/3.6_upgrade.md
+++ b/_includes/manuals/1.6/3.6_upgrade.md
@@ -11,7 +11,7 @@ Please note the following important change:
 
 When upgrading across more than one version it is recommended to upgrade to each
 intermediate version and follow all upgrade instructions for the previous versions
-before updating to {{page.version}}
+before updating to {{page.version}}.
 
 #### Step 1 - Backup
 

--- a/_includes/manuals/1.6/3.6_upgrade.md
+++ b/_includes/manuals/1.6/3.6_upgrade.md
@@ -9,9 +9,9 @@ Please note the following important change:
   backup of /etc/foreman-proxy/settings.yml in case the automatic migration
   fails.
 
-If you are upgrading across more than one version, follow upgrade
-instructions for all previous versions for additional steps which may be
-necessary.
+When upgrading across more than one version it is recommended to upgrade to each
+intermediate version and follow all upgrade instructions for the previous versions
+before updating to {{page.version}}
 
 #### Step 1 - Backup
 

--- a/_includes/manuals/1.7/3.6_upgrade.md
+++ b/_includes/manuals/1.7/3.6_upgrade.md
@@ -15,7 +15,7 @@ Please note the following important changes:
 
 When upgrading across more than one version it is recommended to upgrade to each
 intermediate version and follow all upgrade instructions for the previous versions
-before updating to {{page.version}}
+before updating to {{page.version}}.
 
 #### Step 1 - Backup
 

--- a/_includes/manuals/1.7/3.6_upgrade.md
+++ b/_includes/manuals/1.7/3.6_upgrade.md
@@ -13,9 +13,9 @@ Please note the following important changes:
   when the Foreman and Puppet master are on the same host ([more info](http://projects.theforeman.org/projects/foreman/wiki/Ubuntu_Precise_Brightbox)).
   When upgrading from v2, check [our upgrade notes](http://projects.theforeman.org/projects/foreman/wiki/FAQ#Upgrade-puppet-from-v2-to-v3-gotchas) for config changes.
 
-If you are upgrading across more than one version, follow upgrade
-instructions for all previous versions for additional steps which may be
-necessary.
+When upgrading across more than one version it is recommended to upgrade to each
+intermediate version and follow all upgrade instructions for the previous versions
+before updating to {{page.version}}
 
 #### Step 1 - Backup
 

--- a/_includes/manuals/1.8/3.6_upgrade.md
+++ b/_includes/manuals/1.8/3.6_upgrade.md
@@ -7,9 +7,9 @@ Please note the following known issues:
 * `media_path` in provisioning templates expands incorrectly to /media
   ([#9782](http://projects.theforeman.org/issues/9782)).
 
-If you are upgrading across more than one version, follow upgrade
-instructions for all previous versions for additional steps which may be
-necessary.
+When upgrading across more than one version it is recommended to upgrade to each
+intermediate version and follow all upgrade instructions for the previous versions
+before updating to {{page.version}}
 
 #### Step 1 - Backup
 

--- a/_includes/manuals/1.8/3.6_upgrade.md
+++ b/_includes/manuals/1.8/3.6_upgrade.md
@@ -9,7 +9,7 @@ Please note the following known issues:
 
 When upgrading across more than one version it is recommended to upgrade to each
 intermediate version and follow all upgrade instructions for the previous versions
-before updating to {{page.version}}
+before updating to {{page.version}}.
 
 #### Step 1 - Backup
 

--- a/_includes/manuals/1.9/3.6_upgrade.md
+++ b/_includes/manuals/1.9/3.6_upgrade.md
@@ -9,7 +9,7 @@ Please note the following known issue:
 
 When upgrading across more than one version it is recommended to upgrade to each 
 intermediate version and follow all upgrade instructions for the previous versions
-before updating to {{page.version}}
+before updating to {{page.version}}.
 
 #### Step 1 - Backup
 

--- a/_includes/manuals/1.9/3.6_upgrade.md
+++ b/_includes/manuals/1.9/3.6_upgrade.md
@@ -7,9 +7,9 @@ Please note the following known issue:
 * Hosts may lose their partition table association on upgrade, affecting rebuilds.
   Edit and re-save the host to fix it ([#11443](http://projects.theforeman.org/issues/11443)).
 
-If you are upgrading across more than one version, follow upgrade
-instructions for all previous versions for additional steps which may be
-necessary.
+When upgrading across more than one version it is recommended to upgrade to each 
+intermediate version and follow all upgrade instructions for the previous versions
+before updating to {{page.version}}
 
 #### Step 1 - Backup
 


### PR DESCRIPTION
Adjust the wording to explicitly state that you should upgrade to each intermediate version, and run the db:migrate, previous wording lead me to believe that I could go from 1.5 -> 1.9 as long as I did the steps listed in "Preparation" on each version. The db:migrate didn't seem to be an "additional" step of previous versions, rather the final step. 
