### PR TITLE
Document new 1.11 and 1.10.1 configuration options

### DIFF
--- a/_includes/manuals/1.10/3.5.2_configuration_options.md
+++ b/_includes/manuals/1.10/3.5.2_configuration_options.md
@@ -155,6 +155,11 @@ In a normal installation, only the "production" environment is relevant - develo
 When Foreman needs to mail the administrator then this is the email address that it will contact.  The domain is determined from Facter, else it will default to the ":domain" setting in /etc/foreman/settings.yaml.
 Default: root@<your domain>.
 
+##### always_show_configuration_status
+
+When reporting the configuration status of hosts, usually only hosts with outdated reports, or a Puppet proxy/master set and no reports will be considered out of sync. When true, all hosts will be considered out of sync until a report is received. This setting should be enabled in environments where Foreman is used for reporting without smart proxies.
+Default: false
+
 ##### authorize_login_delegation
 
 mod_proxy and other load balancers will set a REMOTE_USER environment variable. If this is _true_ , your users will be able to login through an external service and Foreman requests will be authenticated using this REMOTE_USER variable.

--- a/_includes/manuals/1.11/3.5.2_configuration_options.md
+++ b/_includes/manuals/1.11/3.5.2_configuration_options.md
@@ -155,6 +155,11 @@ In a normal installation, only the "production" environment is relevant - develo
 When Foreman needs to mail the administrator then this is the email address that it will contact.  The domain is determined from Facter, else it will default to the ":domain" setting in /etc/foreman/settings.yaml.
 Default: root@<your domain>.
 
+##### always_show_configuration_status
+
+When reporting the configuration status of hosts, usually only hosts with outdated reports, or a Puppet proxy/master set and no reports will be considered out of sync. When true, all hosts will be considered out of sync until a report is received. This setting should be enabled in environments where Foreman is used for reporting without smart proxies.
+Default: false
+
 ##### authorize_login_delegation
 
 mod_proxy and other load balancers will set a REMOTE_USER environment variable. If this is _true_ , your users will be able to login through an external service and Foreman requests will be authenticated using this REMOTE_USER variable.
@@ -169,6 +174,11 @@ Default: false
 
 If you have authorize_login_delegation set, new users can be autocreated through your external authentication mechanism by changing this to the name of the Auth Source you want to use to auto create users.
 Default: ''
+
+##### clean_up_failed_deployment
+
+During host provisioning onto a compute resource using images or templates and a finish script, this setting controls the behavior of Foreman when the script fails. When true, the new host and virtual machine (on the compute resource) will be deleted if the script fails. When false, the host and virtual machine are left running so the script can be debugged.
+Default: true
 
 ##### create_new_host_when_facts_are_uploaded
 
@@ -257,6 +267,13 @@ Default: true
 
 If this option is set to _true_ then Foreman will not update the IP and MAC addresses stored on a host's network interfaces with the values that it receives from facts. It will also include Foreman's values for IP and MAC to Puppet in its node/ENC information.
 Default: false
+See also: ignored_interface_identifiers
+
+##### ignored_interface_identifiers
+
+When importing facts and updating stored information on network interfaces, any network interface with an identifier (e.g. `eth0`) that matches any of the items in this list will be ignored and not updated. This can be used to avoid updating special types of interfaces when Foreman has limited or no understanding of them. The contents are an array of strings which may contain `*` wildcards to match zero or more characters.
+Default: `['lo', 'usb*', 'vnet*', 'macvtap*']`
+See also: ignore_puppet_facts_for_provisioning
 
 ##### legacy_puppet_hostname
 
@@ -390,10 +407,17 @@ Default: true
 New account holders will receive a welcome email when the account is created if this is enabled, including their username and a link to Foreman.
 Default: false
 
+##### ssl_client_cert_env
+
+Environment variable containing the entire PEM-encoded certificate from the client.  This environment variable is required when authenticating using Subject Alternative Names and will be preferred over `ssl_client_dn_env` if available.  Under Apache HTTP and mod_ssl, `SSLOptions +ExportCertData` sets this environment variable.
+Default: SSL_CLIENT_CERT
+See also: ssl_client_dn_env
+
 ##### ssl_client_dn_env
 
-Environment variable containing the subject DN from a client SSL certificate
+Environment variable containing the subject DN from a client SSL certificate.  Under Apache HTTP and mod_ssl, `SSLOptions +StdEnvVars` sets this environment variable.
 Default: SSL_CLIENT_S_DN
+See also: ssl_client_cert_env
 
 ##### ssl_client_verify_env
 

--- a/_includes/manuals/1.11/5.4.1_comms_puppetmaster.md
+++ b/_includes/manuals/1.11/5.4.1_comms_puppetmaster.md
@@ -30,7 +30,7 @@ Using Apache HTTP with mod_ssl and mod_passenger is recommended.  For simple set
 2. The mod_ssl configuration must contain:
   <ol><li>*SSLCACertificateFile* set to the Puppet CA</li>
   <li>*SSLVerifyClient optional*</li>
-  <li>*SSLOptions +StdEnvVars*</li></ol>
+  <li>*SSLOptions +StdEnvVars +ExportCertData*</li></ol>
 3. ENC script (e.g. `/etc/puppet/node.rb`) should have these settings:
   <ol><li>*:ssl_ca* set to the Puppet CA</li>
   <li>*:ssl_cert* set to the puppet master's certificate</li>
@@ -55,7 +55,7 @@ A typical small setup will use a single Puppet CA and certificates it provides f
 
 * Ensure the Common Name (CN) is present in certificates used by Foreman (as clients will validate it) and puppet master clients (used to verify against smart proxies).
 * Foreman's SSL terminator must be able to validate puppet master client SSL certificates.  In Apache with mod_ssl, the *SSLCACertificateFile* option must point to the CA used to validate clients and *SSLVerifyClient* set to _optional_.
-* Environment variables from the SSL terminator are used to get the client certificate's DN and verification status.  mod_ssl's *SSLOptions +StdEnvVars* setting enables this.  Variable names are defined by *ssl_client_dn_env* and *ssl_client_verify_env* settings in Foreman.
+* Environment variables from the SSL terminator are used to get the client certificate and verification status.  mod_ssl's *SSLOptions +StdEnvVars +ExportCertData* setting enables this.  Variable names are defined by *ssl_client_cert_env*, *ssl_client_dn_env* and *ssl_client_verify_env* settings in Foreman.
 
 #### Reduced security: HTTP host-based authentication
 


### PR DESCRIPTION
I notice the formatting is broken in this section of the manual with the default/see also lines missing line breaks.  For now I've just followed what's there.  I'll try to follow up with a fix for that across the whole section.
