### PR TITLE
Fixes #17517 - default to Puppet 4 on new Katello installs

### DIFF
--- a/plugins/katello/3.2/installation/index.md
+++ b/plugins/katello/3.2/installation/index.md
@@ -105,9 +105,11 @@ yum-config-manager --enable rhel-6-server-optional-rpms
 
 <div id="el6" markdown="1">
 {% highlight bash %}
+yum -y update
 yum -y localinstall http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el6/x86_64/katello-repos-latest.rpm
 yum -y localinstall http://fedorapeople.org/groups/katello/releases/yum/foreman/{{ page.foreman_version }}/el6/x86_64/foreman-release.rpm
-yum -y localinstall http://yum.puppetlabs.com/puppetlabs-release-el-6.noarch.rpm
+yum -y localinstall https://yum.puppetlabs.com/puppetlabs-release-pc1-el-6.noarch.rpm # will install with Puppet 4
+#yum -y localinstall http://yum.puppetlabs.com/puppetlabs-release-el-6.noarch.rpm # use this instead if you prefer Puppet 3
 yum -y localinstall http://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
 yum -y install foreman-release-scl
 {% endhighlight %}
@@ -127,7 +129,8 @@ yum-config-manager --enable rhel-7-server-extras-rpms
 {% highlight bash %}
 yum -y localinstall http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el7/x86_64/katello-repos-latest.rpm
 yum -y localinstall http://yum.theforeman.org/releases/{{ page.foreman_version  }}/el7/x86_64/foreman-release.rpm
-yum -y localinstall http://yum.puppetlabs.com/puppetlabs-release-el-7.noarch.rpm
+yum -y localinstall https://yum.puppetlabs.com/puppetlabs-release-pc1-el-7.noarch.rpm # will install with Puppet 4
+#yum -y localinstall http://yum.puppetlabs.com/puppetlabs-release-el-7.noarch.rpm # use this instead if you prefer Puppet 3
 yum -y localinstall http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 yum -y install foreman-release-scl
 {% endhighlight %}

--- a/plugins/katello/nightly/installation/index.md
+++ b/plugins/katello/nightly/installation/index.md
@@ -99,7 +99,8 @@ yum-config-manager --enable rhel-7-server-extras-rpms
 {% highlight bash %}
 yum -y localinstall http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el7/x86_64/katello-repos-latest.rpm
 yum -y localinstall http://yum.theforeman.org/releases/{{ page.foreman_version  }}/el7/x86_64/foreman-release.rpm
-yum -y localinstall http://yum.puppetlabs.com/puppetlabs-release-el-7.noarch.rpm
+yum -y localinstall https://yum.puppetlabs.com/puppetlabs-release-pc1-el-7.noarch.rpm # will install with Puppet 4
+#yum -y localinstall http://yum.puppetlabs.com/puppetlabs-release-el-7.noarch.rpm # use this instead if you prefer Puppet 3
 yum -y localinstall http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 yum -y install foreman-release-scl
 {% endhighlight %}


### PR DESCRIPTION
The current documentation will install Puppet 3 if you copy/paste.
This patch alters the snippet to use Puppet 4 repos by default.

Additionally, do a yum update on el6 to pull the latest updates
before installing anything. Without this, epel will fail with a TLS
error.