### PR TITLE
Plugin landing page improvements

### DIFF
--- a/plugins/foreman_chef/index.md
+++ b/plugins/foreman_chef/index.md
@@ -1,16 +1,16 @@
 ---
 layout: plugin_index
-title: Foreman discovery documentation
-versions: [4.1, 4.0, 3.0, 2.0]
+title: Foreman Chef documentation
+versions: [0.2, 0.1]
 ---
 
-# Foreman discovery manuals
+# Foreman Chef manuals
 -----------------------------
 
 <div class='row plugin-manual'>
     {% for version in page.versions %}
 	<div class='col-md-4 center'>
-		<a href="plugins/foreman_discovery/{{ version }}/index.html" class="btn-doc btn">
+		<a href="plugins/foreman_chef/{{ version }}/index.html" class="btn-doc btn">
 			<i class="fa fa-newspaper-o"></i>
 			<p id='manual'>{{ version }}</p>
 		</a>

--- a/plugins/foreman_docker/index.md
+++ b/plugins/foreman_docker/index.md
@@ -1,16 +1,16 @@
 ---
 layout: plugin_index
-title: Foreman discovery documentation
-versions: [4.1, 4.0, 3.0, 2.0]
+title: Foreman docker documentation
+versions: [1.x]
 ---
 
-# Foreman discovery manuals
+# Foreman docker manuals
 -----------------------------
 
 <div class='row plugin-manual'>
     {% for version in page.versions %}
 	<div class='col-md-4 center'>
-		<a href="plugins/foreman_discovery/{{ version }}/index.html" class="btn-doc btn">
+		<a href="plugins/foreman_docker/{{ version }}/index.html" class="btn-doc btn">
 			<i class="fa fa-newspaper-o"></i>
 			<p id='manual'>{{ version }}</p>
 		</a>

--- a/plugins/foreman_openscap/index.md
+++ b/plugins/foreman_openscap/index.md
@@ -1,16 +1,16 @@
 ---
 layout: plugin_index
-title: Foreman discovery documentation
-versions: [4.1, 4.0, 3.0, 2.0]
+title: Foreman OpenSCAP documentation
+versions: [0.4]
 ---
 
-# Foreman discovery manuals
+# Foreman OpenSCAP manuals
 -----------------------------
 
 <div class='row plugin-manual'>
     {% for version in page.versions %}
 	<div class='col-md-4 center'>
-		<a href="plugins/foreman_discovery/{{ version }}/index.html" class="btn-doc btn">
+		<a href="plugins/foreman_openscap/{{ version }}/index.html" class="btn-doc btn">
 			<i class="fa fa-newspaper-o"></i>
 			<p id='manual'>{{ version }}</p>
 		</a>

--- a/plugins/foreman_remote_execution/index.md
+++ b/plugins/foreman_remote_execution/index.md
@@ -1,16 +1,16 @@
 ---
 layout: plugin_index
-title: Foreman discovery documentation
-versions: [4.1, 4.0, 3.0, 2.0]
+title: Foreman Remote Execution Documentation
+versions: [0.0]
 ---
 
-# Foreman discovery manuals
+# Foreman Remote Execution manuals
 -----------------------------
 
 <div class='row plugin-manual'>
     {% for version in page.versions %}
 	<div class='col-md-4 center'>
-		<a href="plugins/foreman_discovery/{{ version }}/index.html" class="btn-doc btn">
+		<a href="plugins/foreman_remote_execution/{{ version }}/index.html" class="btn-doc btn">
 			<i class="fa fa-newspaper-o"></i>
 			<p id='manual'>{{ version }}</p>
 		</a>

--- a/plugins/foreman_salt/index.md
+++ b/plugins/foreman_salt/index.md
@@ -1,34 +1,19 @@
 ---
 layout: plugin_index
 title: Foreman Salt documentation
+versions: [4.0, 3.0, 2.1, 2.0]
 ---
 
 # Foreman Salt manuals
 -----------------------------
 
 <div class='row plugin-manual'>
+    {% for version in page.versions %}
 	<div class='col-md-4 center'>
-		<a href="plugins/foreman_salt/4.0/index.html" class="btn-doc btn">
+		<a href="plugins/foreman_salt/{{ version }}/index.html" class="btn-doc btn">
 			<i class="fa fa-newspaper-o"></i>
-			<p id='manual'>4.0</p>
+			<p id='manual'>{{ version }}</p>
 		</a>
 	</div>
-	<div class='col-md-4 center'>
-		<a href="plugins/foreman_salt/3.0/index.html" class="btn-doc btn">
-			<i class="fa fa-newspaper-o"></i>
-			<p id='manual'>3.0</p>
-		</a>
-	</div>
-	<div class='col-md-4 center'>
-		<a href="plugins/foreman_salt/2.1/index.html" class="btn-doc btn">
-			<i class="fa fa-newspaper-o"></i>
-			<p id='manual'>2.1</p>
-		</a>
-	</div>
-    <div class='col-md-4 center'>
-		<a href="plugins/foreman_salt/2.0/index.html" class="btn-doc btn">
-			<i class="fa fa-newspaper-o"></i>
-			<p id='manual'>2.0</p>
-		</a>
-	</div>
+    {% endfor %}
 </div>

--- a/plugins/index.md
+++ b/plugins/index.md
@@ -24,7 +24,7 @@ Foreman plugins are implemented as [Rails engines](http://guides.rubyonrails.org
 		</a>
 	</div>
 	<div class='col-md-3 center'>
-		<a href="plugins/foreman_chef/0.2" class="btn-doc btn">
+		<a href="plugins/foreman_chef" class="btn-doc btn">
 			<p class='h2 doc-icon'><i class="fa fa-cutlery"></i></p>
 			Chef
 		</a>
@@ -50,13 +50,13 @@ Foreman plugins are implemented as [Rails engines](http://guides.rubyonrails.org
 		</a>
 	</div>
 	<div class='col-md-3 center'>
-		<a href="plugins/foreman_discovery/" class="btn-doc btn">
+		<a href="plugins/foreman_discovery" class="btn-doc btn">
 			<p class='h2 doc-icon'><i class="fa fa-wifi"></i></p>
 			Discovery
 		</a>
 	</div>
 	<div class='col-md-3 center'>
-		<a href="plugins/foreman_docker/1.x/" class="btn-doc btn">
+		<a href="plugins/foreman_docker" class="btn-doc btn">
 			<p class='h2 doc-icon'><i class="fa fa-ship"></i></p>
 			Docker
 		</a>
@@ -88,7 +88,7 @@ Foreman plugins are implemented as [Rails engines](http://guides.rubyonrails.org
 		</a>
 	</div>
 	<div class='col-md-3 center'>
-		<a href="plugins/foreman_openscap/0.4/" class="btn-doc btn">
+		<a href="plugins/foreman_openscap" class="btn-doc btn">
 			<p class='h2 doc-icon'><i class="fa fa-bank"></i></p>
 			OpenSCAP
 		</a>
@@ -96,13 +96,13 @@ Foreman plugins are implemented as [Rails engines](http://guides.rubyonrails.org
 </div>
 <div class='row'>
 	<div class='col-md-3 center'>
-		<a href="plugins/foreman_remote_execution/0.0/" class="btn-doc btn">
+		<a href="plugins/foreman_remote_execution" class="btn-doc btn">
 			<p class='h2 doc-icon'><i class="fa fa-toggle-right"></i></p>
 			Remote Execution
 		</a>
 	</div>
 	<div class='col-md-3 center'>
-		<a href="plugins/foreman_salt/" class="btn-doc btn">
+		<a href="plugins/foreman_salt" class="btn-doc btn">
 			<p class='h2 doc-icon'><i class="fa fa-cube"></i></p>
 			Salt
 		</a>


### PR DESCRIPTION
It's really causing some difficulty when plugins don't have an index page, you link to a hardcoded version, and later release new versions.  All the links on the internet are going to be pointing to old documentation.

I add a landing page for everyone here.
