### PR TITLE
Fixes version numbers in katello

### DIFF
--- a/plugins/katello/2.4/cli/index.md
+++ b/plugins/katello/2.4/cli/index.md
@@ -1,7 +1,8 @@
 ---
 layout: plugins/katello/documentation
 title: CLI
-version: 3.2
+version: 2.4
+foreman_version: "1.10"
 script: osmenu.js
 ---
 
@@ -36,8 +37,8 @@ yum-config-manager --enable rhel-6-server-optional-rpms
 
 <div id="el6" markdown="1">
 {% highlight bash %}
-yum -y localinstall http://fedorapeople.org/groups/katello/releases/yum/{{ site.version }}/katello/el6/x86_64/katello-repos-latest.rpm
-yum -y localinstall http://yum.theforeman.org/releases/{{ site.foreman_version }}/el6/x86_64/foreman-release.rpm
+yum -y localinstall http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el6/x86_64/katello-repos-latest.rpm
+yum -y localinstall http://yum.theforeman.org/releases/{{ page.foreman_version }}/el6/x86_64/foreman-release.rpm
 yum -y localinstall http://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
 {% endhighlight %}
 </div>
@@ -54,8 +55,8 @@ yum-config-manager --enable rhel-7-server-extras-rpms
 
 <div id="el7" style="display: none;" markdown="1">
 {% highlight bash %}
-yum -y localinstall http://fedorapeople.org/groups/katello/releases/yum/{{ site.version }}/katello/el7/x86_64/katello-repos-latest.rpm
-yum -y localinstall http://yum.theforeman.org/releases/{{ site.foreman_version }}/el7/x86_64/foreman-release.rpm
+yum -y localinstall http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el7/x86_64/katello-repos-latest.rpm
+yum -y localinstall http://yum.theforeman.org/releases/{{ page.foreman_version }}/el7/x86_64/foreman-release.rpm
 yum -y localinstall http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 {% endhighlight %}
 </div>

--- a/plugins/katello/2.4/installation/2.0-transition.md
+++ b/plugins/katello/2.4/installation/2.0-transition.md
@@ -2,6 +2,7 @@
 layout: plugins/katello/documentation
 version: 2.4
 title: "Transitioning from 1.4 to 2.0"
+latest: 3.2
 ---
 
 # Transitioning from Katello 1.4 to 2.0
@@ -32,7 +33,7 @@ The general steps for transitioning are:
 
 ## Installing a new Katello 2.0 Server
 
-Follow the installation instructions for the latest Katello version: [Installation](/docs/{{ site.latest }}/installation/)
+Follow the installation instructions for the latest Katello version: [Installation](/docs/{{ page.latest }}/installation/)
 
 ## Configuration of the Katello 2.0 Server
 

--- a/plugins/katello/2.4/installation/capsule.md
+++ b/plugins/katello/2.4/installation/capsule.md
@@ -13,7 +13,7 @@ The Capsule server is only supported on x86_64 Operating Systems
 
  * 2 Two Logical CPUs
  * 4 GB of memory
- * Disk space usage is similar to that of the main Katello server [Installation](/docs/{{ site.version }}/installation/index.html)
+ * Disk space usage is similar to that of the main Katello server [Installation](/docs/{{ page.version }}/installation/index.html)
 
 
 ## Required Ports
@@ -24,7 +24,7 @@ At a minimum, the following ports need to be open to external connections for in
 * 443 TCP - HTTPS, used for web access and api communication
 * 9090 TCP - HTTPS - used for communication with the smart proxy
 
-See the [User Guide](/docs/{{ site.version }}/user_guide/capsules/index.html) for additional information about Capsule services and required ports.
+See the [User Guide](/docs/{{ page.version }}/user_guide/capsules/index.html) for additional information about Capsule services and required ports.
 
 ## Installation
 
@@ -71,7 +71,7 @@ Installing             Done                     [100%] [.....................]
 
 ### Install needed packages:
 
-The same yum repositories need to be configured on the Capsule server as the main Katello server. See the installation guide for the [list of required repositories](/docs/{{ site.version }}/installation/index.html#required-repositories).
+The same yum repositories need to be configured on the Capsule server as the main Katello server. See the installation guide for the [list of required repositories](/docs/{{ page.version }}/installation/index.html#required-repositories).
 
 ```
 yum install -y capsule-installer
@@ -81,4 +81,4 @@ yum install -y capsule-installer
 
 Use the provide installation command from `capsule-certs-generate`, and tailor for your own purposes as needed.  The defaults will give you a Capsule ready for Content-related services.
 
-See the [User Guide](/docs/{{ site.version }}/user_guide/capsules/index.html) to learn about setting up provisioning related services, as well as the [Foreman manual](http://theforeman.org/manuals/latest/index.html#4.3SmartProxies)
+See the [User Guide](/docs/{{ page.version }}/user_guide/capsules/index.html) to learn about setting up provisioning related services, as well as the [Foreman manual](http://theforeman.org/manuals/latest/index.html#4.3SmartProxies)

--- a/plugins/katello/2.4/installation/index.md
+++ b/plugins/katello/2.4/installation/index.md
@@ -2,8 +2,9 @@
 layout: plugins/katello/documentation
 title: Katello Installation
 version: 2.4
-foreman_version: 1.10
+foreman_version: "1.10"
 script: osmenu.js
+latest: 3.2
 ---
 
 # Katello {{ page.version }} Installation

--- a/plugins/katello/2.4/upgrade/capsule.md
+++ b/plugins/katello/2.4/upgrade/capsule.md
@@ -1,6 +1,7 @@
 ---
 layout: plugins/katello/documentation
 version: 2.4
+foreman_version: 1.10
 title: Capsule Upgrade
 ---
 
@@ -26,14 +27,14 @@ Update the Foreman and Katello release packages:
 
 {% highlight bash %}
   yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/RHEL/6Server/x86_64/katello-repos-latest.rpm
-  yum update -y http://yum.theforeman.org/{{ site.foreman_version }}/el6/x86_64/foreman-release.rpm
+  yum update -y http://yum.theforeman.org/{{ page.foreman_version }}/el6/x86_64/foreman-release.rpm
 {% endhighlight %}
 
   * RHEL7 / CentOS 7:
 
 {% highlight bash %}
   yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/RHEL/7Server/x86_64/katello-repos-latest.rpm
-  yum update -y http://yum.theforeman.org/{{ site.foreman_version }}/el7/x86_64/foreman-release.rpm
+  yum update -y http://yum.theforeman.org/{{ page.foreman_version }}/el7/x86_64/foreman-release.rpm
 {% endhighlight %}
 
 ## Step 3 - Update Packages

--- a/plugins/katello/2.4/upgrade/index.md
+++ b/plugins/katello/2.4/upgrade/index.md
@@ -1,6 +1,7 @@
 ---
 layout: plugins/katello/documentation
 version: 2.4
+foreman_version: "1.10"
 title: Katello Upgrade
 ---
 
@@ -30,14 +31,14 @@ Update the Foreman and Katello release packages:
 
 {% highlight bash %}
   yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/RHEL/6Server/x86_64/katello-repos-latest.rpm
-  yum update -y http://yum.theforeman.org/{{ site.foreman_version }}/el6/x86_64/foreman-release.rpm
+  yum update -y http://yum.theforeman.org/{{ page.foreman_version }}/el6/x86_64/foreman-release.rpm
 {% endhighlight %}
 
   * RHEL7 / CentOS 7:
 
 {% highlight bash %}
-  # yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/RHEL/7Server/x86_64/katello-repos-latest.rpm
-  # yum update -y http://yum.theforeman.org/{{ site.foreman_version }}/el7/x86_64/foreman-release.rpm
+  yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/RHEL/7Server/x86_64/katello-repos-latest.rpm
+  yum update -y http://yum.theforeman.org/{{ page.foreman_version }}/el7/x86_64/foreman-release.rpm
 {% endhighlight %}
 
 ## Step 4 - Update Packages

--- a/plugins/katello/2.4/user_guide/hammer.md
+++ b/plugins/katello/2.4/user_guide/hammer.md
@@ -12,7 +12,7 @@ Katello via HTTP or HTTPS.
 
 ### Remote install
 
-Install the prerequisite repositories [as per our installation guide](/docs/{{ site.version }}/installation/index.html#required-repositories).
+Install the prerequisite repositories [as per our installation guide](/docs/{{ page.version }}/installation/index.html#required-repositories).
 
 Now install the hammer-cli-katello package:
 

--- a/plugins/katello/3.0/cli/index.md
+++ b/plugins/katello/3.0/cli/index.md
@@ -1,7 +1,8 @@
 ---
 layout: plugins/katello/documentation
 title: CLI
-version: 3.2
+version: 3.0
+foreman_version: 1.11
 script: osmenu.js
 ---
 
@@ -36,8 +37,8 @@ yum-config-manager --enable rhel-6-server-optional-rpms
 
 <div id="el6" markdown="1">
 {% highlight bash %}
-yum -y localinstall http://fedorapeople.org/groups/katello/releases/yum/{{ site.version }}/katello/el6/x86_64/katello-repos-latest.rpm
-yum -y localinstall http://yum.theforeman.org/releases/{{ site.foreman_version }}/el6/x86_64/foreman-release.rpm
+yum -y localinstall http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el6/x86_64/katello-repos-latest.rpm
+yum -y localinstall http://yum.theforeman.org/releases/{{ page.foreman_version }}/el6/x86_64/foreman-release.rpm
 yum -y localinstall http://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
 {% endhighlight %}
 </div>
@@ -54,8 +55,8 @@ yum-config-manager --enable rhel-7-server-extras-rpms
 
 <div id="el7" style="display: none;" markdown="1">
 {% highlight bash %}
-yum -y localinstall http://fedorapeople.org/groups/katello/releases/yum/{{ site.version }}/katello/el7/x86_64/katello-repos-latest.rpm
-yum -y localinstall http://yum.theforeman.org/releases/{{ site.foreman_version }}/el7/x86_64/foreman-release.rpm
+yum -y localinstall http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el7/x86_64/katello-repos-latest.rpm
+yum -y localinstall http://yum.theforeman.org/releases/{{ page.foreman_version }}/el7/x86_64/foreman-release.rpm
 yum -y localinstall http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 {% endhighlight %}
 </div>

--- a/plugins/katello/3.0/installation/index.md
+++ b/plugins/katello/3.0/installation/index.md
@@ -102,7 +102,7 @@ yum-config-manager --enable rhel-6-server-optional-rpms
 <div id="el6" markdown="1">
 {% highlight bash %}
 yum -y localinstall http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el6/x86_64/katello-repos-latest.rpm
-yum -y localinstall http://yum.theforeman.org/releases/{{ site.foreman_version }}/el6/x86_64/foreman-release.rpm
+yum -y localinstall http://yum.theforeman.org/releases/{{ page.foreman_version }}/el6/x86_64/foreman-release.rpm
 yum -y localinstall http://yum.puppetlabs.com/puppetlabs-release-el-6.noarch.rpm
 yum -y localinstall http://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
 yum -y install foreman-release-scl
@@ -122,7 +122,7 @@ yum-config-manager --enable rhel-7-server-extras-rpms
 <div id="el7" style="display: none;" markdown="1">
 {% highlight bash %}
 yum -y localinstall http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el7/x86_64/katello-repos-latest.rpm
-yum -y localinstall http://yum.theforeman.org/releases/{{ site.foreman_version  }}/el7/x86_64/foreman-release.rpm
+yum -y localinstall http://yum.theforeman.org/releases/{{ page.foreman_version  }}/el7/x86_64/foreman-release.rpm
 yum -y localinstall http://yum.puppetlabs.com/puppetlabs-release-el-7.noarch.rpm
 yum -y localinstall http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 yum -y install foreman-release-scl

--- a/plugins/katello/3.0/upgrade/capsule.md
+++ b/plugins/katello/3.0/upgrade/capsule.md
@@ -1,6 +1,7 @@
 ---
 layout: plugins/katello/documentation
 version: 3.0
+foreman_version: 1.11
 title: Capsule Upgrade
 ---
 
@@ -37,14 +38,14 @@ Update the Foreman and Katello release packages:
 
 {% highlight bash %}
   yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/RHEL/6Server/x86_64/katello-repos-latest.rpm
-  yum update -y http://yum.theforeman.org/{{ site.foreman_version }}/el6/x86_64/foreman-release.rpm
+  yum update -y http://yum.theforeman.org/{{ page.foreman_version }}/el6/x86_64/foreman-release.rpm
 {% endhighlight %}
 
   * RHEL7 / CentOS 7:
 
 {% highlight bash %}
   yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/RHEL/7Server/x86_64/katello-repos-latest.rpm
-  yum update -y http://yum.theforeman.org/{{ site.foreman_version }}/el7/x86_64/foreman-release.rpm
+  yum update -y http://yum.theforeman.org/{{ page.foreman_version }}/el7/x86_64/foreman-release.rpm
 {% endhighlight %}
 
 ## Step 3 - Update Packages

--- a/plugins/katello/3.0/upgrade/index.md
+++ b/plugins/katello/3.0/upgrade/index.md
@@ -1,6 +1,7 @@
 ---
 layout: plugins/katello/documentation
 version: 3.0
+foreman_version: 1.11
 title: Katello Upgrade
 ---
 
@@ -55,15 +56,15 @@ Update the Foreman and Katello release packages:
   * RHEL6 / CentOS 6:
 
 {% highlight bash %}
-  # yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el6/x86_64/katello-repos-latest.rpm
-  # yum update -y http://yum.theforeman.org/releases/{{ site.foreman_version }}/el6/x86_64/foreman-release.rpm
+  yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el6/x86_64/katello-repos-latest.rpm
+  yum update -y http://yum.theforeman.org/releases/{{ page.foreman_version }}/el6/x86_64/foreman-release.rpm
 {% endhighlight %}
 
   * RHEL7 / CentOS 7:
 
 {% highlight bash %}
-  # yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el7/x86_64/katello-repos-latest.rpm
-  # yum update -y http://yum.theforeman.org/releases/{{ site.foreman_version }}/el7/x86_64/foreman-release.rpm
+  yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el7/x86_64/katello-repos-latest.rpm
+  yum update -y http://yum.theforeman.org/releases/{{ page.foreman_version }}/el7/x86_64/foreman-release.rpm
 {% endhighlight %}
 
 ## Step 4 - Update Packages

--- a/plugins/katello/3.1/cli/index.md
+++ b/plugins/katello/3.1/cli/index.md
@@ -1,7 +1,8 @@
 ---
 layout: plugins/katello/documentation
 title: CLI
-version: 3.2
+version: 3.1
+foreman_version: 1.12
 script: osmenu.js
 ---
 
@@ -36,8 +37,8 @@ yum-config-manager --enable rhel-6-server-optional-rpms
 
 <div id="el6" markdown="1">
 {% highlight bash %}
-yum -y localinstall http://fedorapeople.org/groups/katello/releases/yum/{{ site.version }}/katello/el6/x86_64/katello-repos-latest.rpm
-yum -y localinstall http://yum.theforeman.org/releases/{{ site.foreman_version }}/el6/x86_64/foreman-release.rpm
+yum -y localinstall http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el6/x86_64/katello-repos-latest.rpm
+yum -y localinstall http://yum.theforeman.org/releases/{{ page.foreman_version }}/el6/x86_64/foreman-release.rpm
 yum -y localinstall http://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
 {% endhighlight %}
 </div>
@@ -54,8 +55,8 @@ yum-config-manager --enable rhel-7-server-extras-rpms
 
 <div id="el7" style="display: none;" markdown="1">
 {% highlight bash %}
-yum -y localinstall http://fedorapeople.org/groups/katello/releases/yum/{{ site.version }}/katello/el7/x86_64/katello-repos-latest.rpm
-yum -y localinstall http://yum.theforeman.org/releases/{{ site.foreman_version }}/el7/x86_64/foreman-release.rpm
+yum -y localinstall http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el7/x86_64/katello-repos-latest.rpm
+yum -y localinstall http://yum.theforeman.org/releases/{{ page.foreman_version }}/el7/x86_64/foreman-release.rpm
 yum -y localinstall http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 {% endhighlight %}
 </div>

--- a/plugins/katello/3.1/installation/index.md
+++ b/plugins/katello/3.1/installation/index.md
@@ -102,7 +102,7 @@ yum-config-manager --enable rhel-6-server-optional-rpms
 <div id="el6" markdown="1">
 {% highlight bash %}
 yum -y localinstall http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el6/x86_64/katello-repos-latest.rpm
-yum -y localinstall http://yum.theforeman.org/releases/{{ site.foreman_version }}/el6/x86_64/foreman-release.rpm
+yum -y localinstall http://yum.theforeman.org/releases/{{ page.foreman_version }}/el6/x86_64/foreman-release.rpm
 yum -y localinstall http://yum.puppetlabs.com/puppetlabs-release-el-6.noarch.rpm
 yum -y localinstall http://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
 yum -y install foreman-release-scl
@@ -122,7 +122,7 @@ yum-config-manager --enable rhel-7-server-extras-rpms
 <div id="el7" style="display: none;" markdown="1">
 {% highlight bash %}
 yum -y localinstall http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el7/x86_64/katello-repos-latest.rpm
-yum -y localinstall http://yum.theforeman.org/releases/{{ site.foreman_version  }}/el7/x86_64/foreman-release.rpm
+yum -y localinstall http://yum.theforeman.org/releases/{{ page.foreman_version  }}/el7/x86_64/foreman-release.rpm
 yum -y localinstall http://yum.puppetlabs.com/puppetlabs-release-el-7.noarch.rpm
 yum -y localinstall http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 yum -y install foreman-release-scl

--- a/plugins/katello/3.1/upgrade/capsule.md
+++ b/plugins/katello/3.1/upgrade/capsule.md
@@ -2,6 +2,7 @@
 layout: plugins/katello/documentation
 title: Capsule Upgrade
 version: 3.1
+foreman_version: 1.12
 ---
 
 # Capsule Upgrade
@@ -24,14 +25,14 @@ Update the Foreman and Katello release packages:
 
 {% highlight bash %}
   yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el6/x86_64/katello-repos-latest.rpm
-  yum update -y http://yum.theforeman.org/releases/{{ site.foreman_version }}/el6/x86_64/foreman-release.rpm
+  yum update -y http://yum.theforeman.org/releases/{{ page.foreman_version }}/el6/x86_64/foreman-release.rpm
 {% endhighlight %}
 
   * RHEL7 / CentOS 7:
 
 {% highlight bash %}
   yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el7/x86_64/katello-repos-latest.rpm
-  yum update -y http://yum.theforeman.org/releases/{{ site.foreman_version }}/el7/x86_64/foreman-release.rpm
+  yum update -y http://yum.theforeman.org/releases/{{ page.foreman_version }}/el7/x86_64/foreman-release.rpm
 {% endhighlight %}
 
 ## Step 3 - Update Packages

--- a/plugins/katello/3.1/upgrade/index.md
+++ b/plugins/katello/3.1/upgrade/index.md
@@ -2,6 +2,7 @@
 layout: plugins/katello/documentation
 title: Katello Upgrade
 version: 3.1
+foreman_version: 1.12
 ---
 
 # Katello Upgrade
@@ -57,14 +58,14 @@ Update the Foreman and Katello release packages:
 
 {% highlight bash %}
   yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el6/x86_64/katello-repos-latest.rpm
-  yum update -y http://yum.theforeman.org/releases/{{ site.foreman_version }}/el6/x86_64/foreman-release.rpm
+  yum update -y http://yum.theforeman.org/releases/{{ page.foreman_version }}/el6/x86_64/foreman-release.rpm
 {% endhighlight %}
 
   * RHEL7 / CentOS 7:
 
 {% highlight bash %}
   yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el7/x86_64/katello-repos-latest.rpm
-  yum update -y http://yum.theforeman.org/releases/{{ site.foreman_version }}/el7/x86_64/foreman-release.rpm
+  yum update -y http://yum.theforeman.org/releases/{{ page.foreman_version }}/el7/x86_64/foreman-release.rpm
 {% endhighlight %}
 
 ## Step 4 - Update Packages

--- a/plugins/katello/3.1/user_guide/capsules/index.md
+++ b/plugins/katello/3.1/user_guide/capsules/index.md
@@ -39,7 +39,7 @@ In the simplest use case, a user may only want to use the Default Capsule. Large
 
 ## Installation
 
-See [Capsule Installation](/plugins/katello/{{ site.version }}/installation/capsule.html)
+See [Capsule Installation](/plugins/katello/{{ page.version }}/installation/capsule.html)
 
 ## Removal
 
@@ -95,7 +95,7 @@ Required Connectivity:
 
 ### 4 - Subscription Management
 
-Content Hosts utilize [Subscription Manager](/plugins/katello/{{ site.version }}/user_guide/content_hosts/index.html#how-is-a-content-host-registered) for registration to Katello and enabling/disabling specific repositories.
+Content Hosts utilize [Subscription Manager](/plugins/katello/{{ page.version }}/user_guide/content_hosts/index.html#how-is-a-content-host-registered) for registration to Katello and enabling/disabling specific repositories.
 
 Install Option:
 

--- a/plugins/katello/3.1/user_guide/hammer.md
+++ b/plugins/katello/3.1/user_guide/hammer.md
@@ -12,7 +12,7 @@ Katello via HTTP or HTTPS.
 
 ### Remote install
 
-Install the prerequisite repositories [as per our installation guide](/plugins/katello/{{ site.version }}/installation/index.html#required-repositories).
+Install the prerequisite repositories [as per our installation guide](/plugins/katello/{{ page.version }}/installation/index.html#required-repositories).
 
 Now install the hammer-cli-katello package:
 

--- a/plugins/katello/3.1/user_guide/lifecycle_environments/index.md
+++ b/plugins/katello/3.1/user_guide/lifecycle_environments/index.md
@@ -21,7 +21,7 @@ What can a Lifecycle Environments be used for?
 ## General Workflow
 
 First create a lifecycle environment connected to the library life cycle environment and promote content views to the new lifecycle environment.
-A [Content Host](/plugins/katello/{{ site.version }}/user_guide/content_hosts/index.html) can now register directly to the promoted content view in the promoted environment or library therein.  Updates will be available as soon as new content is synced and promoted.
+A [Content Host](/plugins/katello/{{ page.version }}/user_guide/content_hosts/index.html) can now register directly to the promoted content view in the promoted environment or library therein.  Updates will be available as soon as new content is synced and promoted.
 
 
 ## Viewing the list of lifecycle environments

--- a/plugins/katello/3.2/cli/index.md
+++ b/plugins/katello/3.2/cli/index.md
@@ -2,6 +2,7 @@
 layout: plugins/katello/documentation
 title: CLI
 version: 3.2
+foreman_version: 1.13
 script: osmenu.js
 ---
 
@@ -36,8 +37,8 @@ yum-config-manager --enable rhel-6-server-optional-rpms
 
 <div id="el6" markdown="1">
 {% highlight bash %}
-yum -y localinstall http://fedorapeople.org/groups/katello/releases/yum/{{ site.version }}/katello/el6/x86_64/katello-repos-latest.rpm
-yum -y localinstall http://yum.theforeman.org/releases/{{ site.foreman_version }}/el6/x86_64/foreman-release.rpm
+yum -y localinstall http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el6/x86_64/katello-repos-latest.rpm
+yum -y localinstall http://yum.theforeman.org/releases/{{ page.foreman_version }}/el6/x86_64/foreman-release.rpm
 yum -y localinstall http://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
 {% endhighlight %}
 </div>
@@ -54,8 +55,8 @@ yum-config-manager --enable rhel-7-server-extras-rpms
 
 <div id="el7" style="display: none;" markdown="1">
 {% highlight bash %}
-yum -y localinstall http://fedorapeople.org/groups/katello/releases/yum/{{ site.version }}/katello/el7/x86_64/katello-repos-latest.rpm
-yum -y localinstall http://yum.theforeman.org/releases/{{ site.foreman_version }}/el7/x86_64/foreman-release.rpm
+yum -y localinstall http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el7/x86_64/katello-repos-latest.rpm
+yum -y localinstall http://yum.theforeman.org/releases/{{ page.foreman_version }}/el7/x86_64/foreman-release.rpm
 yum -y localinstall http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 {% endhighlight %}
 </div>

--- a/plugins/katello/3.2/upgrade/capsule.md
+++ b/plugins/katello/3.2/upgrade/capsule.md
@@ -2,6 +2,7 @@
 layout: plugins/katello/documentation
 title: Capsule Upgrade
 version: 3.2
+foreman_version: 1.13
 ---
 
 # Capsule Upgrade
@@ -23,15 +24,15 @@ Update the Foreman and Katello release packages:
   * RHEL6 / CentOS 6 **Foreman packages are not available yet**:
 
 {% highlight bash %}
-  yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ site.version }}/katello/el6/x86_64/katello-repos-latest.rpm
-  yum update -y http://fedorapeople.org/groups/katello/releases/yum/foreman/{{ site.foreman_version }}/el6/x86_64/foreman-release.rpm
+  yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el6/x86_64/katello-repos-latest.rpm
+  yum update -y http://fedorapeople.org/groups/katello/releases/yum/foreman/{{ page.foreman_version }}/el6/x86_64/foreman-release.rpm
 {% endhighlight %}
 
   * RHEL7 / CentOS 7:
 
 {% highlight bash %}
-  yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ site.version }}/katello/el7/x86_64/katello-repos-latest.rpm
-  yum update -y http://yum.theforeman.org/releases/{{ site.foreman_version }}/el7/x86_64/foreman-release.rpm
+  yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el7/x86_64/katello-repos-latest.rpm
+  yum update -y http://yum.theforeman.org/releases/{{ page.foreman_version }}/el7/x86_64/foreman-release.rpm
 {% endhighlight %}
 
 ## Step 3 - Update Packages
@@ -69,7 +70,7 @@ scp ~/mycapsule.example.com-certs.tar mycapsule.example.com:
 
 ## Step 5 - Run Installer
 
-The installer with the --upgrade flag will run the right database migrations for all component services, as well as adjusting the configuration to reflect what's new in Katello {{ site.version }}
+The installer with the --upgrade flag will run the right database migrations for all component services, as well as adjusting the configuration to reflect what's new in Katello {{ page.version }}
 
 {% highlight bash %}
 foreman-installer --scenario capsule --upgrade\
@@ -77,6 +78,6 @@ foreman-installer --scenario capsule --upgrade\
                   --certs-update-all --regenerate --deploy
 {% endhighlight %}
 
-**Congratulations! You have now successfully upgraded your Capsule to {% if site.version %}{{ site.version }} For a rundown of what was added, please see [release notes](/plugins/katello/{{ site.version }}/release_notes/release_notes.html).{% else %}the latest nightly{% endif %}!**
+**Congratulations! You have now successfully upgraded your Capsule to {% if page.version %}{{ page.version }} For a rundown of what was added, please see [release notes](/plugins/katello/{{ page.version }}/release_notes/release_notes.html).{% else %}the latest nightly{% endif %}!**
 
 If for any reason, the above steps failed, please review /var/log/foreman-installer/capsule.log -- if any of the "Upgrade step" tasks failed, you may try to run them manaully below to aid in troubleshooting.

--- a/plugins/katello/3.2/upgrade/clients.md
+++ b/plugins/katello/3.2/upgrade/clients.md
@@ -27,31 +27,31 @@ Update the Katello client release packages:
 
 <div id="el5" markdown="1">
 {% highlight bash %}
-yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ site.version }}/client/el5/x86_64/katello-client-repos-latest.rpm
+yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/el5/x86_64/katello-client-repos-latest.rpm
 {% endhighlight %}
 </div>
 
 <div id="el6" style="display:none;" markdown="1">
 {% highlight bash %}
-yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ site.version }}/client/el6/x86_64/katello-client-repos-latest.rpm
+yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/el6/x86_64/katello-client-repos-latest.rpm
 {% endhighlight %}
 </div>
 
 <div id="el7" style="display:none;" markdown="1">
 {% highlight bash %}
-yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ site.version }}/client/el7/x86_64/katello-client-repos-latest.rpm
+yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/el7/x86_64/katello-client-repos-latest.rpm
 {% endhighlight %}
 </div>
 
 <div id="fc23" style="display:none;" markdown="1">
 {% highlight bash %}
-yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ site.version }}/client/fc23/x86_64/katello-client-repos-latest.rpm
+yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/fc23/x86_64/katello-client-repos-latest.rpm
 {% endhighlight %}
 </div>
 
 ### Provisioned Clients
 
-If the katello-agent was setup during proviosioning from a locally synced repository then you will need to go through some [initial setup](/plugins/katello/{{ site.version }}/installation/clients.html) to add the {{ site.version }} client repositories to your Katello for each version needed. After you create the new repositories, they will then need to be added to the relevant content view(s) and the older versions removed. At this point, a new version of the content view can be published and promoted to the appropriate environments. Once the new package is available the clients can be updated following the next steps.
+If the katello-agent was setup during proviosioning from a locally synced repository then you will need to go through some [initial setup](/plugins/katello/{{ page.version }}/installation/clients.html) to add the {{ page.version }} client repositories to your Katello for each version needed. After you create the new repositories, they will then need to be added to the relevant content view(s) and the older versions removed. At this point, a new version of the content view can be published and promoted to the appropriate environments. Once the new package is available the clients can be updated following the next steps.
 
 ## Step 2: Update Packages
 

--- a/plugins/katello/3.2/upgrade/index.md
+++ b/plugins/katello/3.2/upgrade/index.md
@@ -2,11 +2,12 @@
 layout: plugins/katello/documentation
 title: Katello Upgrade
 version: 3.2
+foreman_version: 1.13
 ---
 
 # Katello Upgrade
 
-Katello supports upgrades from version 2.0.  For users transitioning from 1.4, please see - [Transition Guide](/plugins/katello/{{ site.version }}/installation/2.0-transition.html).
+Katello supports upgrades from version 2.0.  For users transitioning from 1.4, please see - [Transition Guide](/plugins/katello/{{ page.version }}/installation/2.0-transition.html).
 
 
 # Pre-upgrade considerations
@@ -21,7 +22,7 @@ foreman-rake katello:upgrade_check
 
 ## Step 1 - Backup
 
-If Katello is running on a Virtual Machine, we reccomend to take a snapshot prior to upgrading. Otherwise, take a backup of the relevant databases by following the [instructions here](/plugins/katello/{{ site.version }}/user_guide/backup/).
+If Katello is running on a Virtual Machine, we reccomend to take a snapshot prior to upgrading. Otherwise, take a backup of the relevant databases by following the [instructions here](/plugins/katello/{{ page.version }}/user_guide/backup/).
 
 ## Step 2 - Operating System
 
@@ -40,15 +41,15 @@ Update the Foreman and Katello release packages:
   * RHEL6 / CentOS 6:
 
 {% highlight bash %}
-  yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ site.version }}/katello/el6/x86_64/katello-repos-latest.rpm
-  yum update -y http://fedorapeople.org/groups/katello/releases/yum/foreman/{{ site.foreman_version }}/el6/x86_64/foreman-release.rpm
+  yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el6/x86_64/katello-repos-latest.rpm
+  yum update -y http://fedorapeople.org/groups/katello/releases/yum/foreman/{{ page.foreman_version }}/el6/x86_64/foreman-release.rpm
 {% endhighlight %}
 
   * RHEL7 / CentOS 7:
 
 {% highlight bash %}
-  yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ site.version }}/katello/el7/x86_64/katello-repos-latest.rpm
-  yum update -y http://yum.theforeman.org/releases/{{ site.foreman_version }}/el7/x86_64/foreman-release.rpm
+  yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el7/x86_64/katello-repos-latest.rpm
+  yum update -y http://yum.theforeman.org/releases/{{ page.foreman_version }}/el7/x86_64/foreman-release.rpm
 {% endhighlight %}
 
 ## Step 4 - Update Packages
@@ -67,13 +68,13 @@ yum -y update
 
 ## Step 5 - Run Installer
 
-The installer with the --upgrade flag will run the right database migrations for all component services, as well as adjusting the configuration to reflect what's new in Katello {{ site.version }}
+The installer with the --upgrade flag will run the right database migrations for all component services, as well as adjusting the configuration to reflect what's new in Katello {{ page.version }}
 
 {% highlight bash %}
 foreman-installer --scenario katello --upgrade
 {% endhighlight %}
 
-**Congratulations! You have now successfully upgraded your Katello to {% if site.version %}{{ site.version }} For a rundown of what was added, please see [release notes](/plugins/katello/{{ site.version }}/release_notes/release_notes.html).{% else %}the latest nightly{% endif %}!**
+**Congratulations! You have now successfully upgraded your Katello to {% if page.version %}{{ page.version }} For a rundown of what was added, please see [release notes](/plugins/katello/{{ page.version }}/release_notes/release_notes.html).{% else %}the latest nightly{% endif %}!**
 
 
 If for any reason, the above steps failed, please review /var/log/foreman-installer/katello.log -- if any of the "Upgrade step" tasks failed, you may try to run them manaully below to aid in troubleshooting.

--- a/plugins/katello/3.2/user_guide/capsules/index.md
+++ b/plugins/katello/3.2/user_guide/capsules/index.md
@@ -39,7 +39,7 @@ In the simplest use case, a user may only want to use the Default Capsule. Large
 
 ## Installation
 
-See [Capsule Installation](/plugins/katello/{{ site.version }}/installation/capsule.html)
+See [Capsule Installation](/plugins/katello/{{ page.version }}/installation/capsule.html)
 
 ## Removal
 
@@ -95,7 +95,7 @@ Required Connectivity:
 
 ### 4 - Subscription Management
 
-Content Hosts utilize [Subscription Manager](/plugins/katello/{{ site.version }}/user_guide/content_hosts/index.html#how-is-a-content-host-registered) for registration to Katello and enabling/disabling specific repositories.
+Content Hosts utilize [Subscription Manager](/plugins/katello/{{ page.version }}/user_guide/content_hosts/index.html#how-is-a-content-host-registered) for registration to Katello and enabling/disabling specific repositories.
 
 Install Option:
 

--- a/plugins/katello/3.2/user_guide/hammer.md
+++ b/plugins/katello/3.2/user_guide/hammer.md
@@ -18,7 +18,7 @@ Katello via HTTP or HTTPS.
 
 ### Remote install
 
-Install the prerequisite repositories [as per our installation guide](/plugins/katello/{{ site.version }}/installation/index.html#required-repositories).
+Install the prerequisite repositories [as per our installation guide](/plugins/katello/{{ page.version }}/installation/index.html#required-repositories).
 
 Now install the hammer-cli-katello package:
 

--- a/plugins/katello/3.2/user_guide/lifecycle_environments/index.md
+++ b/plugins/katello/3.2/user_guide/lifecycle_environments/index.md
@@ -21,7 +21,7 @@ What can a Lifecycle Environments be used for?
 ## General Workflow
 
 First create a lifecycle environment connected to the library life cycle environment and promote content views to the new lifecycle environment.
-A [Content Host](/plugins/katello/{{ site.version }}/user_guide/content_hosts/index.html) can now register directly to the promoted content view in the promoted environment or library therein.  Updates will be available as soon as new content is synced and promoted.
+A [Content Host](/plugins/katello/{{ page.version }}/user_guide/content_hosts/index.html) can now register directly to the promoted content view in the promoted environment or library therein.  Updates will be available as soon as new content is synced and promoted.
 
 
 ## Viewing the list of lifecycle environments

--- a/plugins/katello/nightly/cli/index.md
+++ b/plugins/katello/nightly/cli/index.md
@@ -2,6 +2,7 @@
 layout: plugins/katello/documentation
 title: CLI
 version: 3.2
+foreman_version: 1.13
 script: osmenu.js
 ---
 
@@ -36,8 +37,8 @@ yum-config-manager --enable rhel-6-server-optional-rpms
 
 <div id="el6" markdown="1">
 {% highlight bash %}
-yum -y localinstall http://fedorapeople.org/groups/katello/releases/yum/{{ site.version }}/katello/el6/x86_64/katello-repos-latest.rpm
-yum -y localinstall http://yum.theforeman.org/releases/{{ site.foreman_version }}/el6/x86_64/foreman-release.rpm
+yum -y localinstall http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el6/x86_64/katello-repos-latest.rpm
+yum -y localinstall http://yum.theforeman.org/releases/{{ page.foreman_version }}/el6/x86_64/foreman-release.rpm
 yum -y localinstall http://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
 {% endhighlight %}
 </div>
@@ -54,8 +55,8 @@ yum-config-manager --enable rhel-7-server-extras-rpms
 
 <div id="el7" style="display: none;" markdown="1">
 {% highlight bash %}
-yum -y localinstall http://fedorapeople.org/groups/katello/releases/yum/{{ site.version }}/katello/el7/x86_64/katello-repos-latest.rpm
-yum -y localinstall http://yum.theforeman.org/releases/{{ site.foreman_version }}/el7/x86_64/foreman-release.rpm
+yum -y localinstall http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el7/x86_64/katello-repos-latest.rpm
+yum -y localinstall http://yum.theforeman.org/releases/{{ page.foreman_version }}/el7/x86_64/foreman-release.rpm
 yum -y localinstall http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 {% endhighlight %}
 </div>

--- a/plugins/katello/nightly/installation/index.md
+++ b/plugins/katello/nightly/installation/index.md
@@ -15,7 +15,7 @@ script: osmenu.js
   </div>
 {% elsif page.version != page.latest %}
   <div class="alert alert-danger">
-    These instructions are for installing Katello {{ page.version }}, but the latest stable is <a href="/plugins/katello/{{ page.latest }}/installation/index.html">{{ page.latest }}</a>.
+    These instructions are for installing Katello {{ page.version }}, but the latest stable is <a href="/plugins/katello/{{ site.latest }}/installation/index.html">{{ site.latest }}</a>.
   </div>
 {% endif %}
 

--- a/plugins/katello/nightly/user_guide/capsules/index.md
+++ b/plugins/katello/nightly/user_guide/capsules/index.md
@@ -39,7 +39,7 @@ In the simplest use case, a user may only want to use the Default Capsule. Large
 
 ## Installation
 
-See [Capsule Installation](/plugins/katello/{{ site.version }}/installation/capsule.html)
+See [Capsule Installation](/plugins/katello/{{ page.version }}/installation/capsule.html)
 
 ## Removal
 
@@ -95,7 +95,7 @@ Required Connectivity:
 
 ### 4 - Subscription Management
 
-Content Hosts utilize [Subscription Manager](/plugins/katello/{{ site.version }}/user_guide/content_hosts/index.html#how-is-a-content-host-registered) for registration to Katello and enabling/disabling specific repositories.
+Content Hosts utilize [Subscription Manager](/plugins/katello/{{ page.version }}/user_guide/content_hosts/index.html#how-is-a-content-host-registered) for registration to Katello and enabling/disabling specific repositories.
 
 Install Option:
 

--- a/plugins/katello/nightly/user_guide/hammer.md
+++ b/plugins/katello/nightly/user_guide/hammer.md
@@ -18,7 +18,7 @@ Katello via HTTP or HTTPS.
 
 ### Remote install
 
-Install the prerequisite repositories [as per our installation guide](/plugins/katello/{{ site.version }}/installation/index.html#required-repositories).
+Install the prerequisite repositories [as per our installation guide](/plugins/katello/{{ page.version }}/installation/index.html#required-repositories).
 
 Now install the hammer-cli-katello package:
 

--- a/plugins/katello/nightly/user_guide/lifecycle_environments/index.md
+++ b/plugins/katello/nightly/user_guide/lifecycle_environments/index.md
@@ -21,7 +21,7 @@ What can a Lifecycle Environments be used for?
 ## General Workflow
 
 First create a lifecycle environment connected to the library life cycle environment and promote content views to the new lifecycle environment.
-A [Content Host](/plugins/katello/{{ site.version }}/user_guide/content_hosts/index.html) can now register directly to the promoted content view in the promoted environment or library therein.  Updates will be available as soon as new content is synced and promoted.
+A [Content Host](/plugins/katello/{{ page.version }}/user_guide/content_hosts/index.html) can now register directly to the promoted content view in the promoted environment or library therein.  Updates will be available as soon as new content is synced and promoted.
 
 
 ## Viewing the list of lifecycle environments


### PR DESCRIPTION
Many links are broken because we aren't using the variables from the `page` instead of the `site`