### PR TITLE
Headline features for 1.10

### DIFF
--- a/_includes/manuals/1.10/1.2_release_notes.md
+++ b/_includes/manuals/1.10/1.2_release_notes.md
@@ -2,6 +2,48 @@
 
 ### Headline features
 
+#### Orchestration rebuilder
+
+A new "Rebuild Config" option is available from the dropdown menu on *All hosts* to rebuild DHCP, DNS and TFTP records and files for one or more selected hosts.
+
+When creating or editing a host, Foreman instructs the smart proxy during orchestration to add DHCP or DNS records to the service (e.g. ISC DHCP server) that it manages.  If the service state is lost, or the server is reinstalled, the reservations and records would be lost.  The rebuild action will force a rewrite of all orchestrated records, by deleting and recreating them.
+
+A corresponding API is available at `PUT /api/hosts/:id/rebuild_config`.
+
+#### Global statuses
+
+The status of a host as shown on the *All hosts* list is now derived from a set of detailed statuses, which can be viewed in the tooltip or from the host page in the *Properties* table.
+
+New detailed statuses have been added for configuration management (Puppet) and build state, and plugins are now able to add their own to this list, allowing them to easily show a host in a warning or error state if desired.
+
+#### Cloning
+
+Host and host group cloning has improved immeasurably in this release, with new features and many bug fixes.  For hosts that are on a compute resource (virtual machines), Foreman now copies the details of the storage and networking for most providers, plus other attributes such as memory, CPUs etc. when creating the new host.  The new host is still installed from scratch (using the selected provisioning method), but should be created with an equivalent configuration.
+
+Bug fixes allow proper cloning of parameters, Puppet class and config group associations, parameter overrides and more, for both hosts and host groups.
+
+A related improvement in image provisioning of new VMware hosts applies networking and storage configuration from the host Virtual Machine tab to the templated VM.
+
+#### Unsetting attributes
+
+Some attributes have traditionally been hard to "unset" using the web interface.  When creating a host with a host group, you can now select which attributes (e.g. Puppet master, environment) are used from the host group, or they can be explicitly unset by depressing a new *inherit* button and changing the value.  This allows a host to be created with some attributes from a host group, but excluding others.  Note that hosts still copy the attributes, and will not continue to inherit changes from the host group.
+
+Host root passwords, compute resource, LDAP server password fields etc. now show whether a password is set and using the adjacent edit button, the value can be edited or unset.
+
+#### DNS plugin support
+
+As well as the built in nsupdate and MS AD providers, the Smart Proxy now supports more DNS servers through a new pluggable interface.  Plugins for [PowerDNS](https://github.com/theforeman/smart_proxy_dns_powerdns) and [Route53](https://github.com/theforeman/smart_proxy_dns_route53) are already available, and new plugins can [be written easily](http://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Smart-Proxy_Plugin#Adding-a-DNS-provider).
+
+It is hoped that this will extend to DHCP and other parts of the Smart Proxy in future versions.
+
+#### Parameters improvements
+
+Smart class parameters and variables can now additionally merge the default value of the parameter into that of any matchers when using hashes/arrays/YAML/JSON, using a new *Merge default* checkbox on the parameter.
+
+The parameters tab of the Puppet class edit has been partially rearranged to display settings in a clearer manner, and make it easier to add and manage matchers with dropdown menus.
+
+Lastly, the parameters tab of the host and host group forms has had a number of improvements to standardize the layout, improving tooltips and display of long class and parameter names.
+
 ### Release notes for 1.10.0
 
 #### API


### PR DESCRIPTION
Do these seem like reasonable things to highlight from http://theforeman.org/manuals/1.10/index.html#Releasenotesfor1.10?  I'm trying to keep to fewer than six.

The only other one might be the partial reorganisation of the Puppet class edit form, and a mention of layout changes on the host edit parameters tab, e.g. to show full parameter names.

Once agreed we can add some screenshots and screencasts.
