### PR TITLE
NoVNC tip about FQDN

### DIFF
--- a/_includes/manuals/1.11/7.1_novnc.md
+++ b/_includes/manuals/1.11/7.1_novnc.md
@@ -28,6 +28,7 @@ For VNC only, encrypted connections are the default on new installations.  If yo
 * Check for a "websockify.py" process on your Foreman server when opening the console page in Foreman
 * If websockify.py is missing, check /var/log/foreman/production.log for stderr output with logging increased to debug
 * Look at the last argument of the process command line, it will have the hypervisor hostname and port - ensure you can resolve and ping this hostname
+* Make sure you access Foreman web UI via FQDN as the certificate does not have shortened hostname.
 * Try a telnet/netcat connection from the Foreman host to the hypervisor hostname/port
 * The penultimate argument of websockify.py is the listening port number, check if your web client host can telnet to it
 * If using Firefox, check the known issues above and set the config appropriately


### PR DESCRIPTION
When you force-ignore a certificate in Firefox, console does not work in SSL
mode, until you use FQDN. Looks like browsers remember this per port.
