### PR TITLE
training: add landing page, netways foreman course, and a blog post

### DIFF
--- a/_layouts/training.html
+++ b/_layouts/training.html
@@ -1,0 +1,15 @@
+---
+pagename: Training
+---
+{% include header.html %}
+<div id="wrap">
+	<div class="container">
+		<div class="row">
+			<div id='doc' class="col-md-12">
+				{{ content }}
+			</div>
+		</div>
+	</div>
+</div>
+{% include tocify.html %}
+{% include footer.html %}

--- a/_posts/2016-05-04-new-foreman-training-course.md
+++ b/_posts/2016-05-04-new-foreman-training-course.md
@@ -1,0 +1,74 @@
+---
+layout: post
+title: New Foreman Training Course!
+date: 2016-05-04
+author: Greg Sutcliffe
+tags:
+- foreman
+- training
+- community
+- netways
+---
+
+Foreman now has a training course! The awesome folks over at NETWAYS decided to
+release their Foreman material as an open project for the community to use and
+contribute to. Read on for details!
+
+<!--more-->
+
+# The background
+
+A while ago, I got talking to [Dirk Götz][dirk] over at
+[NETWAYS][netways], and learned that they had been working on a training
+course for Foreman, so that they could offer it as part of their training
+progamme. I was interested in finding out more, as it's something that until
+now we haven't had in the Foreman community.
+
+[dirk]: //blog.netways.de/author/dgoetz
+[netways]: //netways.de
+
+Dirk kindly agreed to let me take a look at the material, and I was impressed!
+Weighing in at over 180 pages, covering not just basic Foreman activities, but
+also a lot of the plugins too, there was a lot of good stuff here... and then
+inspiration struck! We'd had comments on the [community survey][survey] that
+the manual was too dry for some people's learning style... so maybe a training
+course would be a good alternative for those looking to get to grips with
+Foreman in a more hands-on way.
+
+[survey]: //2016/03/2016-forman-survey-analysis.html
+
+# Opening it up
+
+Excited now, not just to be able to offer something new, but also to provide a
+solution to some of the feedback we'd had, we approached Dirk and NETWAYS with
+the suggestion to release the training course as an open collaboration, for the
+benefit of the Foreman community. To my great delight, they agreed!
+
+You can find the training course on our new [Training Page][training] or
+on the [NETWAYS github.io site][rendered]. The course is designed as a 2 day
+workshop, and is available to both those looking to self-study or provide
+Foreman training of their own.
+
+[training]: //training.html
+[rendered]: //netways.github.io/foreman-training/
+
+You can read Dirk's own thoughts on this on [his blog][blog], or listen to us
+discuss the release on last week's [community demo][demo].
+
+[blog]: https://blog.netways.de/2016/04/29/foreman-training-release
+[demo]: https://youtu.be/-bCIcN5i-24?t=1140
+
+# What next?
+
+Of course, we'd really like to see contributions to this - if you're giving or
+taking the training and see any problems, please do send us [patches][patches].
+If you're a plugin developer, perhaps consider adding a [module][plugins] to
+the course for your plugin?
+
+[patches]: https://github.com/NETWAYS/foreman-training/pulls
+[plugins]: https://github.com/NETWAYS/foreman-training/tree/gh-pages/plugins
+
+Also, if you do decide to do training courses of your own, consider letting us
+know - you can add such events to our shiny new [events page][events]!
+
+[events]: //events/

--- a/documentation.md
+++ b/documentation.md
@@ -54,9 +54,9 @@ version: '1.11'
     </a>
   </div>
   <div class='col-md-4 center'>
-    <a href="/support.html" class="btn-doc btn">
-      <h2 class='doc-icon'><i class="fa fa-support"></i></h2>
-      Support
+    <a href="/training.html" class="btn-doc btn">
+      <h2 class='doc-icon'><i class="fa fa-wrench"></i></h2>
+      Training
     </a>
   </div>
   <div class='col-md-4 center'>
@@ -67,13 +67,19 @@ version: '1.11'
   </div>
 </div>
 <div class='row'>
-  <div class='col-md-6 center'>
+  <div class='col-md-4 center'>
     <a href="/blog" class="btn-doc btn">
       <h2 class='doc-icon'><i class="fa fa-rss"></i></h2>
       Blog
     </a>
   </div>
-  <div class='col-md-6 center'>
+  <div class='col-md-4 center'>
+    <a href="/support.html" class="btn-doc btn">
+      <h2 class='doc-icon'><i class="fa fa-support"></i></h2>
+      Support
+    </a>
+  </div>
+  <div class='col-md-4 center'>
     <a href="/events" class="btn-doc btn">
       <h2 class='doc-icon'><i class="fa fa-calendar"></i></h2>
       Events

--- a/training.md
+++ b/training.md
@@ -1,0 +1,44 @@
+---
+layout: training
+title: Training Materials
+---
+
+# Foreman training materials
+
+This page lists the materials available for those wishing to study/practice working
+with Foreman, as an alternative style to reading the manual.
+
+## NETWAYS Training Course
+
+This course was developed by NETWAYS and made available to the Foreman
+community for use in developing training courses of their own, or for community
+members to use for self-study. It is designed as a two-day hands-on training
+course, and as well as the presentation below, it comes with
+[handouts][handouts], [exercises][exercises], and [solutions][solutions].
+
+[handouts]: https://github.com/NETWAYS/foreman-training/releases/download/v1.0/foreman-training-handouts.pdf
+[exercises]: https://github.com/NETWAYS/foreman-training/releases/download/v1.0/foreman-training-exercises.pdf
+[solutions]: https://github.com/NETWAYS/foreman-training/releases/download/v1.0/foreman-training-solutions.pdf
+
+A full-page version of the presentation can be found at
+[netways.github.io/foreman-training/][rendered]
+
+[rendered]: //netways.github.io/foreman-training/static
+
+<hr/>
+<div class='row'>
+  <div class='center'>
+    <iframe width="1024" height="710" frameborder="0" marginwidth="0" marginheight="0" scrolling="no"
+            style="border:1px solid #CCC; border-width:1px; margin-bottom:5px; max-width: 100%;"
+            src="//netways.github.io/foreman-training/"
+            frameBorder="0" allowfullscreen>
+    </iframe>
+  </div>
+</div>
+<hr/>
+
+The source for this training material, along with handouts and
+excercises/solutions can be found on the [NETWAYS GitHub page][source].
+Contribution to improve the source material is welcome!
+
+[source]: https://github.com/NETWAYS/foreman-training


### PR DESCRIPTION
- Adds a new landing page for training materials (my aim is eventually to move the relevant parts of Media page here, to declutter that one a bit)
- Add the new Netways training material on the training page
- Adds a link from the Documentation landing page
- Adds a blog post about the training material and collaboration on it

Previews:
http://theforeman.emeraldreverie.org/documentation.html
http://theforeman.emeraldreverie.org/training.html
http://theforeman.emeraldreverie.org/2016/05/new-foreman-training-course.html

@dgoetz how does that look to you?
