### PR TITLE
Update Salt plugin URL in section 4.7

### DIFF
--- a/_includes/manuals/1.12/4.7_managing_salt.md
+++ b/_includes/manuals/1.12/4.7_managing_salt.md
@@ -1,1 +1,1 @@
-Please refer to the [foreman_salt plugin documentation](/plugins/foreman_salt/2.0/).
+Please refer to the [foreman_salt plugin documentation](/plugins/foreman_salt/).


### PR DESCRIPTION
This commit changes the Salt plugin URL referenced in section 4.7 to be version independent and to be aligned with the Chef link in 4.8.
