### PR TITLE
Document Puppet 4 compatibility and installation

### DIFF
--- a/_includes/manuals/1.12/2.1_quickstart_installation.md
+++ b/_includes/manuals/1.12/2.1_quickstart_installation.md
@@ -1,4 +1,4 @@
-[The Foreman installer](/manuals/{{page.version}}/index.html#3.2ForemanInstaller) uses Puppet to install Foreman. This guide assumes that you have a newly installed operating system, on which the installer will setup Foreman, a Puppet master with Passenger and the [Smart Proxy](/manuals/{{page.version}}/index.html#4.3SmartProxies) by default.
+[The Foreman installer](/manuals/{{page.version}}/index.html#3.2ForemanInstaller) uses Puppet to install Foreman. This guide assumes that you have a newly installed operating system, on which the installer will setup Foreman, a Puppet master, and the [Smart Proxy](/manuals/{{page.version}}/index.html#4.3SmartProxies) by default.
 
 #### Select operating system
 
@@ -69,8 +69,18 @@ yum-config-manager --enable rhel-7-server-optional-rpms rhel-server-rhscl-7-rpms
 
 <div class="quickstart_os quickstart_os_rhel6 quickstart_os_el6">
   <p>
-    Using Puppet 3.x is required, which is available from the Puppet Labs repository.
-    The version in EPEL (2.7.26) is not supported.
+    Using Puppet 3.x or 4.x is required, which is available from the Puppet Labs
+    repositories. The version in EPEL (2.7.26) is not supported.
+
+    To use Puppet 4.x with Puppet Agent and Puppet Server:
+  </p>
+
+{% highlight bash %}
+rpm -ivh https://yum.puppetlabs.com/puppetlabs-release-pc1-el-6.noarch.rpm
+{% endhighlight %}
+
+  <p>
+    Or to use Puppet 3.x:
   </p>
 
 {% highlight bash %}
@@ -99,6 +109,16 @@ yum -y install epel-release https://yum.theforeman.org/releases/{{page.version}}
   <p>
     Using a recent version of Puppet is recommended, which is available from the Puppet Labs repository.
     You may skip this and use the older version from EPEL without a problem, however it has reduced community support.
+
+    To use Puppet 4.x with Puppet Agent and Puppet Server:
+  </p>
+
+{% highlight bash %}
+rpm -ivh https://yum.puppetlabs.com/puppetlabs-release-pc1-el-7.noarch.rpm
+{% endhighlight %}
+
+  <p>
+    Or to use Puppet 3.x from Puppet Labs:
   </p>
 
 {% highlight bash %}
@@ -133,8 +153,17 @@ yum -y install https://yum.theforeman.org/releases/{{page.version}}/f24/x86_64/f
 
 <div class="quickstart_os quickstart_os_debian8">
   <p>
-    Note that Puppet Labs does not provide Puppet 3.x packages for jessie.
+    Using Puppet 4.x is recommended, which is available from the Puppet Labs repository.
+    You may skip this and use Puppet 3.x from Debian without a problem, however it has reduced community support.
+
+    To use Puppet 4.x with Puppet Agent and Puppet Server:
   </p>
+
+{% highlight bash %}
+apt-get -y install ca-certificates
+wget https://apt.puppetlabs.com/puppetlabs-release-pc1-jessie.deb
+dpkg -i puppetlabs-release-pc1-jessie.deb
+{% endhighlight %}
 
   <p>Enable the Foreman repo:</p>
 
@@ -148,8 +177,20 @@ wget -q https://deb.theforeman.org/pubkey.gpg -O- | apt-key add -
 
 <div class="quickstart_os quickstart_os_ubuntu1404">
   <p>
-    You may optionally use the latest available version of Puppet from the Puppet Labs repositories, which is
-    a bit newer than that provided by Ubuntu itself.
+    Using a recent version of Puppet is recommended, which is available from the Puppet Labs repository.
+    You may skip this and use Puppet 3.x from Ubuntu without a problem, however it has reduced community support.
+
+    To use Puppet 4.x with Puppet Agent and Puppet Server:
+  </p>
+
+{% highlight bash %}
+apt-get -y install ca-certificates
+wget https://apt.puppetlabs.com/puppetlabs-release-pc1-trusty.deb
+dpkg -i puppetlabs-release-pc1-trusty.deb
+{% endhighlight %}
+
+  <p>
+    Or to use Puppet 3.x from Puppet Labs:
   </p>
 
 {% highlight bash %}
@@ -170,8 +211,17 @@ wget -q https://deb.theforeman.org/pubkey.gpg -O- | apt-key add -
 
 <div class="quickstart_os quickstart_os_ubuntu1604">
   <p>
-    Note that Puppet Labs does not provide Puppet 3.x packages for xenial.
+    Using Puppet 4.x is recommended, which is available from the Puppet Labs repository.
+    You may skip this and use Puppet 3.x from Ubuntu without a problem, however it has reduced community support.
+
+    To use Puppet 4.x with Puppet Agent and Puppet Server:
   </p>
+
+{% highlight bash %}
+apt-get -y install ca-certificates
+wget https://apt.puppetlabs.com/puppetlabs-release-pc1-xenial.deb
+dpkg -i puppetlabs-release-pc1-xenial.deb
+{% endhighlight %}
 
   <p>Enable the Foreman repo:</p>
 

--- a/_includes/manuals/1.12/2.2_quickstart_puppet.md
+++ b/_includes/manuals/1.12/2.2_quickstart_puppet.md
@@ -5,25 +5,23 @@ After installation, the Foreman installer will have set up a puppet master on th
 puppet agent --test
 {% endhighlight %}
 
-<div class="alert alert-info">Puppet 3+ will show a warning the first time that the node can't be found, this can be ignored.</div>
+<div class="alert alert-info">Puppet will show a warning the first time that the node can't be found, this can be ignored.</div>
 
 In Foreman, click on the *Hosts* tab and your Foreman host should be visible in the list with an "O" status.  This indicates its status is OK, with no changes made on the last Puppet run.
 
 #### Downloading a Puppet module
 
-Next, we'll install a Puppet module for managing the NTP service.  If you have Puppet 2.7.14 or higher, install the module automatically from [Puppet Forge](http://forge.puppetlabs.com) to our "production" environment (the default):
+Next, we'll install a Puppet module for managing the NTP service from [Puppet Forge](http://forge.puppetlabs.com) to our "production" environment (the default):
 
 {% highlight bash %}
-puppet module install -i /etc/puppet/environments/production/modules saz/ntp
+puppet module install puppetlabs/ntp
 {% endhighlight %}
-
-On older versions, [download the tar.gz](http://forge.puppetlabs.com/saz/ntp) and unpack to `/etc/puppet/environments/production/modules/`.  Rename the directory to "ntp", removing the author and version number.
 
 In Foreman, go to *Configure > Classes* and click *Import from hostname* (top right) to read the available Puppet classes from the puppet master and populate Foreman's database.  The "ntp" class will appear in the Puppet class list if installed correctly.
 
 #### Using the Puppet module
 
-Click on the "ntp" class in the list, change to the *Smart Class Parameters* tab and select the *server_list* parameter on the left hand side.  Tick the *Override* checkbox so Foreman manages the "server_list" parameter of the class and change the default value if desired, before submitting the page.
+Click on the "ntp" class in the list, change to the *Smart Class Parameters* tab and select the *servers* parameter on the left hand side.  Tick the *Override* checkbox so Foreman manages the "servers" parameter of the class and change the default value if desired, before submitting the page.
 
 * More info: [Parameterized classes documentation](/manuals/{{page.version}}/index.html#4.2.5ParameterizedClasses)
 * Screencast: [Parameterized class support in Foreman](http://www.youtube.com/watch?v=Ksr0tilbmcc)
@@ -32,7 +30,7 @@ Change back to the *Hosts* tab and click *Edit* on the Foreman host.  On the *Pu
 
 <div class="alert alert-info">Managed parameters can be overridden when editing an individual host from its <i>Parameters</i> tab.</div>
 
-Clicking the *YAML* button when back on the host page will show the *ntp* class and the server_list parameter, as passed to Puppet via the ENC (external node classifier) interface.  Re-run `puppet agent --test` on the Foreman host to see the NTP service automatically reconfigured by Puppet and the NTP module.
+Clicking the *YAML* button when back on the host page will show the *ntp* class and the servers parameter, as passed to Puppet via the ENC (external node classifier) interface.  Re-run `puppet agent --test` on the Foreman host to see the NTP service automatically reconfigured by Puppet and the NTP module.
 
 #### Adding more Puppet-managed hosts
 

--- a/_includes/manuals/1.12/2_quickstart_guide.md
+++ b/_includes/manuals/1.12/2_quickstart_guide.md
@@ -1,7 +1,7 @@
 
 The Foreman installer is a collection of Puppet modules that installs everything required for a full working Foreman setup.  It uses native OS packaging (e.g. RPM and .deb packages) and adds necessary configuration for the complete installation.
 
-Components include the Foreman web UI, Smart Proxy, Passenger (for the puppet master and Foreman itself), and optionally TFTP, DNS and DHCP servers.  It is configurable and the Puppet modules can be read or run in "no-op" mode to see what changes it will make.
+Components include the Foreman web UI, Smart Proxy, Passenger, a Puppet master (either Puppet Server or under Passenger), and optionally TFTP, DNS and DHCP servers.  It is configurable and the Puppet modules can be read or run in "no-op" mode to see what changes it will make.
 
 #### Supported platforms
 * CentOS, Scientific Linux or Oracle Linux 7, x86_64

--- a/_includes/manuals/1.12/3.1.1_supported_platforms.md
+++ b/_includes/manuals/1.12/3.1.1_supported_platforms.md
@@ -21,7 +21,7 @@ The following operating systems are supported by the installer, have packages an
 
 It is recommended to apply all OS updates if possible.
 
-All platforms will require Puppet 3.x, which may be installed from OS or the Puppet Labs repositories.
+All platforms will require Puppet 3 or higher, which may be installed from OS or the Puppet Labs repositories.
 
 Other operating systems will need to use alternative installation methods, such as from source.
 

--- a/_includes/manuals/1.12/3.1.2_puppet_versions.md
+++ b/_includes/manuals/1.12/3.1.2_puppet_versions.md
@@ -1,4 +1,4 @@
-Foreman integrates with Puppet and Facter in a few places, but generally using a recent, stable version will be fine.  The exact versions of Puppet and Facter that Foreman is compatible with are listed below.
+Foreman integrates with Puppet and Facter in a few places, but generally using a recent, stable version will be fine.  The exact versions of Puppet, Puppet Server and Facter that Foreman is compatible with are listed below.
 
 <table class="table table-bordered table-condensed">
   <tr>
@@ -38,44 +38,68 @@ Foreman integrates with Puppet and Facter in a few places, but generally using a
   </tr>
   <tr>
     <td>3.0.x</td>
-    <td>Limited support</td>
-    <td>1.1 or higher</td>
-    <td>Supported</td>
-    <td>Supported</td>
-  </tr>
-  <tr>
-    <td>3.1.x - 3.4.x</td>
-    <td>1.1 or higher</td>
-    <td>1.1 or higher</td>
-    <td>Supported</td>
-    <td>Supported</td>
-  </tr>
-  <tr>
-    <td>3.5.x</td>
-    <td>1.4.3 or higher</td>
-    <td>1.4.2 or higher</td>
-    <td>Supported</td>
-    <td>Supported</td>
-  </tr>
-  <tr>
-    <td>3.6.0+</td>
-    <td>1.4.3 or higher</td>
-    <td>1.5.1 or higher</td>
-    <td>Supported</td>
-    <td>Supported</td>
-  </tr>
-  <tr>
-    <td>4.x</td>
     <td>Not supported</td>
-    <td>Partial support</td>
-    <td>Untested</td>
-    <td>Untested</td>
+    <td>Supported</td>
+    <td>Supported</td>
+    <td>Supported</td>
+  </tr>
+  <tr>
+    <td>3.1.x - 3.8.x</td>
+    <td>Supported</td>
+    <td>Supported</td>
+    <td>Supported</td>
+    <td>Supported</td>
+  </tr>
+  <tr>
+    <td>4.x (AIO)</td>
+    <td>Supported</td>
+    <td>Supported</td>
+    <td>Supported</td>
+    <td>Supported</td>
+  </tr>
+  <tr>
+    <td>4.x (non-AIO)</td>
+    <td>Supported</td>
+    <td>Supported</td>
+    <td>Supported</td>
+    <td>Supported</td>
   </tr>
 </table>
 
 Lines indicated with <span class='footnote'>*</span> require `Parametrized_Classes_in_ENC` in Foreman to be disabled.
 
-The Foreman installer and packages are generally incompatible with Puppet Enterprise, however with some manual reconfiguration, individual Foreman components such as the smart proxy should work if needed (some further unsupported documentation can be found on the wiki).  The installer in particular will conflict with a Puppet Enterprise installation.  It is recommended that Foreman is installed using [Puppet "open source"](http://docs.puppetlabs.com/guides/installation.html).
+#### Puppet Server compatibility
+
+Puppet Server is the application for serving Puppet agents used by default in Puppet 4 AIO installations.
+
+<table class="table table-bordered table-condensed">
+  <tr>
+    <th>Puppet Server version</th>
+    <th>Foreman installer</th>
+    <th>Notes</th>
+  </tr>
+  <tr>
+    <td>1.x</td>
+    <td>Limited support</td>
+    <td />
+  </tr>
+  <tr>
+    <td>2.0 - 2.1</td>
+    <td>Limited support</td>
+    <td>Requires server_use_legacy_use_conf, server_puppetserver_version to be set</td>
+  </tr>
+  <tr>
+    <td>2.2 - 2.5</td>
+    <td>Supported</td>
+    <td />
+  </tr>
+</table>
+
+#### AIO installer compatibility
+
+The Foreman installer supports both AIO and non-AIO configurations when using Puppet 4, switching behavior automatically based on the version of Puppet installed (usually during the first run when answers are stored).
+
+When using an AIO installation of Puppet to run the installer, it will default to configuring the Puppet Server application, and when using a non-AIO version of Puppet, it defaults to a traditional Rack/Passenger configuration.
 
 #### Facter compatibility
 
@@ -84,3 +108,8 @@ Foreman is known to be compatible with all Facter 1.x releases.
 For Facter 2.x, both Foreman installer and Foreman 1.4.2 or higher are required.
 
 Compatibility with structured facts in Facter 2.x is being introduced via [#4528](http://projects.theforeman.org/issues/4528).
+
+#### Puppet Enterprise compatibility
+
+The Foreman installer and packages are generally incompatible with Puppet Enterprise, however with some manual reconfiguration, individual Foreman components such as the smart proxy should work if needed (some further unsupported documentation can be found on the wiki).  The installer in particular will conflict with a Puppet Enterprise installation.  It is recommended that Foreman is installed using [Puppet "open source"](http://docs.puppetlabs.com/guides/installation.html).
+

--- a/_includes/manuals/1.12/3.2.3_installation_scenarios.md
+++ b/_includes/manuals/1.12/3.2.3_installation_scenarios.md
@@ -37,6 +37,8 @@ Transfer the following files to the same paths on the new host:
 * /var/lib/puppet/ssl/certs/new-puppetmaster.example.com.pem
 * /var/lib/puppet/ssl/private_keys/new-puppetmaster.example.com.pem
 
+Under a Puppet 4 AIO installation, substitute above paths with `/etc/puppetlabs/puppet/ssl/`.
+
 This provides the new host a certificate in the same authority, but doesn't make it a CA itself.  Certificates will continue to be generated on the central Puppet CA host.
 
 #### Standalone Puppet master

--- a/_includes/manuals/1.12/3.3.1_rpm_packages.md
+++ b/_includes/manuals/1.12/3.3.1_rpm_packages.md
@@ -33,7 +33,10 @@ To enable both optional and software collections on a RHEL 6 system using subscr
 
 #### Pre-requisites: Puppet
 
-Optionally, the Puppet Labs repository can be configured to obtain the latest version of Puppet available, instead of the version on EPEL.  See the [Puppet Labs Package Repositories](http://docs.puppetlabs.com/guides/puppetlabs_package_repositories.html#for-red-hat-enterprise-linux-and-derivatives) documentation on how to configure these.
+It's recommended to configure the Puppet Labs repositories to obtain the latest version of Puppet available, instead of the version on EPEL. Either the 3.x open source repository or the Puppet Collection (PC1) repository may be configured:
+
+* [Using Puppet Collections: Yum-based Systems](https://docs.puppet.com/guides/puppetlabs_package_repositories.html#yum-based-systems) (Puppet 4)
+* [Pre-4.0 Open Source Repositories: Yum-based Systems](https://docs.puppet.com/guides/puppetlabs_package_repositories.html#yum-based-systems-repository) (Puppet 3)
 
 #### Available repositories
 

--- a/_includes/manuals/1.12/3.5.4_puppet_reports.md
+++ b/_includes/manuals/1.12/3.5.4_puppet_reports.md
@@ -14,6 +14,7 @@ Without it, no reports will be sent.
 
 First identify the directory containing report processors, e.g.
 
+* AIO installations: /opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/reports/
 * EL6 (e.g. RHEL, CentOS): /usr/lib/ruby/site_ruby/1.8/puppet/reports/
 * EL7 or Fedora: /usr/share/ruby/vendor_ruby/puppet/reports/
 * Debian or Ubuntu: /usr/lib/ruby/vendor_ruby/puppet/reports/
@@ -21,7 +22,7 @@ First identify the directory containing report processors, e.g.
 
 Copy [the report processor source](https://raw.githubusercontent.com/theforeman/puppet-foreman/master/files/foreman-report_v2.rb) to this report directory and name it `foreman.rb`.
 
-Create a new configuration file at `/etc/puppet/foreman.yaml` containing:
+Create a new configuration file at `/etc/puppetlabs/puppet/foreman.yaml` (Puppet 4 AIO) or `/etc/puppet/foreman.yaml` (non-AIO) containing:
 <pre>
 ---
 # Update for your Foreman and Puppet master hostname(s)
@@ -38,7 +39,7 @@ Create a new configuration file at `/etc/puppet/foreman.yaml` containing:
 :threads: null
 </pre>
 
-Edit the URL field to point to your Foreman instance, and the SSL fields for the hostname of the Puppet master (which may be the same host.)
+Edit the URL field to point to your Foreman instance, and the SSL fields for the hostname of the Puppet master (which may be the same host). Paths to Puppet's SSL certificates will be under /etc/puppetlabs/ssl/ when using Puppet 4 with AIO.
 
 Lastly add this report processor to your Puppet master configuration.  In your master puppet.conf under the `[main]` section add:
 
@@ -52,7 +53,7 @@ You should start seeing reports coming in under the reports link.
 
 If reports aren't showing up in Foreman when an agent is run, there can be a number of reasons.  First check through the above configuration steps, and then look at these places to narrow down the cause:
 
-1. Puppet master logs may show an issue either loading or executing the report processor.  Check syslog (/var/log/messages or syslog) for `puppet-master` messages.
+1. Puppet master logs may show an issue either loading or executing the report processor.  Check syslog (/var/log/messages or syslog) for `puppet-master` messages, or /var/log/puppetlabs/puppetserver/.
 1. /var/log/foreman/production.log should show a `POST "/api/reports"` request each time a report is received, and will end in `Completed 201 Created` when successful.  Check for errors within the block of log messages.
 1. When viewing reports in Foreman's UI, be aware that the default search is for "eventful" reports.  Clear the search ('x') to see reports with no changes.
 

--- a/_includes/manuals/1.12/3.5.5_facts_and_the_enc.md
+++ b/_includes/manuals/1.12/3.5.5_facts_and_the_enc.md
@@ -7,9 +7,9 @@ The external nodes script we supply also deals with uploading facts from hosts t
 
 ##### Puppet master
 
-Download [the ENC script](https://raw.githubusercontent.com/theforeman/puppet-foreman/2.2.3/files/external_node_v2.rb) to to `/etc/puppet/node.rb` (the name is arbitrary, but must match configuration below) and ensure it's executable by "puppet" with `chmod +x /etc/puppet/node.rb`.
+Download [the ENC script](https://raw.githubusercontent.com/theforeman/puppet-foreman/master/files/external_node_v2.rb) to `/etc/puppetlabs/puppet/node.rb` (Puppet 4 AIO) or `/etc/puppet/node.rb` (non-AIO). The name is arbitrary, but must match configuration below, and ensure it's executable by "puppet" with `chmod +x /etc/puppet/node.rb`.
 
-Unless it already exists from setting up reporting, create a new configuration file at `/etc/puppet/foreman.yaml` containing:
+Unless it already exists from setting up reporting, create a new configuration file at `/etc/puppetlabs/puppet/foreman.yaml` (Puppet 4 AIO) or `/etc/puppet/foreman.yaml` (non-AIO) containing
 
 <pre>
 ---
@@ -27,7 +27,7 @@ Unless it already exists from setting up reporting, create a new configuration f
 :threads: null
 </pre>
 
-Edit the URL field to point to your Foreman instance, and the SSL fields for the hostname of the Puppet master (which may be the same host).  More information on SSL certificates is at [Securing communications with SSL](/manuals/{{page.version}}/index.html#5.4SecuringCommunicationswithSSL).
+Edit the URL field to point to your Foreman instance, and the SSL fields for the hostname of the Puppet master (which may be the same host). Paths to Puppet's SSL certificates will be under /etc/puppetlabs/ssl/ when using Puppet 4 with AIO. More information on SSL certificates is at [Securing communications with SSL](/manuals/{{page.version}}/index.html#5.4SecuringCommunicationswithSSL).
 
 Add the following lines to the [master] section of puppet.conf:
 
@@ -146,4 +146,4 @@ supplied. The 'facts' hash must be a flat hash, not nested with other arrays or 
 See _link-to-API-when-its-updated-here_ for more details.
 
 This body can be POSTed to '/api/hosts/facts' using Foreman API v2. See the
-[node.rb template](https://raw.github.com/theforeman/puppet-foreman/2.1-stable/templates/external_node_v2.rb.erb) for an example of constructing and sending data in Ruby.
+[node.rb template](https://github.com/theforeman/puppet-foreman/blob/master/files/external_node_v2.rb) for an example of constructing and sending data in Ruby.

--- a/_includes/manuals/1.12/4.3.10_smartproxy_ssl.md
+++ b/_includes/manuals/1.12/4.3.10_smartproxy_ssl.md
@@ -29,6 +29,8 @@ Configure the locations to the SSL files in `/etc/foreman-proxy/settings.yml`, p
 #- foreman.dev.domain
 </pre>
 
+Under a Puppet 4 AIO installation, substitute above paths with `/etc/puppetlabs/puppet/ssl/`.
+
 ##### SSL cipher suites
 
 By default, the smart proxy permits the following SSL cipher suites:
@@ -61,6 +63,8 @@ To generate a certificate for a proxy host that isn't managed by Puppet, do the 
   <li>/var/lib/puppet/ssl/certs/ca.pem</li>
   <li>/var/lib/puppet/ssl/certs/proxy-FQDN.pem</li>
   <li>/var/lib/puppet/ssl/private_keys/proxy-FQDN.pem</li></ol>
+
+Under a Puppet 4 AIO installation, substitute above paths with `/etc/puppetlabs/puppet/ssl/`.
 
 Follow the configuration section above, however use the `/etc/foreman-proxy` paths instead of the Puppet defaults.
 

--- a/_includes/manuals/1.12/4.3.6_smartproxy_puppet.md
+++ b/_includes/manuals/1.12/4.3.6_smartproxy_puppet.md
@@ -60,7 +60,7 @@ For the optional Puppet run functionality, one of a number of implementations ca
 
 Available providers are:
 
-* `puppetrun` - for puppetrun/kick, deprecated in Puppet 3, see section below
+* `puppetrun` - for puppetrun/kick, deprecated in Puppet 3, not available in Puppet 4, see section below
 * `mcollective` - uses mco puppet, see section below
 * `puppetssh` - run puppet over ssh
 * `salt` - uses salt puppet.run
@@ -70,9 +70,9 @@ Once a provider is configured, in Foreman itself, enable "puppetrun" under *Admi
 
 The `puppetrun_wait` setting controls whether to block on completion of the Puppet command, so the result of the Puppet run can be returned to Foreman, else it's usually asynchronous.  When true, increase `proxy_request_timeout` under *Administer > Settings* in Foreman itself to ensure it waits longer for a response, as the Puppet run may take some time to complete.
 
-##### puppetrun
+##### puppetrun (deprecated)
 
-`puppet kick` (or puppetrun in 2.x) can be used to trigger an immediate Puppet run on a client by connecting to the agent daemon on the client over HTTPS.  This method however is deprecated in Puppet 3 and isn't recommended for new deployments.
+`puppet kick` (or puppetrun in 2.x) can be used to trigger an immediate Puppet run on a client by connecting to the agent daemon on the client over HTTPS.  This functionality is not available in Puppet 4 and was deprecated in Puppet 3, therefore isn't recommended for new deployments - consider alternatives, e.g. puppetssh or mcollective.
 
 More information can be found in the [puppet kick](https://docs.puppetlabs.com/references/stable/man/kick.html) documentation, specifically the [Usage Notes](https://docs.puppetlabs.com/references/stable/man/kick.html#USAGE-NOTES) which describe the configuration of the agents to listen and authorize connections.
 

--- a/_includes/manuals/1.12/4.3.7_smartproxy_puppetca.md
+++ b/_includes/manuals/1.12/4.3.7_smartproxy_puppetca.md
@@ -20,6 +20,13 @@ The 'puppetdir' setting is used to find autosign.conf:
 
 The proxy requires write access to the puppet autosign.conf file, which is usually owner and group puppet, and has mode 0644 according to the puppet defaults.
 
+Under a Puppet 4 AIO installation, paths should be set to:
+
+<pre>
+:ssldir: /etc/puppetlabs/puppet/ssl
+:puppetdir: /etc/puppetlabs/puppet
+</pre>
+
 Ensure the foreman-proxy user is added to the puppet group ( e.g. `gpasswd -a foreman-proxy puppet` or `usermod -aG puppet foreman-proxy`)
 
 puppet.conf:
@@ -28,14 +35,23 @@ puppet.conf:
 autosign = $confdir/autosign.conf {owner = service, group = service, mode = 664 }
 </pre>
 
-sudo access for the proxy is required - in your sudoers file ensure you have the following lines:
+sudo access for the proxy is required - in your sudoers file ensure you allow the "puppet cert" command with NOPASSWD and without requiretty.
+
+Under a Puppet 4 AIO installation, configuration should be:
+
+<pre>
+foreman-proxy ALL = NOPASSWD: /opt/puppetlabs/bin/puppet cert *
+Defaults:foreman-proxy !requiretty
+</pre>
+
+Under a non-AIO Puppet installation:
 
 <pre>
 foreman-proxy ALL = NOPASSWD: /usr/bin/puppet cert *
 Defaults:foreman-proxy !requiretty
 </pre>
 
-For older versions of Puppet (2.x) without separate commands:
+For older versions of Puppet (2.x) with separate commands:
 
 <pre>
 foreman-proxy ALL = NOPASSWD: /usr/sbin/puppetca *

--- a/_includes/manuals/1.12/5.4.1_comms_puppetmaster.md
+++ b/_includes/manuals/1.12/5.4.1_comms_puppetmaster.md
@@ -31,14 +31,10 @@ Using Apache HTTP with mod_ssl and mod_passenger is recommended.  For simple set
   <ol><li>*SSLCACertificateFile* set to the Puppet CA</li>
   <li>*SSLVerifyClient optional*</li>
   <li>*SSLOptions +StdEnvVars +ExportCertData*</li></ol>
-3. ENC script (e.g. `/etc/puppet/node.rb`) should have these settings:
+3. Puppet ENC/report processor configuration (e.g. `/etc/puppetlabs/puppet/foreman.yaml` or `/etc/puppet/foreman.yaml`) should have these settings:
   <ol><li>*:ssl_ca* set to the Puppet CA</li>
   <li>*:ssl_cert* set to the puppet master's certificate</li>
   <li>*:ssl_key* set to the puppet master's private key</li></ol>
-4. Report processor (e.g. `/usr/lib/ruby/site_ruby/1.8/puppet/reports/foreman.rb`) should have these settings:
-  <ol><li>*$foreman_ssl_ca* set to the Puppet CA</li>
-  <li>*$foreman_ssl_cert* set to the puppet master's certificate</li>
-  <li>*$foreman_ssl_key* set to the puppet master's private key</li></ol>
 
 ##### Troubleshooting
 

--- a/_includes/manuals/1.12/5.4.2_comms_proxy.md
+++ b/_includes/manuals/1.12/5.4.2_comms_proxy.md
@@ -19,7 +19,7 @@ In a simple setup, a single Puppet Certificate Authority (CA) can be used for au
 :ssl_private_key: /var/lib/puppet/ssl/private_keys/FQDN.pem
 </pre>
 
-In this example, the proxy is sharing Puppet's certificates, but it could equally use its own.
+In this example, the proxy is sharing Puppet's certificates, but it could equally use its own. Under a Puppet 4 AIO installation, substitute above paths with `/etc/puppetlabs/puppet/ssl/`.
 
 In addition it contains a list of hosts that connections will be accepted from, which should be the host(s) running Foreman:
 

--- a/_includes/manuals/1.12/5.5.1_backup.md
+++ b/_includes/manuals/1.12/5.5.1_backup.md
@@ -38,6 +38,8 @@ For all other distribution do similar command:
 
     tar -czvf var_lib_puppet_dir.tar.gz /var/lib/puppet/ssl
 
+Under a Puppet 4 AIO installation, back up `/etc/puppetlabs/puppet/ssl` instead.
+
 ### DHCP, DNS and TFTP services
 
 Depending on used software packages, perform backup of important data and


### PR DESCRIPTION
Recommends the use of either PC1 or 3.x repos depending on the OS
availability, documents compatibility with Puppet 4 and Puppet Server
versions, and adds notes about differing SSL certificate paths
throughout the manual.
