### PR TITLE
Add a News Teaser banner to the top of the site

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -14,6 +14,8 @@ excerpt_separator: <!--more-->
 permalink: /:year/:month/:title.html
 blogname: Foreman Blog
 blogdesc: News, notes and noise from around the Foreman community
+teaseurl: /2016/06/foremans-7th-birthday-events.html
+teasetext: Foreman's 7th Birthday is coming! See if there's a party near you!
 
 safe:        false
 

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -44,7 +44,10 @@
 </head>
 
 <body>
- {% if page.url != "/" %}
+  {% if site.teaseurl != nil %}
+    <a href='{{ site.teaseurl }}' class="news-tease">{{ site.teasetext }}</a>
+  {% endif %}
+  {% if page.url != "/" %}
     <header id="page-header" style='padding: 0'>
 	{% else %}
     <header id="page-header">

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1186,3 +1186,21 @@ a.fc-event.old {
   border-color: #9d8d9e;
 	background-color: rgba(2, 93, 140, 0.2);
 }
+
+/* Banner alert */
+
+a.news-tease {
+  background-color: rgb(0, 62, 95);
+  box-sizing: border-box;
+  color: rgb(255, 255, 255);
+  display: block;
+  line-height: 20px;
+  padding-bottom: 5px;
+  padding-left: 20px;
+  padding-right: 20px;
+  padding-top: 5px;
+  text-align: center;
+  text-decoration-line: none;
+  text-decoration-style: solid;
+  text-decoration-color: rgb(255, 255, 255);
+}


### PR DESCRIPTION
This is to (on occasion) draw attention to something important happening (events, new releases, etc). It adds a hopefully-not-too-obnoxious banner to the top of the site, if `_config.yml` is configured to do so.

As a starter, I've pointed it to the birthday page, since I want to promote that pretty heavily.
