### PR TITLE
Remove broken link to Apache foreman.conf config

### DIFF
--- a/_includes/manuals/1.11/3.3.2_software_collections.md
+++ b/_includes/manuals/1.11/3.3.2_software_collections.md
@@ -43,8 +43,6 @@ Next, the Foreman config file at `/etc/httpd/conf.d/foreman.conf` must contain t
 
     PassengerRuby /usr/bin/tfm-ruby
 
-The full foreman.conf template from the installer is [available here](https://github.com/theforeman/puppet-foreman/blob/master/templates/foreman-vhost.conf.erb) for comparison.
-
 Ensure both `RailsAutoDetect` and `RakeAutoDetect` config entries are removed from foreman.conf and puppet.conf when using Passenger 4, since they have been deprecated.
 
 When successfully configured, two Passenger RackApp processes will be visible and by inspecting the open files, the Ruby version being loaded can be confirmed:

--- a/_includes/manuals/1.12/3.3.2_software_collections.md
+++ b/_includes/manuals/1.12/3.3.2_software_collections.md
@@ -43,8 +43,6 @@ Next, the Foreman config file at `/etc/httpd/conf.d/foreman.conf` must contain t
 
     PassengerRuby /usr/bin/tfm-ruby
 
-The full foreman.conf template from the installer is [available here](https://github.com/theforeman/puppet-foreman/blob/master/templates/foreman-vhost.conf.erb) for comparison.
-
 Ensure both `RailsAutoDetect` and `RakeAutoDetect` config entries are removed from foreman.conf and puppet.conf when using Passenger 4, since they have been deprecated.
 
 When successfully configured, two Passenger RackApp processes will be visible and by inspecting the open files, the Ruby version being loaded can be confirmed:


### PR DESCRIPTION
No real equivalent at the moment to change the link to, better to remove it.
