### PR TITLE
 The option --foreman-configure-ipa-repo is no longer needed

### DIFF
--- a/_includes/manuals/1.10/3.2.2_installer_options.md
+++ b/_includes/manuals/1.10/3.2.2_installer_options.md
@@ -212,10 +212,6 @@ More information about compute resources can be found in the [Compute Resources 
         <td>If disabled the EPEL repo will not be configured on RedHat family systems.</td>
       </tr>
       <tr>
-        <td style='white-space:nowrap'>--foreman-configure-ipa-repo</td>
-        <td>Enable custom yum repo with packages needed for external authentication via IPA, this may be needed on RHEL 6.5 and older.</td>
-      </tr>
-      <tr>
         <td style='white-space:nowrap'>--foreman-configure-scl-repo</td>
         <td>If disabled the SCL repo will not be configured on Red Hat clone systems. (Currently only installs repos for CentOS and Scientific)</td>
       </tr>

--- a/_includes/manuals/1.10/5.7.1_quick_configuration.md
+++ b/_includes/manuals/1.10/5.7.1_quick_configuration.md
@@ -16,11 +16,6 @@ foreman-installer --foreman-ipa-authentication=true
 {% endhighlight %}
 This option can be used for the reconfiguration of existing installation as well.
 
-Some of required packages may not be available in older RHEL versions. You can get them from Jan Pazdziora's copr yum repo at http://copr.fedoraproject.org/coprs/adelton/identity_demo/ .
-{% highlight bash %}
-foreman-installer --foreman-ipa-authentication=true --foreman-configure-ipa-repo=true
-{% endhighlight %}
-
 In case you want to use IPA server's host-based access control (HBAC) features (make sure *allow_all* rule is disabled), the default PAM service name (which would be matched by HBAC service name) is *foreman*. You can override the default name with:
 {% highlight bash %}
 foreman-installer --foreman-ipa-authentication=true --foreman-pam-service=<pam_service_name>


### PR DESCRIPTION
The option --foreman-configure-ipa-repo is no longer needed since the
packages are included in RHEL/CentOS versions 6 and 7 now.

This feature was needed in older RHEL/CentOS versions, in which some
packages weren't available. Now there is no need for it.

The option is already removed from 1.10 installer.
