### PR TITLE
Fix ICS file dates and tootlips

### DIFF
--- a/_includes/calendar.js
+++ b/_includes/calendar.js
@@ -1,3 +1,12 @@
+$(document).ready(function() {
+  var adjustClasses, tooltipHide, tooltipShow, $tip, tip, $widget, now;
+  now = Date.now();
+  $widget = $("#calendar");
+
+  // Create tooltips on events
+  tip = '<div id="fc-tooltip" class="fc-tooltip hidden"></div>';
+  $tip = $(tip).appendTo($widget).hide().removeClass('hidden');
+
 // Display the tooltip during mouseover
 tooltipShow = function(event, jsEvent, view) {
   var $item, eventInfo, eventText, label, value;
@@ -53,14 +62,6 @@ adjustClasses = function(event, element, view) {
 
 };
 
-$(document).ready(function() {
-  var adjustClasses, tooltipHide, tooltipShow, $tip, tip, $widget, now;
-  now = Date.now();
-  $widget = $("#calendar");
-
-  // Create tooltips on events
-  tip = '<div id="fc-tooltip" class="fc-tooltip hidden"></div>';
-  $tip = $(tip).appendTo($widget).hide().removeClass('hidden');
 
   $widget.fullCalendar({
     editable: false,

--- a/_plugins/events.rb
+++ b/_plugins/events.rb
@@ -105,8 +105,11 @@ module Jekyll
         cal_event.description = (speaker_text + description_text).strip
 
         if event['start'] && event['end']
+          # ICS also needs the off-by-one end-day fix, see fix_calendar_dates()
+          dend = event['end'].class == Date ? event['end'].next_day : event['end']
+
           cal_event.dtstart = ical_time(event['start'])
-          cal_event.dtend   = ical_time(event['end'])
+          cal_event.dtend   = ical_time(dend)
         elsif event['start'] && event['start'].class != Date
           # Has a time, assume 1hr duration
           cal_event.dtstart = ical_time(event['start'])


### PR DESCRIPTION
Two commits here. The first adds the off-by-one date fix to the ICS file (eg if you import the current ICS to you calendar, you'll see that OSDC is only showing as 2 days, not 3).

The second moves the javascript functions for the tooltips back inside document.ready. They currently aren't working from outside the ready, and I can't work out why. In addition http://stackoverflow.com/questions/2645344/functions-inside-or-outside-jquery-document-ready seems to imply that making things global when you don't need to isn't a good idea.
