### PR TITLE
Fixes #699 - Added npm install steps missing from the manual

### DIFF
--- a/_includes/manuals/1.13/3.4_install_from_source.md
+++ b/_includes/manuals/1.13/3.4_install_from_source.md
@@ -13,7 +13,7 @@ to get latest "development" version do:
 You will want to make sure that you have one of the *mysql-devel*,
 *postgresql-devel*, and *sqlite-devel* libraries installed so the database
 gems can install properly. Also, you would also need *gcc*, *ruby-devel*,
-*libxml-devel*, *libxslt-devel*, and *libvirt-devel* packages.
+*libxml-devel*, *libxslt-devel*, *libvirt-devel*, *nodejs*, and *npm* packages.
 
 For RHEL6 or clones, you can issue the following commands to install *all*
 required packages:
@@ -22,7 +22,7 @@ required packages:
     yum -y install gcc-c++ git ruby ruby-devel rubygems \
         libvirt-devel mysql-devel postgresql-devel openssl-devel \
         libxml2-devel sqlite-devel libxslt-devel zlib-devel \
-        readline-devel tar
+        readline-devel tar nodejs npm
 
 Additionally, it is important that `config/database.yml` is set to use
 the correct database in the "production" block. Rails (and subsequently
@@ -43,7 +43,7 @@ gem install bundler
 bundle install --without mysql2 pg test --path vendor # or postgresql
 # set up database schema, precompile assets and locales
 RAILS_ENV=production bundle exec rake db:migrate
-RAILS_ENV=production bundle exec rake db:seed assets:precompile locale:pack
+RAILS_ENV=production bundle exec rake db:seed assets:precompile locale:pack webpack:compile
 {% endhighlight %}
 
 The db:seed step will print out the default admin password, record this in order to log in later.

--- a/_includes/manuals/1.13/3.6_upgrade.md
+++ b/_includes/manuals/1.13/3.6_upgrade.md
@@ -116,6 +116,7 @@ You should compile i18n strings and precompile assets now:
 
     foreman-rake locale:pack
     foreman-rake assets:precompile RAILS_ENV=production
+    foreman-rake webpack:compile RAILS_ENV=production
 
 #### Step 3 - Post-upgrade steps
 

--- a/contribute.md
+++ b/contribute.md
@@ -7,7 +7,7 @@ title: Contributing to Foreman
 
 ## Read the Foreman [handbook](/handbook.html)
 
-The Foreman is an open-source project that's licensed under the GNU Public License version 3.<br>
+The Foreman is an open-source project that's licensed under the GNU General Public License version 3.<br>
 Contributions of all types are gladly accepted!
 
 ## Attend some [Events](/events)


### PR DESCRIPTION
- Added npm install steps missing from source installation section of the manual.
- Added correct form of GNU GPL to contributing guide.
- Added nodejs and npm to list of packages to be installed.
