### PR TITLE
[WIP] Removed broken 'jump to content' links

### DIFF
--- a/plugins/katello/2.4/installation/capsule.md
+++ b/plugins/katello/2.4/installation/capsule.md
@@ -71,7 +71,7 @@ Installing             Done                     [100%] [.....................]
 
 ### Install needed packages:
 
-The same yum repositories need to be configured on the Capsule server as the main Katello server. See the installation guide for the [list of required repositories](/docs/{{ site.version }}/installation/index.html#required-repositories).
+The same yum repositories need to be configured on the Capsule server as the main Katello server. See the installation guide for the [list of required repositories](/docs/{{ site.version }}/installation/index.html).
 
 ```
 yum install -y capsule-installer
@@ -81,4 +81,4 @@ yum install -y capsule-installer
 
 Use the provide installation command from `capsule-certs-generate`, and tailor for your own purposes as needed.  The defaults will give you a Capsule ready for Content-related services.
 
-See the [User Guide](/docs/{{ site.version }}/user_guide/capsules/index.html) to learn about setting up provisioning related services, as well as the [Foreman manual](http://theforeman.org/manuals/latest/index.html#4.3SmartProxies)
+See the [User Guide](/plugins/katello/{{ site.version }}/user_guide/capsules/index.html) to learn about setting up provisioning related services, as well as the [Foreman manual](http://theforeman.org/manuals/latest/index.html#4.3SmartProxies)

--- a/plugins/katello/2.4/troubleshooting/index.md
+++ b/plugins/katello/2.4/troubleshooting/index.md
@@ -8,13 +8,6 @@ title: Troubleshooting
 
 For general support information, see [here](/support.html).
 
-## Table of Contents
-
- * [Sub-service Status](/plugins/katello/{{ page.version }}/troubleshooting/index.html#sub-service-status)
- * [Tasks](/plugins/katello/{{ page.version }}/troubleshooting/index.html#tasks)
- * [Debug Certificate](/plugins/katello/{{ page.version }}/troubleshooting/index.html#debug-certificate)
- * [FAQ](/plugins/katello/{{ page.version }}/troubleshooting/index.html#frequently-asked-questions)
-
 ## Sub-services status
 
 Katello uses a set of back-end services to perform the actual job. The status of these services can negatively influence the whole system and it's one of the first things to check when some errors occur.

--- a/plugins/katello/2.4/user_guide/activation_keys/index.md
+++ b/plugins/katello/2.4/user_guide/activation_keys/index.md
@@ -16,7 +16,7 @@ Activation Keys provide a mechanism to define properties that may be applied to 
 
 ## Definitions
 
-- [Content Host](/plugins/katello/{{ page.version }}/user_guide/content_hosts/index.html#what-are-content-hosts)
+- [Content Host](/plugins/katello/{{ page.version }}/user_guide/content_hosts/index.html)
 - Host Collection - A statically defined group of Content Hosts.
 - Subscription - The right to receive the associated content from Katello.
 
@@ -126,6 +126,6 @@ The simplest form of registering a content host with an activation key is this:
 subscription-manager register --org=Default_Organization --activationkey=$KEY_NAME
 ```
 
-[Click here for more information](/plugins/katello/{{ page.version }}/user_guide/content_hosts/index.html#how-is-a-content-host-registered)
+[Click here for more information](/plugins/katello/{{ page.version }}/user_guide/content_hosts/index.html)
 
 Note that modifying an activation key does not change anything on content hosts previously registered with the key.

--- a/plugins/katello/2.4/user_guide/capsules/index.md
+++ b/plugins/katello/2.4/user_guide/capsules/index.md
@@ -95,7 +95,7 @@ Required Connectivity:
 
 ### 4 - Subscription Management
 
-Content Hosts utilize [Subscription Manager](/plugins/katello/{{ page.version }}/user_guide/content_hosts/index.html#how-is-a-content-host-registered) for registration to Katello and enabling/disabling specific repositories.
+Content Hosts utilize [Subscription Manager](/plugins/katello/{{ page.version }}/user_guide/content_hosts/index.html) for registration to Katello and enabling/disabling specific repositories.
 
 Install Option:
 

--- a/plugins/katello/2.4/user_guide/content_views/index.md
+++ b/plugins/katello/2.4/user_guide/content_views/index.md
@@ -25,7 +25,7 @@ What can a Content View be used for?
 
 ## General Workflow
 
-First [create a product and repository](/plugins/katello/{{ page.version }}/user_guide/content/content.html#creating-a-product) in the library environment and populate the repository with content (by syncing it or uploading content).
+First [create a product and repository](/plugins/katello/{{ page.version }}/user_guide/content/content.html).
 A [Content Host](/plugins/katello/{{ page.version }}/user_guide/content_hosts/index.html) can now register directly to library and be attached to the content therein.  Updates will be available as soon as new content is synced or uploaded.
 
 To utilize Content Views for filtering and snapshoting:
@@ -77,7 +77,7 @@ hammer content-view create \
 ## Adding Repositories
 
 Adding a repository to a Content View means whenever a Content View is published, all of the content contained within the repository at that time is included in the Content View.
-If the [repository is synced](/plugins/katello/{{ page.version }}/user_guide/content/content.html#syncing-a-repository) after publishing the Content View, the Content View will contain the state of the repository prior to syncing.
+If the [repository is synced](/plugins/katello/{{ page.version }}/user_guide/content/content.html) after publishing the Content View, the Content View will contain the state of the repository prior to syncing.
 A new version of the Content View must be published in order for the new version to get the contents of the newly synced repository.
 
 To add a repository using the web UI, navigate to:

--- a/plugins/katello/2.4/user_guide/disconnected/index.md
+++ b/plugins/katello/2.4/user_guide/disconnected/index.md
@@ -50,7 +50,7 @@ DESCRIPTION
 
 To start with *katello-disconnected* there are a series of steps you need to take to get it installed and configured. The installation should take place on your Synchronization Server seen above.  This system is the one that has access to the internet and Red Hat's CDN servers.  These instructions point at the ''katello nightly'' builds but you can substitute this for the latest stable version of Katello if you desire.
 
-**1)** Configure repositories on your Synchronization Server [as per our installation guide](/plugins/katello/{{ page.version }}/installation/index.html#required-repositories).
+**1)** Configure repositories on your Synchronization Server [as per our installation guide](/plugins/katello/{{ page.version }}/installation/index.html).
 
 **2)** Install katello-utils and associated RPMs:
 

--- a/plugins/katello/2.4/user_guide/errata/index.md
+++ b/plugins/katello/2.4/user_guide/errata/index.md
@@ -19,7 +19,7 @@ With regard to Content Hosts, Errata is divided into two distinct classification
 
 ## Definitions
 
-- [Content Host](/plugins/katello/{{ page.version }}/user_guide/content_hosts/index.html#what-are-content-hosts)
+- [Content Host](/plugins/katello/{{ page.version }}/user_guide/content_hosts/index.html)
 - [Content View](/plugins/katello/{{ page.version }}/user_guide/content_views/content_views.html)
 - [Lifecycle Environment](/plugins/katello/{{ page.version }}/user_guide/lifecycle_environments/environment.html)
 

--- a/plugins/katello/2.4/user_guide/hammer.md
+++ b/plugins/katello/2.4/user_guide/hammer.md
@@ -12,7 +12,7 @@ Katello via HTTP or HTTPS.
 
 ### Remote install
 
-Install the prerequisite repositories [as per our installation guide](/docs/{{ site.version }}/installation/index.html#required-repositories).
+Install the prerequisite repositories [as per our installation guide](/docs/{{ site.version }}/installation/index.html).
 
 Now install the hammer-cli-katello package:
 

--- a/plugins/katello/2.4/user_guide/host_collections/index.md
+++ b/plugins/katello/2.4/user_guide/host_collections/index.md
@@ -16,7 +16,7 @@ Once a Host Collection is created, it can be used to perform various actions on 
 
 ## Definitions
 
-- [Content Host](/plugins/katello/{{ page.version }}/user_guide/host_collections./content_hosts/index.html#what-are-content-hosts)
+- [Content Host](/plugins/katello/{{ page.version }}/user_guide/host_collections./content_hosts/index.html)
 
 ## General Features
 
@@ -78,4 +78,4 @@ To perform an action on Content Hosts within a collection:
 
 ![Host collection actions](/plugins/katello/{{ page.version }}/user_guide/host_collections/host_collection_actions.png)
 
-Note: clicking on an action will take the user to the appropriate Content Hosts Bulk Actions page, where all Content Hosts associated with the collection have been selected.  [Click here, for more information on performing Content Host Bulk Actions](/plugins/katello/{{ page.version }}/user_guide/host_collections./content_hosts/index.html#bulk-actions)
+Note: clicking on an action will take the user to the appropriate Content Hosts Bulk Actions page, where all Content Hosts associated with the collection have been selected.  [Click here, for more information on performing Content Host Bulk Actions](/plugins/katello/{{ page.version }}/user_guide/host_collections./content_hosts/index.html)

--- a/plugins/katello/2.4/user_guide/puppet_integration/index.md
+++ b/plugins/katello/2.4/user_guide/puppet_integration/index.md
@@ -7,7 +7,7 @@ title: Puppet Integration
 # Managing Puppet Content
 
 ### Importing the Puppet Forge
-The [Puppet Forge](https://forge.puppetlabs.com/) is a collection of puppet modules written by the community which can be used to manage hosts in Katello. These modules can be used in content views as described in the [content views guide](/plugins/katello/{{ page.version }}/user_guide/content_views/content_views.html#adding-a-puppet-module) in order to configure the running hosts.
+The [Puppet Forge](https://forge.puppetlabs.com/) is a collection of puppet modules written by the community which can be used to manage hosts in Katello. These modules can be used in content views as described in the [content views guide](/plugins/katello/{{ page.version }}/user_guide/content_views/content_views.html) in order to configure the running hosts.
 
 To import the puppet forge navigate to
 
@@ -36,7 +36,7 @@ hammer repository create
 
 ```
 
-The repository can [now be synced](/plugins/katello/{{ page.version }}/user_guide/content/content.html#syncing-a-repository).
+The repository can [now be synced](/plugins/katello/{{ page.version }}/user_guide/content/content.html).
 
 ### Importing Puppet Modules from Git
 

--- a/plugins/katello/3.0/installation/capsule.md
+++ b/plugins/katello/3.0/installation/capsule.md
@@ -70,7 +70,7 @@ Installing             Done                     [100%] [.....................]
 
 ### Install needed packages:
 
-The same yum repositories need to be configured on the Capsule server as the main Katello server. See the installation guide for the [list of required repositories](/plugins/katello/{{ page.version }}/installation/index.html#required-repositories).
+The same yum repositories need to be configured on the Capsule server as the main Katello server. See the installation guide for the [list of required repositories](/plugins/katello/{{ page.version }}/installation/index.html).
 
 {% highlight bash %}
 yum install -y foreman-installer-katello

--- a/plugins/katello/3.0/troubleshooting/index.md
+++ b/plugins/katello/3.0/troubleshooting/index.md
@@ -8,13 +8,6 @@ title: Troubleshooting
 
 For general support information, see [here](/support.html).
 
-## Table of Contents
-
- * [Sub-service Status](/plugins/katello/{{ page.version }}/troubleshooting/index.html#sub-service-status)
- * [Tasks](/plugins/katello/{{ page.version }}/troubleshooting/index.html#tasks)
- * [Debug Certificate](/plugins/katello/{{ page.version }}/troubleshooting/index.html#debug-certificate)
- * [FAQ](/plugins/katello/{{ page.version }}/troubleshooting/index.html#frequently-asked-questions)
-
 ## Sub-services status
 
 Katello uses a set of back-end services to perform the actual job. The status of these services can negatively influence the whole system and it's one of the first things to check when some errors occur.

--- a/plugins/katello/3.0/user_guide/activation_keys/index.md
+++ b/plugins/katello/3.0/user_guide/activation_keys/index.md
@@ -16,7 +16,7 @@ Activation Keys provide a mechanism to define properties that may be applied to 
 
 ## Definitions
 
-- [Content Host](plugins/katello/{{ page.version }}/user_guide/content_hosts/index.html#what-are-content-hosts)
+- [Content Host](plugins/katello/{{ page.version }}/user_guide/content_hosts/index.html)
 - Host Collection - A statically defined group of Content Hosts.
 - Subscription - The right to receive the associated content from Katello.
 
@@ -126,6 +126,6 @@ The simplest form of registering a content host with an activation key is this:
 subscription-manager register --org=Default_Organization --activationkey=$KEY_NAME
 ```
 
-[Click here for more information](plugins/katello/{{ page.version }}/user_guide/content_hosts/index.html#how-is-a-content-host-registered)
+[Click here for more information](plugins/katello/{{ page.version }}/user_guide/content_hosts/index.html)
 
 Note that modifying an activation key does not change anything on content hosts previously registered with the key.

--- a/plugins/katello/3.0/user_guide/capsules/index.md
+++ b/plugins/katello/3.0/user_guide/capsules/index.md
@@ -95,7 +95,7 @@ Required Connectivity:
 
 ### 4 - Subscription Management
 
-Content Hosts utilize [Subscription Manager](/plugins/katello/{{ page.version }}/user_guide/content_hosts/index.html#how-is-a-content-host-registered) for registration to Katello and enabling/disabling specific repositories.
+Content Hosts utilize [Subscription Manager](/plugins/katello/{{ page.version }}/user_guide/content_hosts/index.html) for registration to Katello and enabling/disabling specific repositories.
 
 Install Option:
 

--- a/plugins/katello/3.0/user_guide/content_views/index.md
+++ b/plugins/katello/3.0/user_guide/content_views/index.md
@@ -24,7 +24,7 @@ What can a Content View be used for?
 
 ## General Workflow
 
-First [create a product and repository](/plugins/katello/{{ page.version }}/user_guide/content/content.html#creating-a-product) in the library environment and populate the repository with content (by syncing it or uploading content).
+First [create a product and repository](/plugins/katello/{{ page.version }}/user_guide/content/content.html).
 A [Content Host](/plugins/katello/{{ page.version }}/user_guide/content_hosts/index.html) can now register directly to library and be attached to the content therein.  Updates will be available as soon as new content is synced or uploaded.
 
 To utilize Content Views for filtering and snapshoting:
@@ -76,7 +76,7 @@ hammer content-view create \
 ## Adding Repositories
 
 Adding a repository to a Content View means whenever a Content View is published, all of the content contained within the repository at that time is included in the Content View.
-If the [repository is synced](/plugins/katello/{{ page.version }}/user_guide/content_views/plugins/katello/{{ page.version }}/user_guide/content/content.html#syncing-a-repository) after publishing the Content View, the Content View will contain the state of the repository prior to syncing.
+If the [repository is synced](/plugins/katello/{{ page.version }}/user_guide/content_views/plugins/katello/{{ page.version }}/user_guide/content/content.html) after publishing the Content View, the Content View will contain the state of the repository prior to syncing.
 A new version of the Content View must be published in order for the new version to get the contents of the newly synced repository.
 
 To add a repository using the web UI, navigate to:

--- a/plugins/katello/3.0/user_guide/errata/index.md
+++ b/plugins/katello/3.0/user_guide/errata/index.md
@@ -19,7 +19,7 @@ With regard to Content Hosts, Errata is divided into two distinct classification
 
 ## Definitions
 
-- [Content Host](plugins/katello/{{ page.version }}/user_guide/content_hosts/index.html#what-are-content-hosts)
+- [Content Host](plugins/katello/{{ page.version }}/user_guide/content_hosts/index.html)
 - [Content View](plugins/katello/{{ page.version }}/user_guide/content_views/content_views.html)
 - [Lifecycle Environment](plugins/katello/{{ page.version }}/user_guide/lifecycle_environments/environment.html)
 

--- a/plugins/katello/3.0/user_guide/hammer.md
+++ b/plugins/katello/3.0/user_guide/hammer.md
@@ -18,7 +18,7 @@ Katello via HTTP or HTTPS.
 
 ### Remote install
 
-Install the prerequisite repositories [as per our installation guide](/plugins/katello/{{ page.version }}/installation/index.html#required-repositories).
+Install the prerequisite repositories [as per our installation guide](/plugins/katello/{{ page.version }}/installation/index.html).
 
 Now install the hammer-cli-katello package:
 

--- a/plugins/katello/3.0/user_guide/host_collections/index.md
+++ b/plugins/katello/3.0/user_guide/host_collections/index.md
@@ -16,7 +16,7 @@ Once a Host Collection is created, it can be used to perform various actions on 
 
 ## Definitions
 
-- [Content Host](plugins/katello/{{ page.version }}/user_guide/content_hosts/index.html#what-are-content-hosts)
+- [Content Host](plugins/katello/{{ page.version }}/user_guide/content_hosts/index.html)
 
 ## General Features
 
@@ -78,4 +78,4 @@ To perform an action on Content Hosts within a collection:
 
 ![Host collection actions](/plugins/katello/{{ page.version }}/user_guide/host_collections/host_collection_actions.png)
 
-Note: clicking on an action will take the user to the appropriate Content Hosts Bulk Actions page, where all Content Hosts associated with the collection have been selected.  [Click here, for more information on performing Content Host Bulk Actions](plugins/katello/{{ page.version }}/user_guide/content_hosts/index.html#bulk-actions)
+Note: clicking on an action will take the user to the appropriate Content Hosts Bulk Actions page, where all Content Hosts associated with the collection have been selected.  [Click here, for more information on performing Content Host Bulk Actions](plugins/katello/{{ page.version }}/user_guide/content_hosts/index.html)

--- a/plugins/katello/3.0/user_guide/puppet_integration/index.md
+++ b/plugins/katello/3.0/user_guide/puppet_integration/index.md
@@ -7,7 +7,7 @@ title: Puppet Integration
 # Managing Puppet Content
 
 ### Importing the Puppet Forge
-The [Puppet Forge](https://forge.puppetlabs.com/) is a collection of puppet modules written by the community which can be used to manage hosts in Katello. These modules can be used in content views as described in the [content views guide](/plugins/katello/{{ page.version }}/user_guide/content_views/content_views.html#adding-a-puppet-module) in order to configure the running hosts.
+The [Puppet Forge](https://forge.puppetlabs.com/) is a collection of puppet modules written by the community which can be used to manage hosts in Katello. These modules can be used in content views as described in the [content views guide](/plugins/katello/{{ page.version }}/user_guide/content_views/content_views.html) in order to configure the running hosts.
 
 To import the puppet forge navigate to
 
@@ -36,7 +36,7 @@ hammer repository create
 
 ```
 
-The repository can [now be synced](/plugins/katello/{{ page.version }}/user_guide/content/content.html#syncing-a-repository).
+The repository can [now be synced](/plugins/katello/{{ page.version }}/user_guide/content/content.html).
 
 ### Importing Puppet Modules from Git
 

--- a/plugins/katello/3.1/installation/capsule.md
+++ b/plugins/katello/3.1/installation/capsule.md
@@ -30,7 +30,7 @@ See the [User Guide](/plugins/katello/{{ page.version }}/user_guide/capsules/ind
 
 ### Install needed packages:
 
-The same yum repositories need to be configured on the Capsule server as the main Katello server. See the installation guide for the [list of required repositories](/plugins/katello/{{ page.version }}/installation/index.html#required-repositories).
+The same yum repositories need to be configured on the Capsule server as the main Katello server. See the installation guide for the [list of required repositories](/plugins/katello/{{ page.version }}/installation/index.html).
 
 Once you get the repositories configured, install the foreman-installer-katello package on the capsule
 

--- a/plugins/katello/3.1/troubleshooting/index.md
+++ b/plugins/katello/3.1/troubleshooting/index.md
@@ -8,13 +8,6 @@ title: Troubleshooting
 
 For general support information, see [here](/support.html).
 
-## Table of Contents
-
- * [Sub-service Status](/plugins/katello/{{ page.version }}/troubleshooting/index.html#sub-service-status)
- * [Tasks](/plugins/katello/{{ page.version }}/troubleshooting/index.html#tasks)
- * [Debug Certificate](/plugins/katello/{{ page.version }}/troubleshooting/index.html#debug-certificate)
- * [FAQ](/plugins/katello/{{ page.version }}/troubleshooting/index.html#frequently-asked-questions)
-
 ## Sub-services status
 
 Katello uses a set of back-end services to perform the actual job. The status of these services can negatively influence the whole system and it's one of the first things to check when some errors occur.

--- a/plugins/katello/3.1/user_guide/activation_keys/index.md
+++ b/plugins/katello/3.1/user_guide/activation_keys/index.md
@@ -16,7 +16,7 @@ Activation Keys provide a mechanism to define properties that may be applied to 
 
 ## Definitions
 
-- [Content Host](/plugins/katello/{{ page.version }}/user_guide/content_hosts/index.html#what-are-content-hosts)
+- [Content Host](/plugins/katello/{{ page.version }}/user_guide/content_hosts/index.html)
 - Host Collection - A statically defined group of Content Hosts.
 - Subscription - The right to receive the associated content from Katello.
 
@@ -126,6 +126,6 @@ The simplest form of registering a content host with an activation key is this:
 subscription-manager register --org=Default_Organization --activationkey=$KEY_NAME
 ```
 
-[Click here for more information](/plugins/katello/{{ page.version }}/user_guide/content_hosts/index.html#how-is-a-content-host-registered)
+[Click here for more information](/plugins/katello/{{ page.version }}/user_guide/content_hosts/index.html)
 
 Note that modifying an activation key does not change anything on content hosts previously registered with the key.

--- a/plugins/katello/3.1/user_guide/capsules/index.md
+++ b/plugins/katello/3.1/user_guide/capsules/index.md
@@ -95,7 +95,7 @@ Required Connectivity:
 
 ### 4 - Subscription Management
 
-Content Hosts utilize [Subscription Manager](/plugins/katello/{{ site.version }}/user_guide/content_hosts/index.html#how-is-a-content-host-registered) for registration to Katello and enabling/disabling specific repositories.
+Content Hosts utilize [Subscription Manager](/plugins/katello/{{ site.version }}/user_guide/content_hosts/index.html) for registration to Katello and enabling/disabling specific repositories.
 
 Install Option:
 

--- a/plugins/katello/3.1/user_guide/content_views/index.md
+++ b/plugins/katello/3.1/user_guide/content_views/index.md
@@ -24,7 +24,7 @@ What can a Content View be used for?
 
 ## General Workflow
 
-First [create a product and repository](/plugins/katello/{{ page.version }}/user_guide/content/content.html#creating-a-product) in the library environment and populate the repository with content (by syncing it or uploading content).
+First [create a product and repository](/plugins/katello/{{ page.version }}/user_guide/content/content.html).
 A [Content Host](/plugins/katello/{{ page.version }}/user_guide/content_hosts/index.html) can now register directly to library and be attached to the content therein.  Updates will be available as soon as new content is synced or uploaded.
 
 To utilize Content Views for filtering and snapshoting:
@@ -76,7 +76,7 @@ hammer content-view create \
 ## Adding Repositories
 
 Adding a repository to a Content View means whenever a Content View is published, all of the content contained within the repository at that time is included in the Content View.
-If the [repository is synced](/plugins/katello/{{ page.version }}/user_guide/content/content.html#syncing-a-repository) after publishing the Content View, the Content View will contain the state of the repository prior to syncing.
+If the [repository is synced](/plugins/katello/{{ page.version }}/user_guide/content/content.html) after publishing the Content View, the Content View will contain the state of the repository prior to syncing.
 A new version of the Content View must be published in order for the new version to get the contents of the newly synced repository.
 
 To add a repository using the web UI, navigate to:

--- a/plugins/katello/3.1/user_guide/errata/index.md
+++ b/plugins/katello/3.1/user_guide/errata/index.md
@@ -19,7 +19,7 @@ With regard to Content Hosts, Errata is divided into two distinct classification
 
 ## Definitions
 
-- [Content Host](/plugins/katello/{{ page.version }}/user_guide/content_hosts/index.html#what-are-content-hosts)
+- [Content Host](/plugins/katello/{{ page.version }}/user_guide/content_hosts/index.html)
 - [Content View](/plugins/katello/{{ page.version }}/user_guide/content_views/content_views.html)
 - [Lifecycle Environment](/plugins/katello/{{ page.version }}/user_guide/lifecycle_environments/environment.html)
 

--- a/plugins/katello/3.1/user_guide/hammer.md
+++ b/plugins/katello/3.1/user_guide/hammer.md
@@ -12,7 +12,7 @@ Katello via HTTP or HTTPS.
 
 ### Remote install
 
-Install the prerequisite repositories [as per our installation guide](/plugins/katello/{{ site.version }}/installation/index.html#required-repositories).
+Install the prerequisite repositories [as per our installation guide](/plugins/katello/{{ site.version }}/installation/index.html).
 
 Now install the hammer-cli-katello package:
 

--- a/plugins/katello/3.1/user_guide/host_collections/index.md
+++ b/plugins/katello/3.1/user_guide/host_collections/index.md
@@ -16,7 +16,7 @@ Once a Host Collection is created, it can be used to perform various actions on 
 
 ## Definitions
 
-- [Content Host](/plugins/katello/{{ page.version }}/user_guide/content_hosts/index.html#what-are-content-hosts)
+- [Content Host](/plugins/katello/{{ page.version }}/user_guide/content_hosts/index.html)
 
 ## General Features
 
@@ -78,4 +78,4 @@ To perform an action on Content Hosts within a collection:
 
 ![Host collection actions](/plugins/katello/{{ page.version }}/user_guide/host_collections/host_collection_actions.png)
 
-Note: clicking on an action will take the user to the appropriate Content Hosts Bulk Actions page, where all Content Hosts associated with the collection have been selected.  [Click here, for more information on performing Content Host Bulk Actions](/plugins/katello/{{ page.version }}/user_guide/content_hosts/index.html#bulk-actions)
+Note: clicking on an action will take the user to the appropriate Content Hosts Bulk Actions page, where all Content Hosts associated with the collection have been selected.  [Click here, for more information on performing Content Host Bulk Actions](/plugins/katello/{{ page.version }}/user_guide/content_hosts/index.html)

--- a/plugins/katello/3.1/user_guide/puppet_integration/index.md
+++ b/plugins/katello/3.1/user_guide/puppet_integration/index.md
@@ -7,7 +7,7 @@ version: 3.1
 # Managing Puppet Content
 
 ### Importing the Puppet Forge
-The [Puppet Forge](https://forge.puppetlabs.com/) is a collection of puppet modules written by the community which can be used to manage hosts in Katello. These modules can be used in content views as described in the [content views guide](/plugins/katello/{{ page.version }}/user_guide/content_views/content_views.html#adding-a-puppet-module) in order to configure the running hosts.
+The [Puppet Forge](https://forge.puppetlabs.com/) is a collection of puppet modules written by the community which can be used to manage hosts in Katello. These modules can be used in content views as described in the [content views guide](/plugins/katello/{{ page.version }}/user_guide/content_views/content_views.html) in order to configure the running hosts.
 
 To import the puppet forge navigate to
 
@@ -36,7 +36,7 @@ hammer repository create
 
 ```
 
-The repository can [now be synced](/plugins/katello/{{ page.version }}/user_guide/content/content.html#syncing-a-repository).
+The repository can [now be synced](/plugins/katello/{{ page.version }}/user_guide/content/content.html).
 
 ### Importing Puppet Modules from Git
 

--- a/plugins/katello/3.2/installation/capsule.md
+++ b/plugins/katello/3.2/installation/capsule.md
@@ -30,7 +30,7 @@ See the [User Guide](/plugins/katello/{{ page.version }}/user_guide/capsules/ind
 
 ### Install needed packages:
 
-The same yum repositories need to be configured on the Capsule server as the main Katello server. See the installation guide for the [list of required repositories](/plugins/katello/{{ page.version }}/installation/index.html#required-repositories).
+The same yum repositories need to be configured on the Capsule server as the main Katello server. See the installation guide for the [list of required repositories](/plugins/katello/{{ page.version }}/installation/index.html).
 
 Once you get the repositories configured, install the katello-capsule package on the capsule
 

--- a/plugins/katello/3.2/troubleshooting/index.md
+++ b/plugins/katello/3.2/troubleshooting/index.md
@@ -8,13 +8,6 @@ title: Troubleshooting
 
 For general support information, see [here](/support.html).
 
-## Table of Contents
-
- * [Sub-service Status](/plugins/katello/{{ page.version }}/troubleshooting/index.html#sub-service-status)
- * [Tasks](/plugins/katello/{{ page.version }}/troubleshooting/index.html#tasks)
- * [Debug Certificate](/plugins/katello/{{ page.version }}/troubleshooting/index.html#debug-certificate)
- * [FAQ](/plugins/katello/{{ page.version }}/troubleshooting/index.html#frequently-asked-questions)
-
 ## Sub-services status
 
 Katello uses a set of back-end services to perform the actual job. The status of these services can negatively influence the whole system and it's one of the first things to check when some errors occur.

--- a/plugins/katello/3.2/user_guide/activation_keys/index.md
+++ b/plugins/katello/3.2/user_guide/activation_keys/index.md
@@ -16,7 +16,7 @@ Activation Keys provide a mechanism to define properties that may be applied to 
 
 ## Definitions
 
-- [Content Host](/plugins/katello/{{ page.version }}/user_guide/content_hosts/index.html#what-are-content-hosts)
+- [Content Host](/plugins/katello/{{ page.version }}/user_guide/content_hosts/index.html)
 - Host Collection - A statically defined group of Content Hosts.
 - Subscription - The right to receive the associated content from Katello.
 
@@ -126,6 +126,6 @@ The simplest form of registering a content host with an activation key is this:
 subscription-manager register --org=Default_Organization --activationkey=$KEY_NAME
 ```
 
-[Click here for more information](/plugins/katello/{{ page.version }}/user_guide/content_hosts/index.html#how-is-a-content-host-registered)
+[Click here for more information](/plugins/katello/{{ page.version }}/user_guide/content_hosts/index.html)
 
 Note that modifying an activation key does not change anything on content hosts previously registered with the key.

--- a/plugins/katello/3.2/user_guide/capsules/index.md
+++ b/plugins/katello/3.2/user_guide/capsules/index.md
@@ -95,7 +95,7 @@ Required Connectivity:
 
 ### 4 - Subscription Management
 
-Content Hosts utilize [Subscription Manager](/plugins/katello/{{ site.version }}/user_guide/content_hosts/index.html#how-is-a-content-host-registered) for registration to Katello and enabling/disabling specific repositories.
+Content Hosts utilize [Subscription Manager](/plugins/katello/{{ site.version }}/user_guide/content_hosts/index.html) for registration to Katello and enabling/disabling specific repositories.
 
 Install Option:
 

--- a/plugins/katello/3.2/user_guide/content_views/index.md
+++ b/plugins/katello/3.2/user_guide/content_views/index.md
@@ -24,7 +24,7 @@ What can a Content View be used for?
 
 ## General Workflow
 
-First [create a product and repository](/plugins/katello/{{ page.version }}/user_guide/content/content.html#creating-a-product) in the library environment and populate the repository with content (by syncing it or uploading content).
+First [create a product and repository](/plugins/katello/{{ page.version }}/user_guide/content/content.html).
 A [Content Host](/plugins/katello/{{ page.version }}/user_guide/content_hosts/index.html) can now register directly to library and be attached to the content therein.  Updates will be available as soon as new content is synced or uploaded.
 
 To utilize Content Views for filtering and snapshoting:
@@ -76,7 +76,7 @@ hammer content-view create \
 ## Adding Repositories
 
 Adding a repository to a Content View means whenever a Content View is published, all of the content contained within the repository at that time is included in the Content View.
-If the [repository is synced](/plugins/katello/{{ page.version }}/user_guide/content/content.html#syncing-a-repository) after publishing the Content View, the Content View will contain the state of the repository prior to syncing.
+If the [repository is synced](/plugins/katello/{{ page.version }}/user_guide/content/content.html) after publishing the Content View, the Content View will contain the state of the repository prior to syncing.
 A new version of the Content View must be published in order for the new version to get the contents of the newly synced repository.
 
 To add a repository using the web UI, navigate to:

--- a/plugins/katello/3.2/user_guide/errata/index.md
+++ b/plugins/katello/3.2/user_guide/errata/index.md
@@ -19,7 +19,7 @@ With regard to Content Hosts, Errata is divided into two distinct classification
 
 ## Definitions
 
-- [Content Host](/plugins/katello/{{ page.version }}/user_guide/content_hosts/index.html#what-are-content-hosts)
+- [Content Host](/plugins/katello/{{ page.version }}/user_guide/content_hosts/index.html)
 - [Content View](/plugins/katello/{{ page.version }}/user_guide/content_views/content_views.html)
 - [Lifecycle Environment](/plugins/katello/{{ page.version }}/user_guide/lifecycle_environments/environment.html)
 

--- a/plugins/katello/3.2/user_guide/hammer.md
+++ b/plugins/katello/3.2/user_guide/hammer.md
@@ -18,7 +18,7 @@ Katello via HTTP or HTTPS.
 
 ### Remote install
 
-Install the prerequisite repositories [as per our installation guide](/plugins/katello/{{ site.version }}/installation/index.html#required-repositories).
+Install the prerequisite repositories [as per our installation guide](/plugins/katello/{{ site.version }}/installation/index.html).
 
 Now install the hammer-cli-katello package:
 

--- a/plugins/katello/3.2/user_guide/host_collections/index.md
+++ b/plugins/katello/3.2/user_guide/host_collections/index.md
@@ -16,7 +16,7 @@ Once a Host Collection is created, it can be used to perform various actions on 
 
 ## Definitions
 
-- [Content Host](/plugins/katello/{{ page.version }}/user_guide/content_hosts/index.html#what-are-content-hosts)
+- [Content Host](/plugins/katello/{{ page.version }}/user_guide/content_hosts/index.html)
 
 ## General Features
 
@@ -78,4 +78,4 @@ To perform an action on Content Hosts within a collection:
 
 ![Host collection actions](/plugins/katello/{{ page.version }}/user_guide/host_collections/host_collection_actions.png)
 
-Note: clicking on an action will take the user to the appropriate Content Hosts Bulk Actions page, where all Content Hosts associated with the collection have been selected.  [Click here, for more information on performing Content Host Bulk Actions](/plugins/katello/{{ page.version }}/user_guide/content_hosts/index.html#bulk-actions)
+Note: clicking on an action will take the user to the appropriate Content Hosts Bulk Actions page, where all Content Hosts associated with the collection have been selected.  [Click here, for more information on performing Content Host Bulk Actions](/plugins/katello/{{ page.version }}/user_guide/content_hosts/index.html)

--- a/plugins/katello/3.2/user_guide/puppet_integration/index.md
+++ b/plugins/katello/3.2/user_guide/puppet_integration/index.md
@@ -7,7 +7,7 @@ version: 3.2
 # Managing Puppet Content
 
 ### Importing the Puppet Forge
-The [Puppet Forge](https://forge.puppetlabs.com/) is a collection of puppet modules written by the community which can be used to manage hosts in Katello. These modules can be used in content views as described in the [content views guide](/plugins/katello/{{ page.version }}/user_guide/content_views/content_views.html#adding-a-puppet-module) in order to configure the running hosts.
+The [Puppet Forge](https://forge.puppetlabs.com/) is a collection of puppet modules written by the community which can be used to manage hosts in Katello. These modules can be used in content views as described in the [content views guide](/plugins/katello/{{ page.version }}/user_guide/content_views/content_views.html) in order to configure the running hosts.
 
 To import the puppet forge navigate to
 
@@ -36,7 +36,7 @@ hammer repository create
 
 ```
 
-The repository can [now be synced](/plugins/katello/{{ page.version }}/user_guide/content/content.html#syncing-a-repository).
+The repository can [now be synced](/plugins/katello/{{ page.version }}/user_guide/content/content.html).
 
 ### Importing Puppet Modules from Git
 

--- a/plugins/katello/nightly/installation/capsule.md
+++ b/plugins/katello/nightly/installation/capsule.md
@@ -30,7 +30,7 @@ See the [User Guide](/plugins/katello/{{ page.version }}/user_guide/capsules/ind
 
 ### Install needed packages:
 
-The same yum repositories need to be configured on the Capsule server as the main Katello server. See the installation guide for the [list of required repositories](/plugins/katello/{{ page.version }}/installation/index.html#required-repositories).
+The same yum repositories need to be configured on the Capsule server as the main Katello server. See the installation guide for the [list of required repositories](/plugins/katello/{{ page.version }}/installation/index.html).
 
 Once you get the repositories configured, install the katello-capsule package on the capsule
 

--- a/plugins/katello/nightly/user_guide/activation_keys/index.md
+++ b/plugins/katello/nightly/user_guide/activation_keys/index.md
@@ -16,7 +16,7 @@ Activation Keys provide a mechanism to define properties that may be applied to 
 
 ## Definitions
 
-- [Content Host](/plugins/katello/{{ page.version }}/user_guide/content_hosts/index.html#what-are-content-hosts)
+- [Content Host](/plugins/katello/{{ page.version }}/user_guide/content_hosts/index.html)
 - Host Collection - A statically defined group of Content Hosts.
 - Subscription - The right to receive the associated content from Katello.
 
@@ -126,6 +126,6 @@ The simplest form of registering a content host with an activation key is this:
 subscription-manager register --org=Default_Organization --activationkey=$KEY_NAME
 ```
 
-[Click here for more information](/plugins/katello/{{ page.version }}/user_guide/content_hosts/index.html#how-is-a-content-host-registered)
+[Click here for more information](/plugins/katello/{{ page.version }}/user_guide/content_hosts/index.html)
 
 Note that modifying an activation key does not change anything on content hosts previously registered with the key.

--- a/plugins/katello/nightly/user_guide/capsules/index.md
+++ b/plugins/katello/nightly/user_guide/capsules/index.md
@@ -95,7 +95,7 @@ Required Connectivity:
 
 ### 4 - Subscription Management
 
-Content Hosts utilize [Subscription Manager](/plugins/katello/{{ site.version }}/user_guide/content_hosts/index.html#how-is-a-content-host-registered) for registration to Katello and enabling/disabling specific repositories.
+Content Hosts utilize [Subscription Manager](/plugins/katello/{{ site.version }}/user_guide/content_hosts/index.html) for registration to Katello and enabling/disabling specific repositories.
 
 Install Option:
 

--- a/plugins/katello/nightly/user_guide/content_views/index.md
+++ b/plugins/katello/nightly/user_guide/content_views/index.md
@@ -24,7 +24,7 @@ What can a Content View be used for?
 
 ## General Workflow
 
-First [create a product and repository](/plugins/katello/{{ page.version }}/user_guide/content/content.html#creating-a-product) in the library environment and populate the repository with content (by syncing it or uploading content).
+First [create a product and repository](/plugins/katello/{{ page.version }}/user_guide/content/content.html).
 A [Content Host](/plugins/katello/{{ page.version }}/user_guide/content_hosts/index.html) can now register directly to library and be attached to the content therein.  Updates will be available as soon as new content is synced or uploaded.
 
 To utilize Content Views for filtering and snapshoting:
@@ -76,7 +76,7 @@ hammer content-view create \
 ## Adding Repositories
 
 Adding a repository to a Content View means whenever a Content View is published, all of the content contained within the repository at that time is included in the Content View.
-If the [repository is synced](/plugins/katello/{{ page.version }}/user_guide/content/content.html#syncing-a-repository) after publishing the Content View, the Content View will contain the state of the repository prior to syncing.
+If the [repository is synced](/plugins/katello/{{ page.version }}/user_guide/content/content.html) after publishing the Content View, the Content View will contain the state of the repository prior to syncing.
 A new version of the Content View must be published in order for the new version to get the contents of the newly synced repository.
 
 To add a repository using the web UI, navigate to:

--- a/plugins/katello/nightly/user_guide/errata/index.md
+++ b/plugins/katello/nightly/user_guide/errata/index.md
@@ -19,7 +19,7 @@ With regard to Content Hosts, Errata is divided into two distinct classification
 
 ## Definitions
 
-- [Content Host](/plugins/katello/{{ page.version }}/user_guide/content_hosts/index.html#what-are-content-hosts)
+- [Content Host](/plugins/katello/{{ page.version }}/user_guide/content_hosts/index.html)
 - [Content View](/plugins/katello/{{ page.version }}/user_guide/content_views/content_views.html)
 - [Lifecycle Environment](/plugins/katello/{{ page.version }}/user_guide/lifecycle_environments/environment.html)
 

--- a/plugins/katello/nightly/user_guide/hammer.md
+++ b/plugins/katello/nightly/user_guide/hammer.md
@@ -18,7 +18,7 @@ Katello via HTTP or HTTPS.
 
 ### Remote install
 
-Install the prerequisite repositories [as per our installation guide](/plugins/katello/{{ site.version }}/installation/index.html#required-repositories).
+Install the prerequisite repositories [as per our installation guide](/plugins/katello/{{ site.version }}/installation/index.html).
 
 Now install the hammer-cli-katello package:
 

--- a/plugins/katello/nightly/user_guide/host_collections/index.md
+++ b/plugins/katello/nightly/user_guide/host_collections/index.md
@@ -16,7 +16,7 @@ Once a Host Collection is created, it can be used to perform various actions on 
 
 ## Definitions
 
-- [Content Host](/plugins/katello/{{ page.version }}/user_guide/content_hosts/index.html#what-are-content-hosts)
+- [Content Host](/plugins/katello/{{ page.version }}/user_guide/content_hosts/index.html)
 
 ## General Features
 
@@ -78,4 +78,4 @@ To perform an action on Content Hosts within a collection:
 
 ![Host collection actions](/plugins/katello/{{ page.version }}/user_guide/host_collections/host_collection_actions.png)
 
-Note: clicking on an action will take the user to the appropriate Content Hosts Bulk Actions page, where all Content Hosts associated with the collection have been selected.  [Click here, for more information on performing Content Host Bulk Actions](/plugins/katello/{{ page.version }}/user_guide/content_hosts/index.html#bulk-actions)
+Note: clicking on an action will take the user to the appropriate Content Hosts Bulk Actions page, where all Content Hosts associated with the collection have been selected.  [Click here, for more information on performing Content Host Bulk Actions](/plugins/katello/{{ page.version }}/user_guide/content_hosts/index.html)

--- a/plugins/katello/nightly/user_guide/puppet_integration/index.md
+++ b/plugins/katello/nightly/user_guide/puppet_integration/index.md
@@ -7,7 +7,7 @@ version: nightly
 # Managing Puppet Content
 
 ### Importing the Puppet Forge
-The [Puppet Forge](https://forge.puppetlabs.com/) is a collection of puppet modules written by the community which can be used to manage hosts in Katello. These modules can be used in content views as described in the [content views guide](/plugins/katello/{{ page.version }}/user_guide/content_views/content_views.html#adding-a-puppet-module) in order to configure the running hosts.
+The [Puppet Forge](https://forge.puppetlabs.com/) is a collection of puppet modules written by the community which can be used to manage hosts in Katello. These modules can be used in content views as described in the [content views guide](/plugins/katello/{{ page.version }}/user_guide/content_views/content_views.html) in order to configure the running hosts.
 
 To import the puppet forge navigate to
 
@@ -36,7 +36,7 @@ hammer repository create
 
 ```
 
-The repository can [now be synced](/plugins/katello/{{ page.version }}/user_guide/content/content.html#syncing-a-repository).
+The repository can [now be synced](/plugins/katello/{{ page.version }}/user_guide/content/content.html).
 
 ### Importing Puppet Modules from Git
 


### PR DESCRIPTION
The links we had in katello.org that would jump to a part of the page using `#partofpage`, but no longer work the way our docs are in theforeman.org. They are all currently broken. This commit removes them, but still links to the full page.