### PR TITLE
Fixes #14999 - correct link to hammer plugin in salt docs

### DIFF
--- a/plugins/foreman_salt/2.0/index.md
+++ b/plugins/foreman_salt/2.0/index.md
@@ -260,7 +260,7 @@ Using Curl to get a list of keys from "smartproxy.example.com":
 
 ## 3.9 CLI
 
-A [hammer](www.theforeman.org/manuals/latest/index.html#4.5CommandLineInterface) plugin for Salt is available, [follow the instructions for installing a plugin](http://www.theforeman.org/manuals/latest/index.html#6.1InstallaPlugin) to install hammer_cli_foreman_salt, and then see `hammer --help` for more information.
+A [hammer](http://www.theforeman.org/manuals/latest/index.html#4.5CommandLineInterface) plugin for Salt is available, [follow the instructions for installing a plugin](http://www.theforeman.org/manuals/latest/index.html#6.1InstallaPlugin) to install hammer_cli_foreman_salt, and then see `hammer --help` for more information.
 
 Examples:
 

--- a/plugins/foreman_salt/2.1/index.md
+++ b/plugins/foreman_salt/2.1/index.md
@@ -312,7 +312,7 @@ Using Curl to get a list of keys from "smartproxy.example.com":
 
 ## 4.9 CLI
 
-A [hammer](www.theforeman.org/manuals/latest/index.html#4.5CommandLineInterface) plugin for Salt is available, [follow the instructions for installing a plugin](http://www.theforeman.org/manuals/latest/index.html#6.1InstallaPlugin) to install hammer_cli_foreman_salt, and then see `hammer --help` for more information.
+A [hammer](http://www.theforeman.org/manuals/latest/index.html#4.5CommandLineInterface) plugin for Salt is available, [follow the instructions for installing a plugin](http://www.theforeman.org/manuals/latest/index.html#6.1InstallaPlugin) to install hammer_cli_foreman_salt, and then see `hammer --help` for more information.
 
 Examples:
 


### PR DESCRIPTION
The docs for later versions of the plugin moved to relative urls.
