### PR TITLE
Remove references to v8314 for 1.13

### DIFF
--- a/_includes/manuals/1.13/3.3.2_software_collections.md
+++ b/_includes/manuals/1.13/3.3.2_software_collections.md
@@ -1,6 +1,6 @@
 The RPMs use a packaging technique called Software Collections, or SCL.  This provides Ruby and all dependencies required to run Foreman separately from the version of Ruby provided by the distribution.
 
-A "tfm" (The Foreman) collection is provided by the Foreman project which ships all dependencies for the main Foreman application, and depends on the "sclo-ror42", "rh-ruby22" and "v8314" (build only) collections which provide newer versions of Ruby and Ruby on Rails.  Packages that are part of these collections will have "tfm-", "sclo-ror42-", "rh-ruby22-" and "v8314-" prefixes, allowing them to be easily identified, and will install entirely underneath `/opt/theforeman` and `/opt/rh`.
+A "tfm" (The Foreman) collection is provided by the Foreman project which ships all dependencies for the main Foreman application, and depends on the "sclo-ror42" and "rh-ruby22" collections which provide newer versions of Ruby and Ruby on Rails.  Packages that are part of these collections will have "tfm-", "sclo-ror42-" and "rh-ruby22-" prefixes, allowing them to be easily identified, and will install entirely underneath `/opt/theforeman` and `/opt/rh`.
 
 The system Ruby version is left alone and will still be used for packages provided both by the distribution, and other third parties who target the system Ruby (e.g. Puppet packages).
 


### PR DESCRIPTION
No longer a dependency of SCL packages.
