### PR TITLE
Katello 2.4 upgrade: .broken link to foreman-release.rpm 

### DIFF
--- a/plugins/katello/2.4/upgrade/index.md
+++ b/plugins/katello/2.4/upgrade/index.md
@@ -31,14 +31,14 @@ Update the Foreman and Katello release packages:
 
 {% highlight bash %}
   yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/RHEL/6Server/x86_64/katello-repos-latest.rpm
-  yum update -y http://yum.theforeman.org/{{ page.foreman_version }}/el6/x86_64/foreman-release.rpm
+  yum update -y http://yum.theforeman.org/releases/{{ page.foreman_version }}/el6/x86_64/foreman-release.rpm
 {% endhighlight %}
 
   * RHEL7 / CentOS 7:
 
 {% highlight bash %}
   yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/RHEL/7Server/x86_64/katello-repos-latest.rpm
-  yum update -y http://yum.theforeman.org/{{ page.foreman_version }}/el7/x86_64/foreman-release.rpm
+  yum update -y http://yum.theforeman.org/releases/{{ page.foreman_version }}/el7/x86_64/foreman-release.rpm
 {% endhighlight %}
 
 ## Step 4 - Update Packages


### PR DESCRIPTION
  yum update -y http://yum.theforeman.org/1.10/el6/x86_64/foreman-release.rpm
  yum update -y http://yum.theforeman.org/1.10/el7/x86_64/foreman-release.rpm

-->
  yum update -y http://yum.theforeman.org/releases/1.10/el6/x86_64/foreman-release.rpm
  yum update -y http://yum.theforeman.org/releases/1.10/el7/x86_64/foreman-release.rpm
