### PR TITLE
Fix broken get started link

### DIFF
--- a/_layouts/homepage.html
+++ b/_layouts/homepage.html
@@ -20,7 +20,7 @@ version: '1.11'
 		<hr />
 		<div class='row center'>
 			<div class="source-buttons">
- 				<a href="/manuals/{{page.version}}/quickstart_guide.html" class="btn btn-primary">Get started</a>
+ 				<a href="/manuals/{{layout.version}}/quickstart_guide.html" class="btn btn-primary">Get started</a>
 		 		<a href="/introduction.html" class="btn btn-default">Learn more</a>
 		  </div>
 		</div>


### PR DESCRIPTION
The get started link on the **bottom** of the home page is broken
