### PR TITLE
Update foreman-remote-execution/nightly/index.md

### DIFF
--- a/plugins/foreman_remote_execution/nightly/index.md
+++ b/plugins/foreman_remote_execution/nightly/index.md
@@ -114,7 +114,7 @@ This chapter covers a clean Foreman and plugin installation. We assume the
 smart proxy will be installed on the same host, however it's not a requirement.
 Please adapt according to your needs.
 
-Start by installing the Foreman nightly or 1.10 repository and EPEL7, see
+Start by installing the latest Foreman or nightly, see
 [Quickstart instructions](/manuals/latest/index.html#2.Quickstart) and [Foreman
 manual](/manuals/latest/index.html#3.InstallingForeman) for more information.
 


### PR DESCRIPTION
Removed reference specifying Foreman 1.10 repository to install from.  Also removed reference to EPEL as this is configured with a successful Foreman install.
