### PR TITLE
Load Open Sans font from CDN for consistent rendering

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -25,6 +25,7 @@
   <link rel="stylesheet" media="all" href="{{ site.baseurl }}static/css/syntax.css" />
 	<link rel="stylesheet" media="all" href="{{ site.baseurl }}static/css/style.css"/>
 	<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
+	<link rel="stylesheet" type="text/css" href="//fonts.googleapis.com/css?family=Open+Sans">
 	<meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="viewport" content="user-scalable=no, width=device-width, initial-scale=1.0, maximum-scale=1.0;" />
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">


### PR DESCRIPTION
Stylesheet prefers Open Sans already, so distribute it to ensure the
page is displayed consistently.
