### PR TITLE
Update version of github-pages gem to 104

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,6 @@ group :therubyracer do
     gem 'therubyracer', :require => 'v8'
 end
 
-gem 'github-pages', '>= 57'
+gem 'github-pages', '>= 104'
 gem 'rake'
 gem 'icalendar'


### PR DESCRIPTION
This is the version currently used by gh-pages (https://pages.github.com/versions/). Further, on Jenkins, the default Ruby is set to 2.3 which combined with the current version of bundler results in the '>=' not being respected as '57' was being installed everytime despite there being numerous newer versions of the github-pages gem. This can be seen by switching to use Ruby 2.2 locally and noticing that the most recent version of github-pages is pulled down on a `bundle install`.