### PR TITLE
Fix issue with 'Get Started' links on Foreman home page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -7,6 +7,7 @@ description: Foreman is an open source project that gives system administrators 
 production_url : http://theforeman.org
 url: http://theforeman.org
 baseurl: "" #keep at "" for the Atom feed
+foreman_version: '1.13'
 
 paginate: 5
 paginate_path: "blog/page:num"

--- a/_includes/features.html
+++ b/_includes/features.html
@@ -7,7 +7,7 @@
 			  </div>
 			  <div class='col-md-10'>
 					<h2>CLI</h2>
-					<p>UIs slow you down? <a href="manuals/{{layout.version}}/index.html#3.5.6CLI">Hammer CLI</a> gives you easy access to all the API calls you need to stay on top of your data center.</p>
+					<p>UIs slow you down? <a href="manuals/{{site.foreman_version}}/index.html#3.5.6CLI">Hammer CLI</a> gives you easy access to all the API calls you need to stay on top of your data center.</p>
 			  </div>
 			</div>
 			<div class='col-md-6'>
@@ -16,7 +16,7 @@
 				</div>
 				<div class='col-md-10'>
 					<h2>API</h2>
-					<p>We provide a RESTful API to give you the power to automate most tasks, such as registering hosts, assigning roles to users, and <a href="api/{{layout.version}}/index.html">more.</a></p>
+					<p>We provide a RESTful API to give you the power to automate most tasks, such as registering hosts, assigning roles to users, and <a href="api/{{site.foreman_version}}/index.html">more.</a></p>
 				</div>
 			</div>
 		</div>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -89,7 +89,7 @@
       </div>
 			<div class='row'>
 				<div class="source-buttons">
-					<a href="/manuals/{{layout.version}}/quickstart_guide.html" class="btn btn-primary">Get started</a>
+					<a href="/manuals/{{site.foreman_version}}/quickstart_guide.html" class="btn btn-primary">Get started</a>
 					<a href="/introduction.html" class="btn btn-default">Learn more</a>
 				</div>
 			</div>

--- a/_layouts/homepage.html
+++ b/_layouts/homepage.html
@@ -1,6 +1,3 @@
----
-version: '1.13'
----
 {% include header.html %}
 {% include screenshots.html %}
 {% include features.html %}
@@ -20,7 +17,7 @@ version: '1.13'
 		<hr />
 		<div class='row center'>
 			<div class="source-buttons">
- 				<a href="/manuals/{{layout.version}}/quickstart_guide.html" class="btn btn-primary">Get started</a>
+ 				<a href="/manuals/{{site.foreman_version}}/quickstart_guide.html" class="btn btn-primary">Get started</a>
 		 		<a href="/introduction.html" class="btn btn-default">Learn more</a>
 		  </div>
 		</div>


### PR DESCRIPTION
While browsing theforeman.org, I noticed that the 'Get Started' link at the top of the page isn't working properly - it's not referencing the major release of The Foreman.

This change moves that version into _config.yml and updates references to it to fix this issue.