### PR TITLE
Make Guest Posts reposted from community authors stand out easily

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -13,12 +13,18 @@
         {% endif %}
         <p class="metadata">
           <span class="author">{{ page.author }}</span> - <span class="date">{{ page.date | date: "%-d %B %Y" }}</span>
+          {% if page.guest_post %}
+          <span class="foreman-blue-infobox pull-right">Guest Post</span>&nbsp;
+          {% endif %}
         </p>
       </div>
 
       <hr/>
 
       <div class="post-content">
+        {% if page.guest_url %}
+        <p><em>This is an authorized repost of <a href="{{ page.guest_url }}">{{ page.guest_url }}</a></em></p>
+        {% endif %}
         {{ content }}
       </div>
 

--- a/_posts/2015-06-11-coreos-cluster-deployments-with-foreman.md
+++ b/_posts/2015-06-11-coreos-cluster-deployments-with-foreman.md
@@ -7,6 +7,8 @@ tags:
 modified_time: '2015-06-11T17:05:40.896+03:00'
 blogger_id: tag:blogger.com,1999:blog-6789674575954398874.post-4810446073191972741
 blogger_orig_url: http://blog.theforeman.org/2015/06/coreos-cluster-deployments-with-foreman.html
+guest_post: true
+guest_url: http://blog.daniellobato.me/coreos-cluster-deployments-with-foreman
 excerpt: |
   As Major Hayden mentioned more than a year ago, deploying CoreOS is a bit of
   a different beast than deploying other operating systems. In this case, we
@@ -14,9 +16,6 @@ excerpt: |
   cloud-config script which will will set the SSH keys, core user password,
   CoreOS version, and register in etcd.
 ---
-
-*This is an authorized repost of [CoreOS cluster deployments with
-Foreman](http://blog.daniellobato.me/coreos-cluster-deployments-with-foreman/)*
 
 As [Major
 Hayden](https://major.io/2014/05/13/coreos-vs-project-atomic-a-review/)

--- a/_posts/2015-06-11-unattended-deployments-of-fedora-and.md
+++ b/_posts/2015-06-11-unattended-deployments-of-fedora-and.md
@@ -7,14 +7,13 @@ tags:
 modified_time: '2015-06-11T17:01:51.974+03:00'
 blogger_id: tag:blogger.com,1999:blog-6789674575954398874.post-339523326737578400
 blogger_orig_url: http://blog.theforeman.org/2015/06/unattended-deployments-of-fedora-and.html
+guest_post: true
+guest_url: http://blog.daniellobato.me/unattended-deployments-of-fedora-and-rhel-atomic-with-foreman
+excerpt: |
+  Project Atomic is a new initiative to have a family of well-known,
+  enterprise-tested operating systems ready for massive container deployments.
 ---
 
-This blog post is an authorized repost of [Unattended deployments of
-Fedora and RHEL Atomic with
-Foreman](http://blog.daniellobato.me/unattended-deployments-of-fedora-and-rhel-atomic-with-foreman/)  
-
-<!--more-->
-  
 [Project Atomic](http://www.projectatomic.io/) is a new initiative to
 have a family of well-known, enterprise-tested operating systems ready
 for massive container deployments. Atomic operating systems focus on:  

--- a/blog/index.html
+++ b/blog/index.html
@@ -8,6 +8,9 @@ layout: post_index
     <h3><a href="{{ post.url }}">{{ post.title }}</a></h3>
     <p class="metadata">
       <span class="author">{{ post.author }}</span> - <span class="date">{{ post.date | date: "%-d %B %Y" }}</span>
+    {% if post.guest_post %}
+      <span class="foreman-blue-infobox pull-right">Guest Post</span>&nbsp;
+    {% endif %}
     </p>
     <div class="post-content">
       {{ post.excerpt }}

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1111,3 +1111,15 @@ code {
   margin: 5px 0;
   max-width: 100%;
 }
+
+.foreman-blue-infobox {
+  background-color: #23B0DB;
+  border-style: solid;
+  border-radius: 4px;
+  padding: 2px 6px 2px;
+  color: #fff;
+  font-size: 14px;
+  font-weight: 700;
+  letter-spacing: .05em;
+  border-width: 0.833333px;
+}


### PR DESCRIPTION
If we're going to solicit guest posts, they should be obvious to readers. This adds a consistently-styled Guest Post badge to the index and the post page, and automatically adds the "authorized repost" found in @dLobatog's posts, if a url is provided.

The CSS might be overkill, but I didn't see anything suitable to inherit from - the other styling inherits from `btn` and this isn't a button.
