### PR TITLE
Add RPM upgrade solutions for two common errors

### DIFF
--- a/_includes/manuals/1.10/3.3.1_rpm_packages.md
+++ b/_includes/manuals/1.10/3.3.1_rpm_packages.md
@@ -6,19 +6,32 @@ Foreman is packaged for the following RPM based distributions:
 
 For most users, it's highly recommended to use the [installer](manuals/{{page.version}}/index.html#3.2ForemanInstaller) as the packages only provide the software and a standalone Foreman service.  The installer installs these packages, then additionally configures Foreman to run under Apache and Passenger with PostgreSQL, plus can configure a complete Puppet setup integrated with Foreman.
 
-#### Pre-requisites
+#### Pre-requisites: EPEL
 
 All RHEL and derivatives must be [subscribed to EPEL](http://fedoraproject.org/wiki/EPEL) to provide additional dependencies.  Install epel-release from [here](http://fedoraproject.org/wiki/EPEL#How_can_I_use_these_extra_packages.3F) to automatically configure it.
 
+#### Pre-requisites: Software collections
+All RHEL and derivatives require Red Hat Software Collections (RHSCL) 1+ or a rebuild.
+
+Packages are available from any of these sources:
+
+1. softwarecollections.org: both [ruby193](https://www.softwarecollections.org/en/scls/rhscl/ruby193/) and [v8314](https://www.softwarecollections.org/en/scls/rhscl/v8314/) repositories
+1. CentOS SCLo SIG: `yum install centos-release-scl` to configure from CentOS Extras, or [sclo on mirror.centos.org](http://mirror.centos.org/centos/7/sclo/x86_64/rh/)
+1. Oracle Linux: [Software Collection Library documentation](http://docs.oracle.com/cd/E37670_01/E59096/html/index.html)
+1. RHEL: customers can access RHSCL as a separate repository or child channel
+1. Scientific Linux: [softwarecollections on ftp.scientificlinux.org](http://ftp.scientificlinux.org/linux/scientific/6x/external_products/softwarecollections/)
+
+A `foreman-release-scl` package is provided in Foreman's repositories, which configures the softwarecollections.org collections.  These are suitable for any EL variant/rebuild.  The Foreman installer will use this package by default.
+
+#### Pre-requisites: Optional repo (RHEL only)
+
 RHEL 6 and 7 hosts must also be subscribed to the RHEL 6/7 Optional repository or child channel in RHN.
-
-All RHEL and derivatives require Red Hat Software Collections (RHSCL) 1 or rebuild, e.g. Software Collections for CentOS.  RHSCL is available to RHEL customers as a separate repository or child channel.  More information on Software Collections for CentOS [is available here](http://wiki.centos.org/AdditionalResources/Repositories/SCL), for Scientific Linux it [is available here](http://ftp.scientificlinux.org/linux/scientific/6x/external_products/softwarecollections/) and for Oracle Linux it [is available here](http://docs.oracle.com/cd/E37670_01/E59096/html/index.html).
-
-<div class="alert alert-info">Please note that SCL is not available at the time of writing for CentOS,  Scientific Linux or Oracle Linux 7, so Foreman cannot yet be installed using packages on these operating systems.</div>
 
 To enable both optional and software collections on a RHEL 6 system using subscription-manager, run:
 
     yum-config-manager --enable rhel-6-server-optional-rpms rhel-server-rhscl-6-rpms
+
+#### Pre-requisites: Puppet
 
 Optionally, the Puppet Labs repository can be configured to obtain the latest version of Puppet available, instead of the version on EPEL.  See the [Puppet Labs Package Repositories](http://docs.puppetlabs.com/guides/puppetlabs_package_repositories.html#for-red-hat-enterprise-linux-and-derivatives) documentation on how to configure these.
 

--- a/_includes/manuals/1.10/3.6_upgrade.md
+++ b/_includes/manuals/1.10/3.6_upgrade.md
@@ -6,6 +6,12 @@ When upgrading across more than one version it is recommended to upgrade to each
 intermediate version and follow all upgrade instructions for the previous versions
 before updating to {{page.version}}.
 
+Please note the following known issue:
+
+* RPM users with `ruby193-rubygems-1.2.4` installed (usually from old Foreman
+  versions) should run `yum downgrade ruby193-rubygems-1.2.3` to fix potential
+  errors with nokogiri and/or pg_ext.
+
 #### Step 1 - Backup
 
 It is recommended that you backup your database and modifications to Foreman
@@ -40,6 +46,15 @@ Clean up the yum cache:
 Next upgrade all Foreman packages:
 
     yum upgrade tfm\* ruby\* foreman\*
+
+Lots of changes were made to the RPM naming in this release, and not all old
+packages have an upgrade path.  If the command above raises an error when
+determining the packages to update, check below for possible resolutions:
+
+* `ruby193-rubygem-thin` errors: remove this package as it's unused by running
+  `rpm -e ruby193-rubygem-thin`
+* `Requires: v8314-runtime`: missing the v8314 software collection repository.
+  Check that a SCL repo with v8314 is enabled as per [RPM Pre-requisites](manuals/{{page.version}}/index.html#3.3.1RPMPackages).
 
 In order to catch all configuration changes and manage them properly you should install and run
 rpmconf from the EPEL repository along with vim-enhanced (for vimdiff):


### PR DESCRIPTION
Rewritten and updated the SCL pre-requisites section as the source for
SCLs used in 1.10 has changed.
