### PR TITLE
refs #15827 - drop armhf packages for trusty

### DIFF
--- a/_includes/manuals/1.13/2_quickstart_guide.md
+++ b/_includes/manuals/1.13/2_quickstart_guide.md
@@ -8,8 +8,8 @@ Components include the Foreman web UI, Smart Proxy, Passenger, a Puppet master (
 * Debian 8 (Jessie), i386/amd64/armhf
 * Fedora 24, x86_64
 * Red Hat Enterprise Linux 7, x86_64
-* Ubuntu 16.04 (Xenial), i386/amd64/armhf
-* Ubuntu 14.04 (Trusty), i386/amd64/armhf
+* Ubuntu 16.04 (Xenial), i386/amd64/armhf/aarch64
+* Ubuntu 14.04 (Trusty), i386/amd64
 * _Supported, but deprecated: RHEL, CentOS, Scientific Linux or Oracle Linux 6_
 
 Other operating systems will need to use alternative installation methods (see the manual).

--- a/_includes/manuals/1.13/3.1.1_supported_platforms.md
+++ b/_includes/manuals/1.13/3.1.1_supported_platforms.md
@@ -15,9 +15,9 @@ The following operating systems are supported by the installer, have packages an
 * Debian 8 (Jessie)
   * Architectures: i386, amd64, armhf
 * Ubuntu 16.04 (Xenial)
-  * Architectures: i386, amd64, armhf
+  * Architectures: i386, amd64, armhf, aarch64
 * Ubuntu 14.04 (Trusty)
-  * Architectures: i386, amd64, armhf
+  * Architectures: i386, amd64
 
 It is recommended to apply all OS updates if possible.
 

--- a/_includes/manuals/1.13/3.3.3_debian_packages.md
+++ b/_includes/manuals/1.13/3.3.3_debian_packages.md
@@ -4,8 +4,8 @@ The Foreman packages should work on the following Debian-based Linux distributio
 #### Distributions
 
 * Debian Linux 8.0 (Jessie), i386, amd64, armhf
-* Ubuntu Linux 16.04 LTS (Xenial Xerus), i386, amd64, armhf
-* Ubuntu Linux 14.04 LTS (Trusty Tahr), i386, amd64, armhf
+* Ubuntu Linux 16.04 LTS (Xenial Xerus), i386, amd64, armhf, aarch64
+* Ubuntu Linux 14.04 LTS (Trusty Tahr), i386, amd64
 
 If you encounter any errors during the installation, [please file a bug report!](/contribute.html#Bugreporting)
 


### PR DESCRIPTION
- add aarch64 for xenial
