### PR TITLE
Redirect old /api pages

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -29,6 +29,9 @@
 	<meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="viewport" content="user-scalable=no, width=device-width, initial-scale=1.0, maximum-scale=1.0;" />
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  {% if page.redirect != nil %}
+  <meta http-equiv="refresh" content="1; url={{ page.redirect }}" />
+  {% endif %}
 </head>
 
 <body>

--- a/api.md
+++ b/api.md
@@ -1,4 +1,8 @@
 ---
-layout: api
-title: 
+layout: default
+redirect: /documentation.html
 ---
+
+# API documentation
+
+Our API documentation has moved to the main documentation page under each version of Foreman. Please update your bookmarks.

--- a/api_v2.md
+++ b/api_v2.md
@@ -1,4 +1,8 @@
 ---
-layout: api_v2
-title:
+layout: default
+redirect: /documentation.html
 ---
+
+# API documentation
+
+Our API documentation has moved to the main documentation page under each version of Foreman. Please update your bookmarks.


### PR DESCRIPTION
Not redirecting to the specific version so the link doesn't get out of date.
