### PR TITLE
Ubuntu Trusty users should set _PassengerRuby_ not _PassengerRoot_

### DIFF
--- a/_includes/manuals/1.11/1.2_release_notes.md
+++ b/_includes/manuals/1.11/1.2_release_notes.md
@@ -255,7 +255,7 @@ Installer modules have been updated, see their respective changelogs for more de
 
 ### Upgrade warnings
 * RPM package users should ensure the newer `rh-ror41` and `rh-ruby22` SCLs are available, following the [upgrade process](/manuals/1.11/index.html#3.6Upgrade).
-* Ubuntu 14.04 (Trusty) package users should set `PassengerRoot` to `/usr/bin/foreman-ruby` (usually in `/etc/apache2/sites-available/05-foreman*.conf`) as this symlink points to the version of Ruby used in packages, which was updated in 1.11.
+* Ubuntu 14.04 (Trusty) package users should set `PassengerRuby` to `/usr/bin/foreman-ruby` (usually in `/etc/apache2/sites-available/05-foreman*.conf`) as this symlink points to the version of Ruby used in packages, which was updated in 1.11.
 
 ### Deprecations
 * Debian 7 (Wheezy) is deprecated and will likely not be updated in Foreman 1.12.  Users are recommended to upgrade to Debian 8 (Jessie) with our [wiki upgrade notes](http://projects.theforeman.org/projects/foreman/wiki/Debian_jessie_notes).


### PR DESCRIPTION
https://www.phusionpassenger.com/library/config/apache/reference/#passengerruby
