### PR TITLE
Show page title correctly everywhere

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -11,11 +11,11 @@
     {% if page.pagename != nil %}
     {% assign pagename = true %}
     {% endif %}
-  {% if page.layout == "post" %}
-  <title>{{ sitename }} :: {{ page.title }}</title>
-  {% else %}
-  <title>{{ sitename }}{% if pagename %} :: {{ page.pagename }}{% endif %}</title>
-  {% endif %}
+
+    {% if page.title != nil and page.title != page.pagename %}
+    {% assign pagetitle = true %}
+    {% endif %}
+    <title>{{ sitename }}{% if pagename %} :: {{ page.pagename }}{% endif %}{% if pagetitle %} :: {{ page.title }}{% endif %}</title>
 
   <script type="text/javascript" src="{{ site.baseurl }}/static/js/jquery.js"></script>
   <script type="text/javascript" src="{{ site.baseurl }}/static/js/bootstrap.min.js"></script>


### PR DESCRIPTION
@GregSutcliffe's PR made me realize this is missing a lot of places like the manuals.  This probably looks better on search results:

Foreman 1.9 Manual: **Foreman :: Manual :: Foreman 1.9 Manual**

REX Manual: **Foreman :: Plugin Manuals :: Foreman Remote Execution 0.0 Manual**
