### PR TITLE
Use old-style permalink for old G+ comments

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -45,7 +45,11 @@
 
       <hr/>
       <div class="g-comments"
+        {% if page.blogger_id != nil %}
+           data-href="http://blog.theforeman.org{{ page.url }}"
+        {% else %}
            data-href="{{ site.url }}{{ page.url }}"
+        {% endif %}
            data-width="642"
            data-first_party_property="BLOGGER"
            data-view_type="FILTERED_POSTMOD">


### PR DESCRIPTION
Turns out you _can_ test the comment system locally - it just uses the href in the comments widget. So, this adds a conditional - anything imported from Blogger has a blogger-id in the frontmatter, so we know to use the old-style URL for comments.
