### PR TITLE
Change 'current versions' by last versions

### DIFF
--- a/_includes/version.html
+++ b/_includes/version.html
@@ -1,6 +1,6 @@
 <div class="version-marker">
   <p>
-    Current versions:
+    Latest versions:
       <a href="{{ site.baseurl }}documentation.html#1.10">1.10.0</a>
       /
       <a href="{{ site.baseurl }}documentation.html#1.9">1.9.3</a>


### PR DESCRIPTION
Current version would be fine if there was just one version listed.
However, with two versions listed on the homepage, it's unclear
which one is actually the most current. I think 'last' or
'supported' versions would be more accurate
