### PR TITLE
Clarify hash usage with foreman-installer

### DIFF
--- a/_includes/manuals/1.11/3.2.2_installer_options.md
+++ b/_includes/manuals/1.11/3.2.2_installer_options.md
@@ -195,6 +195,10 @@ More information about compute resources can be found in the [Compute Resources 
 
 #### Available options
 
+**Note:** When you can specify a hash, you need to specify each option individually to `foreman-installer`.
+
+For example the hash `{show_diff => true, stringify_facts => false}` for `--puppet-server-additional-settings` becomes `--puppet-server-additional-settings=show_diff:true --puppet-server-additional-settings=stringify_facts:false`.
+
 <!-- Generated with:
 /usr/lib/ruby/gems/*/bin/kafo-export-params -c /etc/foreman-installer/scenarios.d/foreman.yaml -f html
 -->


### PR DESCRIPTION
The docs tell you to use a hash in the form of `{show_diff => true, stringify_facts => false}`, which is puppet syntax.

However with foreman-installer you need to use the kafo syntax for passing hash arguments, thus passing them individually.

```
foreman-installer \
--puppet-server-additional-settings=show_diff:true \
--puppet-server-additional-settings=stringify_facts:false
```

The docs for the foreman options are auto-generated and contain the puppet syntax only.

Added a note to the docs so this should be less confusing for users.
@domcleal asked me to update the docs on this via IRC.
