### PR TITLE
Add birthday to frontpage and news footer

### DIFF
--- a/_includes/alerts.html
+++ b/_includes/alerts.html
@@ -1,0 +1,8 @@
+<div class='tease'>
+  <p>
+    Foreman's 7th birthday is coming! See if there's a
+    <a href='https://theforeman.org/2016/06/foremans-7th-birthday-events.html'>
+      party near you!
+    </a>
+  </p>
+</div>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,9 +1,16 @@
 <section id="latest-news" class="center">
-	<div class="container">
-		<div class="latest-news col-md-offset-3 col-md-6">
-			{% include latest_news.html %}
-		</div>
-	</div>
+  <div class="container">
+    <div class='row'>
+      <div class="latest-news col-md-offset-2 col-md-8">
+        {% include alerts.html %}
+      </div>
+    </div>
+    <div class='row'>
+      <div class="latest-news col-md-offset-3 col-md-6">
+        {% include latest_news.html %}
+      </div>
+    </div>
+  </div>
 </section>
 <div class="footer">
   <div class="container">

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -92,6 +92,9 @@
 			<div class='row'>
 				{% include version.html %}
 			</div>
+			<div class='row'>
+				{% include alerts.html %}
+			</div>
       {% endif %}
 		</div>
   </header>

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -670,6 +670,22 @@ border-radius: 4px;
   margin-bottom: 0;
 }
 
+.tease {
+  margin-top: 20px;
+  text-align: center;
+  font-weight: bold;
+  font-size: 20px;
+  color: #ffffff;
+}
+
+.tease p {
+  margin-bottom: 0;
+}
+
+.tease a {
+  text-decoration: underline;
+}
+
 #support h2 img{
 	max-width: 60px;
 	background-color: #f2f2f2;


### PR DESCRIPTION
This is a lower-impact version of #651 which adds a new include for the footer and top of the frontpage. It's structured as a separate include so we can blank it or change if there's other alerts we want to promote in the future.
