### PR TITLE
Remove birthday frontpage banner

### DIFF
--- a/_includes/alerts.html
+++ b/_includes/alerts.html
@@ -1,8 +1,5 @@
-<div class='tease'>
-  <p>
-    Foreman's 7th birthday is coming! See if there's a
-    <a href='https://theforeman.org/2016/06/foremans-7th-birthday-events.html'>
-      party near you!
-    </a>
-  </p>
-</div>
+<!-- <div class='tease'>      -->
+<!--   <p>                    -->
+<!--     something important! -->
+<!--   </p>                   -->
+<!-- </div>                   -->


### PR DESCRIPTION
Sad though I am to see the end of it, it's not our birthday now. I've left the include in place and commented it out so people don't need to go look up the CSS class next time we want to use it.
