### PR TITLE
Fix windows `bundle install` command

### DIFF
--- a/_includes/manuals/1.12/4.3.1_smartproxy_installation.md
+++ b/_includes/manuals/1.12/4.3.1_smartproxy_installation.md
@@ -29,7 +29,7 @@ The Microsoft smart-proxy installation procedure is very basic compared to the R
     1. `ruby <devKitRoot>\dk.rb install`
     1. `gem install --no-ri --no-rdoc bundler`
     1. `cd <smart-proxy location>`
-    1. `bundle install --without development test krb5 puppet puppetca bmc`
+    1. `bundle install --without development test krb5 puppet_proxy_legacy bmc libvirt`
 
 ##### General configuration
 1. Create the SSL certificate and key


### PR DESCRIPTION
In foreman 1.12 smart proxy, the bundler groups have changed.
https://github.com/theforeman/smart-proxy/commit/df0fc729bb8f3275c55f8673c669085755eee347
https://github.com/theforeman/smart-proxy/commit/6798dc589b83eb601a135f914db5ec2308c492e1
