### PR TITLE
Fixed katello CA URL

### DIFF
--- a/plugins/katello/3.2/installation/index.md
+++ b/plugins/katello/3.2/installation/index.md
@@ -19,7 +19,10 @@ script: osmenu.js
   </div>
 {% endif %}
 
-Note: After installation of Katello, be sure to trust Katello's CA certificate on your system.  This is required for the encrypted NoVNC connections. You will find `katello-default-ca.crt` in the `/pub` directory of your Katello server (e.g. `http://katello.example.com/pub/katello-default-ca.crt`).
+Note: After installation of Katello, be sure to trust Katello's CA certificate
+on your system.  This is required for the encrypted NoVNC connections. You
+will find `katello-server-ca.crt` in the `/pub` directory of your Katello
+server (e.g. `http://katello.example.com/pub/katello-server-ca.crt`).
 
 ## Hardware Requirements
 

--- a/plugins/katello/nightly/installation/index.md
+++ b/plugins/katello/nightly/installation/index.md
@@ -19,7 +19,10 @@ script: osmenu.js
   </div>
 {% endif %}
 
-Note: After installation of Katello, be sure to trust Katello's CA certificate on your system.  This is required for the encrypted NoVNC connections. You will find `katello-default-ca.crt` in the `/pub` directory of your Katello server (e.g. `http://katello.example.com/pub/katello-default-ca.crt`).
+Note: After installation of Katello, be sure to trust Katello's CA certificate
+on your system.  This is required for the encrypted NoVNC connections. You
+will find `katello-server-ca.crt` in the `/pub` directory of your Katello
+server (e.g. `http://katello.example.com/pub/katello-server-ca.crt`).
 
 ## Hardware Requirements
 


### PR DESCRIPTION
Have you guys changed this recently? I tried on 3.2 and the file was named this
way really. @ehelms

I was unable to find this in the Sat6 docs too, this is related:

https://bugzilla.redhat.com/show_bug.cgi?id=1396797