### PR TITLE
Added note about initial commit line

### DIFF
--- a/contribute.md
+++ b/contribute.md
@@ -89,11 +89,13 @@ Please make sure there is a [Redmine issue](/contribute.html#Bugreporting) open 
 git checkout -b <branchName> # Example: git checkout -b 1656-add_TB_support
 {% endhighlight %}
 
-*  Make changes and commit. Please reference the Redmine issue this commit addresses via "refs" or "fixes" #issueid in the commit message.
+*  Make changes and commit. Please reference the Redmine issue this commit
+addresses via "Refs" or "Fixes" in the commit message. See [Coding
+Standards](handbook.html#Codingstandards) guide for more details.
 
 {% highlight bash %}
 git add <modifiedFile(s)>
-git commit -m 'fixes #<bug> - <message>'
+git commit -m 'Fixes #<bug> - <message>'
 {% endhighlight %}
 
 * Push topic branch to your fork:


### PR DESCRIPTION
This adds a note about maximum recommended initial commit line. I don't want to
start a war on this and I would suggest 50 as the gold standard, but I think
increasing this to 60 is fine. Linux kernel is usually 50:

http://i.stack.imgur.com/uzUqh.png

If you look on our history, preferred form is "Fixed" instead of "fixed", so I
made this as the recommended form (which I personally prefer too).
