### PR TITLE
limit gem-pages version to one that used jekyll 2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,5 +4,5 @@ group :therubyracer do
     gem 'therubyracer', :require => 'v8'
 end
 
-gem 'github-pages'
+gem 'github-pages', '<44'
 gem 'rake'


### PR DESCRIPTION
github-pages 44 is bringing jekyll 3 and this page is not yet ready for it.
