### PR TITLE
events: separate dates from external URLs

### DIFF
--- a/_layouts/event_index.html
+++ b/_layouts/event_index.html
@@ -15,32 +15,32 @@
 
       {% assign events = site.data.events | filter_old_events %}
       {% for event in events %}
+      {% assign date = event.start | format_event_date: event.end %}
       <div class="blog-item post-content" id="{{ event.title | slugify }}">
         <a href="/events/#{{ event.title | slugify }}">
           <h3>{{ event.title }}
+            <span class="foreman-grey-infobox pull-right">{{ date }}</span>
             <span class="foreman-blue-infobox pull-right">{{ event.type | captitalize }}</span>
           </h3>
         </a>
         <p class="metadata">
-        <span class='location'>
-          {% if event.location == 'virtual' %}
-          Virtual Event
-          {% else %}
-          <a href="https://maps.google.com/maps?q={{event.location}}">{{event.location}}</a>
-          {% endif %}
-          {% if event.speaker %}
-          - {{ event.speaker }}
-          {% endif %}
-        </span>
+          <span class='location'>
+            {% if event.location == 'virtual' %}
+              Virtual Event
+            {% else %}
+              <a href="https://maps.google.com/maps?q={{event.location}}">{{event.location}}</a>
+            {% endif %}
+            {% if event.speaker %}
+              - {{ event.speaker }}
+            {% endif %}
+          </span>
 
-        <span class="date pull-right">
-          {% assign date = event.start | format_event_date: event.end %}
+
           {% if event.url %}
-          <a href='{{ event.url }}'>{{ date }}</a>
-          {% else %}
-          {{ date }}
+            <span class="date pull-right">
+              <a href='{{ event.url }}'>{{ event.url | truncate: 40 }}</a></span>
+            </span>
           {% endif %}
-        </span>
         </p>
 
         <div class="post-content">

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1129,6 +1129,18 @@ code {
   border-width: 0.833333px;
 }
 
+.foreman-grey-infobox {
+  background-color: grey;
+  border-style: solid;
+  border-radius: 4px;
+  padding: 2px 6px 2px;
+  color: #fff;
+  font-size: 14px;
+  font-weight: 700;
+  letter-spacing: .05em;
+  border-width: 0.833333px;
+}
+
 /* Our changes to FullCalendar */
 #calendar {
   padding-top: 20px;


### PR DESCRIPTION
It's easy to miss the fact that there's a URL link in the date section of an event entry - this moves the date to be more visible and puts the URL below.

@mmoll @dLobatog thoughts?
