### PR TITLE
Document 1.13 Foreman/smart proxy settings

### DIFF
--- a/_includes/manuals/1.11/4.3.4_smartproxy_dhcp.md
+++ b/_includes/manuals/1.11/4.3.4_smartproxy_dhcp.md
@@ -6,7 +6,7 @@ The DHCP module is capable of managing the ISC DHCP server, Microsoft Active Dir
 Builtin providers are:
 
 * `dhcp_isc` - ISC DHCP server over OMAPI
-* `dhcp_ms_native` - Microsoft Active Directory using netsh
+* `dhcp_native_ms` - Microsoft Active Directory using netsh
 * `dhcp_virsh` - libvirt embedded DHCP (dnsmasq)
 
 Extra providers are available as plugins and can be installed through packages. See the following pages for more information:

--- a/_includes/manuals/1.12/4.3.4_smartproxy_dhcp.md
+++ b/_includes/manuals/1.12/4.3.4_smartproxy_dhcp.md
@@ -7,7 +7,7 @@ Builtin providers are:
 
 * `dhcp_isc` - ISC DHCP server over OMAPI
 * `dhcp_libvirt` - dnsmasq DHCP via libvirt API
-* `dhcp_ms_native` - Microsoft Active Directory using netsh
+* `dhcp_native_ms` - Microsoft Active Directory using netsh
 
 Extra providers are available as plugins and can be installed through packages. See the following pages for more information:
 

--- a/_includes/manuals/1.13/3.5.2_configuration_options.md
+++ b/_includes/manuals/1.13/3.5.2_configuration_options.md
@@ -302,6 +302,11 @@ Default: foreman_location
 If your external authentication system has a logout URL, redirect your users to it here. This setting can be useful if your users sign in Foreman through SSO, and you want them to sign out from all services when they log out Foreman.
 Default: ''
 
+##### login_text
+
+Specifies text to be displayed on the Foreman login page underneath the version number.
+Default: ''
+
 ##### manage_puppetca
 
 If this option is set to _true_ then Foreman will manage a host's Puppet certificate signing. If it is set to _false_ then some external mechanism is required to ensure that the host's certificate request is signed.
@@ -316,6 +321,11 @@ Default: 30
 
 This it the modulepath that foreman uses when processing puppet modules. It is usually able to determine this itself at runtime but if it is not able to find a value then _modulepath_ is used.
 Default: /etc/puppet/modules
+
+##### name_generator_type
+
+Specifies the method used to generate random hostnames when creating a new host, either _Random-based_, _MAC-based_ for bare metal hosts only, or _Off_ to disable the function and leave the field blank.
+Default: _Random-based_
 
 ##### oauth_active
 

--- a/_includes/manuals/1.13/4.3.4_smartproxy_dhcp.md
+++ b/_includes/manuals/1.13/4.3.4_smartproxy_dhcp.md
@@ -7,7 +7,7 @@ Builtin providers are:
 
 * `dhcp_isc` - ISC DHCP server over OMAPI
 * `dhcp_libvirt` - dnsmasq DHCP via libvirt API
-* `dhcp_ms_native` - Microsoft Active Directory using netsh
+* `dhcp_native_ms` - Microsoft Active Directory using netsh
 
 Extra providers are available as plugins and can be installed through packages. See the following pages for more information:
 
@@ -60,11 +60,15 @@ If the DHCP server is listening on a non-standard OMAPI port (i.e. not 7911), th
 
 For DHCP servers running on a different host, change `:server` in the main `dhcp.yml` configuration file.
 
-#### dhcp_ms_native
+#### dhcp_native_ms
 
-The ms_native provider manages reservations in Microsoft Active Directory by running the "netsh" command.
+The native_ms provider manages reservations in Microsoft Active Directory by running the "netsh" command.
 
-It has no configuration options in `dhcp_ms_native.yml`.
+Possible configuration options in `dhcp_native_ms.yml` are:
+
+	:disable_ddns: true
+
+When `disable_ddns` is true (default), dynamic DNS updates will be disabled for all hosts that the smart proxy creates. This will slightly slow the host creation process but will ensure that the DHCP server will not create or delete DNS entries on behalf of these clients. It's preferable to disable this feature at the scope level.
 
 #### dhcp_libvirt
 


### PR DESCRIPTION
Also corrects name of the native MS DHCP provider, per
https://github.com/theforeman/smart-proxy/commit/36956f8.
