### PR TITLE
Use page.title for blog posts in header

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -11,7 +11,11 @@
     {% if page.pagename != nil %}
     {% assign pagename = true %}
     {% endif %}
+  {% if page.layout == "post" %}
+  <title>{{ sitename }} :: {{ page.title }}</title>
+  {% else %}
   <title>{{ sitename }}{% if pagename %} :: {{ page.pagename }}{% endif %}</title>
+  {% endif %}
 
   <script type="text/javascript" src="{{ site.baseurl }}/static/js/jquery.js"></script>
   <script type="text/javascript" src="{{ site.baseurl }}/static/js/bootstrap.min.js"></script>


### PR DESCRIPTION
Blog posts don't seem to have `pagename` set, so the page title is just "Foreman". Duplicating `title` to `pagename` if the frontmatter of each post seems like a bad idea, so this just adds a conditional to all use of `title` for blog posts.
