### PR TITLE
updating URL for foreman_chef plugin documentation

### DIFF
--- a/_includes/manuals/1.10/4.8_managing_chef.md
+++ b/_includes/manuals/1.10/4.8_managing_chef.md
@@ -1,1 +1,1 @@
-Please refer to the [foreman_chef plugin documentation](/plugins/foreman_chef/0.1/).
+Please refer to the [foreman_chef plugin documentation](/plugins/foreman_chef/0.2/).


### PR DESCRIPTION
documentation points to version 0.1 which is not the latest version (0.2) at the moment
