### PR TITLE
Show more documentation and plugins on smaller resolutions at a time

### DIFF
--- a/documentation.md
+++ b/documentation.md
@@ -28,19 +28,19 @@ version: '1.13'
 ---------------------------
 
 <div class='row'>
-  <div class='col-md-4 center'>
+  <div class='col-xs-4 center'>
     <a id='manual-link' href="manuals/{{page.version}}/index.html" class="btn-doc btn">
       <h2 class='doc-icon'><i class="fa fa-newspaper-o"></i></h2>
       <p id='manual'>manual</p>
     </a>
   </div>
-  <div class='col-md-4 center'>
+  <div class='col-xs-4 center'>
 		<a id='release-notes-link' href="manuals/{{page.version}}/index.html#Releasenotesfor{{page.version}}" class="btn-doc btn">
       <h2 class='doc-icon'><i class="fa fa-pencil"></i></h2>
       <p id='release-notes'>release notes</p>
     </a>
   </div>
-  <div class='col-md-4 center'>
+  <div class='col-xs-4 center'>
     <a id="api-ref-link" href="api/{{page.version}}/index.html" class="btn-doc btn">
       <h2 class='doc-icon'><i class="fa fa-terminal"></i></h2>
       <p id='api-ref'>api</p>
@@ -48,19 +48,19 @@ version: '1.13'
   </div>
 </div>
 <div class='row'>
-  <div class='col-md-4 center'>
+  <div class='col-xs-4 center'>
 		<a href='/plugins' class="btn-doc btn">
       <h2 class='doc-icon'><i class="fa fa-cubes"></i></h2>
       <p id='plugins'>plugins</p>
     </a>
   </div>
-  <div class='col-md-4 center'>
+  <div class='col-xs-4 center'>
     <a href="/training.html" class="btn-doc btn">
       <h2 class='doc-icon'><i class="fa fa-wrench"></i></h2>
       Training
     </a>
   </div>
-  <div class='col-md-4 center'>
+  <div class='col-xs-4 center'>
     <a href="/security.html" class="btn-doc btn">
       <h2 class='doc-icon'><i class="fa fa-lock"></i></h2>
       Security
@@ -68,19 +68,19 @@ version: '1.13'
   </div>
 </div>
 <div class='row'>
-  <div class='col-md-4 center'>
+  <div class='col-xs-4 center'>
     <a href="/blog" class="btn-doc btn">
       <h2 class='doc-icon'><i class="fa fa-rss"></i></h2>
       Blog
     </a>
   </div>
-  <div class='col-md-4 center'>
+  <div class='col-xs-4 center'>
     <a href="/support.html" class="btn-doc btn">
       <h2 class='doc-icon'><i class="fa fa-support"></i></h2>
       Support
     </a>
   </div>
-  <div class='col-md-4 center'>
+  <div class='col-xs-4 center'>
     <a href="/events" class="btn-doc btn">
       <h2 class='doc-icon'><i class="fa fa-calendar"></i></h2>
       Events

--- a/plugins/index.md
+++ b/plugins/index.md
@@ -17,133 +17,133 @@ Foreman plugins are implemented as [Rails engines](http://guides.rubyonrails.org
 ------------------------
 
 <div class='row'>
-  <div class='col-md-3 center'>
+  <div class='col-xs-3 center'>
 		<a href="plugins/foreman_ansible" class="btn-doc btn">
 			<p class='h2 doc-icon'><i class="fa fa-play"></i></p>
 			Ansible
 		</a>
 	</div>
-  <div class='col-md-3 center'>
+  <div class='col-xs-3 center'>
 		<a href="https://github.com/theforeman/foreman_azure" class="btn-doc btn">
 			<p class='h2 doc-icon'><i class="fa fa-cloud"></i></p>
 			Azure
 		</a>
 	</div>
-	<div class='col-md-3 center'>
+	<div class='col-xs-3 center'>
 		<a href="https://github.com/theforeman/foreman_bootdisk" class="btn-doc btn">
 			<p class='h2 doc-icon'><i class="fa fa-floppy-o"></i></p>
 			Bootdisk
 		</a>
 	</div>
-	<div class='col-md-3 center'>
+	<div class='col-xs-3 center'>
 		<a href="plugins/foreman_chef" class="btn-doc btn">
 			<p class='h2 doc-icon'><i class="fa fa-cutlery"></i></p>
 			Chef
 		</a>
 	</div>
-	<div class='col-md-3 center'>
+	<div class='col-xs-3 center'>
 		<a href="https://github.com/GregSutcliffe/foreman_column_view" class="btn-doc btn">
 			<p class='h2 doc-icon'><i class="fa fa-bar-chart"></i></p>
 			Column view
 		</a>
 	</div>
- 	<div class='col-md-3 center'>
+ 	<div class='col-xs-3 center'>
 		<a href="plugins/foreman_cockpit/" class="btn-doc btn">
 			<p class='h2 doc-icon'><i class="fa fa-rocket"></i></p>
 			Cockpit
 		</a>
 	</div>
-	<div class='col-md-3 center'>
+	<div class='col-xs-3 center'>
 		<a href="https://github.com/theforeman/foreman_default_hostgroup/" class="btn-doc btn">
 			<p class='h2 doc-icon'><i class="fa fa-check-circle"></i></p>
 			Default host group
 		</a>
 	</div>
-	<div class='col-md-3 center'>
+	<div class='col-xs-3 center'>
 		<a href="https://github.com/theforeman/foreman-digitalocean/" class="btn-doc btn">
 			<p class='h2 doc-icon'><i class="fa fa-pencil"></i></p>
 			Digitalocean
 		</a>
 	</div>
-	<div class='col-md-3 center'>
+	<div class='col-xs-3 center'>
 		<a href="plugins/foreman_discovery" class="btn-doc btn">
 			<p class='h2 doc-icon'><i class="fa fa-wifi"></i></p>
 			Discovery
 		</a>
 	</div>
-	<div class='col-md-3 center'>
+	<div class='col-xs-3 center'>
 		<a href="plugins/foreman_docker" class="btn-doc btn">
 			<p class='h2 doc-icon'><i class="fa fa-ship"></i></p>
 			Docker
 		</a>
 	</div>
-	<div class='col-md-3 center'>
+	<div class='col-xs-3 center'>
 		<a href="https://github.com/theforeman/foreman_graphite" class="btn-doc btn">
 			<p class='h2 doc-icon'><i class="fa fa-bar-chart"></i></p>
 			Graphite
 		</a>
 	</div>
-	<div class='col-md-3 center'>
+	<div class='col-xs-3 center'>
 		<a href="https://github.com/theforeman/foreman_hooks" class="btn-doc btn">
 			<p class='h2 doc-icon'><i class="fa fa-anchor"></i></p>
 			Hooks
 		</a>
 	</div>
-	<div class='col-md-3 center'>
+	<div class='col-xs-3 center'>
 		<a href="plugins/katello" class="btn-doc btn">
 			<p class='h2 doc-icon'><i class="fa fa-cloud-upload"></i></p>
 			Katello
 		</a>
 	</div>
-	<div class='col-md-3 center'>
+	<div class='col-xs-3 center'>
 		<a href="https://github.com/theforeman/foreman_memcache" class="btn-doc btn">
 			<p class='h2 doc-icon'><i class="fa fa-tasks"></i></p>
 			Memcache
 		</a>
 	</div>
-	<div class='col-md-3 center'>
+	<div class='col-xs-3 center'>
 		<a href="plugins/foreman_openscap" class="btn-doc btn">
 			<p class='h2 doc-icon'><i class="fa fa-bank"></i></p>
 			OpenSCAP
 		</a>
 	</div>
-	<div class='col-md-3 center'>
+	<div class='col-xs-3 center'>
 		<a href="plugins/foreman_remote_execution" class="btn-doc btn">
 			<p class='h2 doc-icon'><i class="fa fa-toggle-right"></i></p>
 			Remote Execution
 		</a>
 	</div>
-	<div class='col-md-3 center'>
+	<div class='col-xs-3 center'>
 		<a href="plugins/foreman_salt" class="btn-doc btn">
 			<p class='h2 doc-icon'><i class="fa fa-cube"></i></p>
 			Salt
 		</a>
 	</div>
-	<div class='col-md-3 center'>
+	<div class='col-xs-3 center'>
 		<a href="https://github.com/theforeman/foreman_setup" class="btn-doc btn">
 			<p class='h2 doc-icon'><i class="fa fa-sun-o"></i></p>
 			Setup
 		</a>
 	</div>
-	<div class='col-md-3 center'>
+	<div class='col-xs-3 center'>
 		<a href="https://github.com/theforeman/foreman_templates" class="btn-doc btn">
 			<p class='h2 doc-icon'><i class="fa fa-file"></i></p>
 			Templates
 		</a>
 	</div>
-	<div class='col-md-3 center'>
+	<div class='col-xs-3 center'>
 		<a href="https://github.com/theforeman/puppetdb_foreman" class="btn-doc btn">
 			<p class='h2 doc-icon'><i class="fa fa-database"></i></p>
 			PuppetDB
 		</a>
 	</div>
-	<div class='col-md-3 center'>
+	<div class='col-xs-3 center'>
 		<a href="https://github.com/theforeman/foreman-xen" class="btn-doc btn">
 			<p class='h2 doc-icon'><i class="fa fa-dashboard"></i></p>
 			Xen
 		</a>
 	</div>
- 	<div class='col-md-3 center'>
+ 	<div class='col-xs-3 center'>
 		<a href="http://projects.theforeman.org/projects/foreman/wiki/List_of_Plugins" class="btn-doc btn">
 			<p class='h2 doc-icon'><i class="fa fa-plus"></i></p>
       More


### PR DESCRIPTION
Currently on smaller resolutions the documentation page and plugins page links display in a vertically stacked line making them hard to naviagate:

![screenshot from 2016-11-15 13-13-42](https://cloud.githubusercontent.com/assets/293363/20317885/f11e6ef4-ab35-11e6-83a7-7198206ec4a0.png)
![screenshot from 2016-11-15 13-07-27](https://cloud.githubusercontent.com/assets/293363/20317884/f11e00ea-ab35-11e6-8da0-331266325a4c.png)


This updates them to stay consistent on smaller resolutions and thus easier to navigate:

![screenshot from 2016-11-15 13-13-19](https://cloud.githubusercontent.com/assets/293363/20317899/043e054e-ab36-11e6-8df7-5cefee8304b7.png)
![screenshot from 2016-11-15 13-13-26](https://cloud.githubusercontent.com/assets/293363/20317900/043fbd94-ab36-11e6-809e-a40861eb0110.png)
