### PR TITLE
Added SELinux note for remote exec

### DIFF
--- a/plugins/foreman_remote_execution/0.0/index.md
+++ b/plugins/foreman_remote_execution/0.0/index.md
@@ -98,6 +98,11 @@ To generate a key, run following command on the host where Smart proxy runs
     chown foreman-proxy ~foreman-proxy/.ssh
     sudo -u foreman-proxy ssh-keygen -f ~foreman-proxy/.ssh/id_rsa_foreman_proxy -N ''
 
+When using SELinux make sure the directory and the files have correct labels
+of ssh_home_t. If not, restore the context:
+
+    restorecon -RvF ~foreman-proxy/.ssh
+
 Don't forget to restart Foreman, Smart proxy and Foreman tasks so
 plugins are loaded
 


### PR DESCRIPTION
As per the discussion in the demo. @ares @iNecas

It worked for you cos by default we do NOT install smart-proxy policy. It is
running unconfined.

Try to re-test with `foreman-proxy-selinux` package installed :-)
