### PR TITLE
Update api url to new schema

### DIFF
--- a/_includes/manuals/1.9/5.1_api.md
+++ b/_includes/manuals/1.9/5.1_api.md
@@ -1,3 +1,3 @@
-[API v2](/api_v2.html) is the default, stable and recommended version for Foreman {{page.version}}.  API v1 is also available, but future versions of Foreman will eventually deprecate and remove it.
+[API v2](api/{{page.version}}/index.html) is the default, stable and recommended version for Foreman {{page.version}}.  API v1 is also available, but future versions of Foreman will eventually deprecate and remove it.
 
 This section documents the JSON API conventions for the Foreman API v2 and Katello API v2. To explicitly select the API version, see [Section 5.1.6](manuals/{{page.version}}/index.html#5.1.6APIVersioning).


### PR DESCRIPTION
The new target is http://theforeman.org/api/1.9/index.html but http://theforeman.org/manuals/1.9/index.html#5.1API links to the outdated url target.
