### PR TITLE
Update smart proxy DHCP module configuration for 1.11

### DIFF
--- a/_includes/manuals/1.11/4.3.4.2_isc_dhcp.md
+++ b/_includes/manuals/1.11/4.3.4.2_isc_dhcp.md
@@ -35,7 +35,7 @@ cat Komapi_key.+*.private |grep ^Key|cut -d ' ' -f2-
     omapi-key omapi_key;
     </pre>
 
-2. Make sure you also add the omapi_key to your proxy's [dhcp.yml](/manuals/{{page.version}}/index.html#4.3.4DHCP)
+2. Make sure you also add the omapi_key to your proxy's [dhcp_isc.yml](/manuals/{{page.version}}/index.html#4.3.4DHCP)
 
 3. Restart the dhcpd and foreman-proxy services
 

--- a/_includes/manuals/1.11/4.3.4.3_ms_dhcp.md
+++ b/_includes/manuals/1.11/4.3.4.3_ms_dhcp.md
@@ -4,19 +4,15 @@ It is not required that the smart-proxy be on the same host as the MS dhcp serve
 
 __Note:__ Refer to the [installation guide](manuals/{{page.version}}/index.html#4.3.1SmartProxyInstallation) for general setup.
 
-1. Edit config/settings.d/dhcp.yml so that it looks a bit like this. `:dhcp_server:` can be left commented out if smart proxy runs on the same host.
+1. Edit config/settings.d/dhcp.yml so that it looks a bit like this. `:server:` can be left commented out if smart proxy runs on the same host.
 
     _Sample config/settings.d/dhcp.yml file_
 
        ---
        # Can be true, false, or http/https to enable just one of the protocols
-       :enabled: true
-       # Enable DHCP management
-       :dhcp: true
-       # The vendor can be either isc or native_ms
-       :dhcp_vendor: native_ms
-       # The dhcp_server is only used by the native_ms implementation
-       :dhcp_server: 10.10.10.1
+       :enabled: https
+       :use_provider: dhcp_native_ms
+       :server: 10.10.10.1
 
 2. If needed, you have to create the option 60 on the Windows DHCP (for PXE Boot)
 

--- a/_includes/manuals/1.11/4.3.4_smartproxy_dhcp.md
+++ b/_includes/manuals/1.11/4.3.4_smartproxy_dhcp.md
@@ -1,52 +1,75 @@
 
-Activate the DHCP management module within the Smart Proxy instance.  This is used to query for available IP addresses (looking at existing leases and reservations), add new and delete existing reservations.  It cannot manage subnet declarations, which should be managed by another means (e.g. [puppet-dhcp](https://github.com/theforeman/puppet-dhcp)).
+Activate the DHCP management module within the Smart Proxy instance. This is used to query for available IP addresses (looking at existing leases and reservations), add new and delete existing reservations. It cannot manage subnet declarations, which should be managed by another means (e.g. [puppet-dhcp](https://github.com/theforeman/puppet-dhcp)).
 
-<pre>
-:enabled: https
-</pre>
+The DHCP module is capable of managing the ISC DHCP server, Microsoft Active Directory and Libvirt instances.
 
-If the DHCP server is ISC compliant then set **dhcp_vendor** to **isc**. In this case Smart Proxy must run on the same host as the DHCP server.
-If the proxy is managing a Microsoft DHCP server then set **dhcp_vendor** to **native_ms**. Smart Proxy must then be run on an NT server so as to access the Microsoft native tools, though it does not have to be the same machine as the DHCP server. More details can be found in the [Foreman Architecture](/manuals/{{page.version}}/index.html#ForemanArchitecture).
+Builtin providers are:
 
-<pre>
-:dhcp_vendor: isc
-</pre>
+* `dhcp_isc` - ISC DHCP server over OMAPI
+* `dhcp_ms_native` - Microsoft Active Directory using netsh
+* `dhcp_virsh` - libvirt embedded DHCP (dnsmasq)
 
-The DHCP component needs access to the DHCP configuration file as well as the currently allocated leases.  For a Red Hat or Fedora-based host, the following values are typical:
-<pre>
-:dhcp_config: /etc/dhcp/dhcpd.conf
-:dhcp_leases: /var/lib/dhcpd/dhcpd.leases
-</pre>
+Extra providers are available as plugins and can be installed through packages. See the following pages for more information:
+
+* [List of smart proxy plugins](http://projects.theforeman.org/projects/foreman/wiki/List_of_Smart-Proxy_Plugins)
+* [Plugin installation documentation]({{ site.baseurl }}plugins/)
+
+To enable the DHCP module and enable a provider, `dhcp.yml` must contain:
+
+    :enabled: https
+    :use_provider: dhcp_isc
+
+For providers from plugins, check the plugin documentation to determine the exact provider name.
+
+The module manages a DHCP server on the local host by default, but for providers that can be run remotely, the server address can be changed:
+
+    :server: 127.0.0.1
+
+Note that if the DHCP server is running remotely, some providers (notably ISC) require that the configuration files must be accessible to the Smart Proxy still. This can be achieved with a network file system, e.g. NFS.
+
+All available subnets will be loaded and can be managed by default, but this can have a performance penalty. If only some subnets are used, specify them as follows in `network_address/network_mask` notation:
+
+    :subnets: [192.168.205.0/255.255.255.128, 192.168.205.128/255.255.255.128]
+
+Each provider has its own configuration file in the same directory with its own settings, e.g. `dhcp_isc.yml`. This usually needs additional configuration after changing the `use_provider` setting.
+
+#### dhcp_isc
+
+The dhcp_isc provider uses a combination of the ISC DHCP server OMAPI management interface and parsing of configuration and lease files. This requires it to be run either on the same host as the DHCP server or to have network filesystem access to these files.
+
+This provider requires the `config` and `leases` settings in the `dhcp_isc.yml` configuration file, which should be set to the location of the DHCP server config and lease files. On a Red Hat or Fedora server use:
+
+    :config: /etc/dhcp/dhcpd.conf
+    :leases: /var/lib/dhcpd/dhcpd.leases
 
 On a Debian or Ubuntu DHCP server, use the following values instead:
-<pre>
-:dhcp_config: /etc/dhcp3/dhcpd.conf
-:dhcp_leases: /var/lib/dhcp3/dhcpd.leases
-</pre>
 
-<div class="alert alert-info">The foreman-proxy account must be able to read both configuration files.  In particular, check the permissions on the parent directory (e.g. /etc/dhcp) permit world read/execute.</div>
+    :dhcp_config: /etc/dhcp3/dhcpd.conf
+    :dhcp_leases: /var/lib/dhcp3/dhcpd.leases
 
-If you secured your DHCP with an "omapi_key", add the entries:
-<pre>
-:dhcp_key_name: omapi_key
-:dhcp_key_secret: XXXXXXXX
-</pre>
+<div class="alert alert-info">The foreman-proxy account must be able to read both configuration files. In particular, check the permissions on the parent directory (e.g. /etc/dhcp) permit world read/execute.</div>
+
+If the DHCP server is secured with an "omapi_key", the following entries must be set with the same values:
+
+    :key_name: omapi_key
+    :key_secret: XXXXXXXX
 
 If the DHCP server is listening on a non-standard OMAPI port (i.e. not 7911), then change this with:
 
-<pre>
-:dhcp_omapi_port: 7911
-</pre>
+    :omapi_port: 7911
 
-If the DHCP server is running on a different host to the Smart Proxy, provide the hostname with:
+For DHCP servers running on a different host, change `:server` in the main `dhcp.yml` configuration file.
 
-<pre>
-:dhcp_server: dhcp.example.com
-</pre>
+#### dhcp_ms_native
 
-Note that if the DHCP server is running remotely, the configuration and/or lease files set above must be accessible to the Smart Proxy still. This can be achieved with a network file system, e.g. NFS.
+The ms_native provider manages reservations in Microsoft Active Directory by running the "netsh" command.
 
-Large numbers of subnets can slow the Smart Proxy down when iterating over the reservations.  You can request that the Smart Proxy only operate on a subset of the subnets managed by the DHCP server.  This works with both isc and native_ms providers.
-<pre>
-:dhcp_subnets: [192.168.1.0/255.255.255.0, 192.168.11.0/255.255.255.0]
-</pre>
+It has no configuration options in `dhcp_ms_native.yml`.
+
+#### dhcp_virsh
+
+The virsh provider interfaces to Libvirt's DHCP configuration and manages reservations via the `virsh` command line tool. It is designed for development setups.
+
+It has no configuration options in `dhcp_virsh.yml`, but is affected by `virsh_network` in `settings.yml`.
+
+More information about using this provider is in the [Libvirt section]({{ site.baseurl }}manuals/{{ page.version }}/index.html#4.3.11Libvirt).


### PR DESCRIPTION
DHCP module now uses separate providers rather than the "vendor"
setting, also rewritten to match the DNS section in style.
