### PR TITLE
Missing </div> in documentation

### DIFF
--- a/documentation.md
+++ b/documentation.md
@@ -44,6 +44,7 @@ version: 1.9
       <p id='api-ref'>api</p>
     </a>
   </div>
+</div>
 <div class='row'>
   <div class='col-md-4 center'>
 		<a href='/plugins' class="btn-doc btn">


### PR DESCRIPTION
**Problem**
A missing </div> in documentation is lost and misaligns the icons.
![](http://i.imgur.com/LyOoB0n.png)

**Solution**
Put the closing div in there.
![](http://i.imgur.com/ATOl5Ft.png)
