### PR TITLE
Remove explicit HTTP protocols from embedded content

### DIFF
--- a/_includes/videos.html
+++ b/_includes/videos.html
@@ -10,7 +10,7 @@ function getYoutubeID(url) {
 };
 $('div.youtube').each(function() {
 	var id = $(this).data('video-id');
-	var thumb_url = "http://img.youtube.com/vi/"+id+"/hqdefault.jpg";
+	var thumb_url = "//img.youtube.com/vi/"+id+"/hqdefault.jpg";
 	$('<img width="100%" class="video" src="'+thumb_url+'" />').appendTo($(this));
 });
 </script>

--- a/_layouts/media.html
+++ b/_layouts/media.html
@@ -26,7 +26,7 @@ pagename: Media
 			</div>
 			<div id="presentations">
 				<h1>Introductory presentations</h1>
-				<iframe width="650" height="400" src="http://www.slideshare.net/slideshow/embed_code/key/t6BM0vxUBf0RG" frameBorder="0"></iframe>
+				<iframe width="650" height="400" src="//www.slideshare.net/slideshow/embed_code/key/t6BM0vxUBf0RG" frameBorder="0"></iframe>
 				<h1>Other presentations</h1>
 				<ul>
 					<li><a href="http://www.slideshare.net/roidelapluie/lifecycle-managementforeman">Lifecycle Management with Foreman</a> (Julien Pivotto)</li>

--- a/introduction.md
+++ b/introduction.md
@@ -71,7 +71,7 @@ Foreman can provision on bare metal as well as the following cloud providers:
 
 <div class='row'>
   <div class='center'>
-    <iframe src="http://www.slideshare.net/slideshow/embed_code/key/sm5T1slNQrceDs" width="850" height="710" frameborder="0" marginwidth="0" marginheight="0" scrolling="no" style="border:1px solid #CCC; border-width:1px; margin-bottom:5px; max-width: 100%;" allowfullscreen> </iframe>
+    <iframe src="//www.slideshare.net/slideshow/embed_code/key/sm5T1slNQrceDs" width="850" height="710" frameborder="0" marginwidth="0" marginheight="0" scrolling="no" style="border:1px solid #CCC; border-width:1px; margin-bottom:5px; max-width: 100%;" allowfullscreen> </iframe>
   </div>
 </div>
 


### PR DESCRIPTION
Will prevent mixed content issues when the site's served over HTTPS.
