### PR TITLE
Import changing FQDN instructions from wiki

### DIFF
--- a/_includes/manuals/1.12/5.5.1_backup.md
+++ b/_includes/manuals/1.12/5.5.1_backup.md
@@ -2,9 +2,9 @@
 This chapter will provide you with information how to backup a Foreman
 instance.
 
-### Database
+#### Database
 
-#### PostgreSQL, MySQL, SQLite
+##### PostgreSQL, MySQL, SQLite
 
 Run ```foreman-rake db:dump```. It will print a message when it finishes with the dump
 file location relative to the Foreman root.
@@ -16,7 +16,7 @@ by copying the file to another location, but it is recommended to shut down
 the instance first, or at least verify the integrity of the created archive
 using sqlite3 command. The dump command above is preferred.
 
-### Configuration
+#### Configuration
 
 On Red Hat compatible systems issue the following command to backup whole /etc
 directory structure:
@@ -27,7 +27,7 @@ For all other distribution do similar command:
 
     tar -czvf etc_foreman_dir.tar.gz /etc/foreman
 
-### Puppet master
+#### Puppet master
 
 On the puppet master node, issue the following command to backup Puppet
 certificates on Red Hat compatible systems
@@ -40,7 +40,7 @@ For all other distribution do similar command:
 
 Under a Puppet 4 AIO installation, back up `/etc/puppetlabs/puppet/ssl` instead.
 
-### DHCP, DNS and TFTP services
+#### DHCP, DNS and TFTP services
 
 Depending on used software packages, perform backup of important data and
 configuration files according to the documentation. For ISC DHCP and DNS

--- a/_includes/manuals/1.12/5.5.2_recovery.md
+++ b/_includes/manuals/1.12/5.5.2_recovery.md
@@ -16,7 +16,7 @@ to notify you when it has finished importing the dump.
 Remember to stop the Foreman instance and any other process consuming data from the
 database temporarily during the import and turn it back on after it ends.
 
-### Configuration
+#### Configuration
 
 On Red Hat compatible systems issue the following command to restore whole /etc
 directory structure:
@@ -31,7 +31,7 @@ It is recommended to extract files to an empty directory first and inspect the
 content before overwriting current files (change -C option to an empty
 directory).
 
-### Puppet master
+#### Puppet master
 
 On the puppet master node, issue the following command to restore Puppet
 certificates on Red Hat compatible systems
@@ -44,8 +44,32 @@ For all other distribution do similar command:
 
 It is recommended to inspect the content of the restore first (see above).
 
-### DHCP, DNS and TFTP services
+#### DHCP, DNS and TFTP services
 
 Depending on used software packages, perform recovery of important data and
 configuration files according to the documentation. This depends on the
 software and distribution that is in use.
+
+#### Changing the FQDN
+
+It's preferable when migrating to keep the FQDN unchanged to reduce the risk
+of configuration errors from references to the old hostname.
+
+However if the FQDN does change, check and update the following items:
+
+* [Foreman settings](manuals/{{page.version}}/index.html#3.5.2ConfigurationOptions) under *Administer > Settings*:
+    * *General > foreman_url* - URL of the Foreman web UI
+    * *Provisioning > unattended_url* - URL of the Foreman web API for unattended provisioning
+    * *Provisioning > ssl_certificate*, *ssl_priv_key* - paths to SSL certificate and key used for smart proxy communications
+* The registered smart proxy URL if installed, edit via *Infrastructure > Smart Proxies*
+* Puppet SSL certs: generate new ones with `puppet cert generate NEW_FQDN`
+* Apache configs: update `conf.d/*-{foreman,puppet}.conf` with new SSL cert/key filenames, ServerName and VirtualHost IP addresses if applicable
+* Smart proxy configuration files in `/etc/foreman-proxy`:
+    * `settings.yml` - update SSL cert/key filenames
+    * `settings.d/dns_nsupdate_gss.yml` - update `dns_tsig_principal` if the principal name has changed
+    * `settings.d/puppet_proxy_legacy.yml` - update SSL cert/key filenames
+    * `settings.d/puppet_proxy_puppet_api.yml` - update SSL cert/key filenames
+    * `settings.d/realm.yml` - update `realm_principal` if the principal name has changed
+    * `settings.d/templates.yml` - update `template_url` for URL of the Foreman web API
+* Puppet masters: URLs and cert/key filenames in `/etc/puppetlabs/puppet/foreman.yaml` or `/etc/puppet/foreman.yaml`
+


### PR DESCRIPTION
Replaces http://projects.theforeman.org/projects/foreman/wiki/Troubleshooting#How-do-I-change-the-FQDN-of-the-Foreman-host
and fixes heading levels for a correct contents list.
