### PR TITLE
Add more generic info to download EPEL

### DIFF
--- a/_includes/manuals/1.10/2.1_quickstart_installation.md
+++ b/_includes/manuals/1.10/2.1_quickstart_installation.md
@@ -75,7 +75,7 @@ yum-config-manager --enable rhel-7-server-optional-rpms rhel-server-rhscl-7-rpms
   </p>
 
 {% highlight bash %}
-rpm -ivh http://yum.puppetlabs.com/puppetlabs-release-el-6.noarch.rpm
+yum -y install http://yum.puppetlabs.com/puppetlabs-release-el-6.noarch.rpm
 {% endhighlight %}
 </div>
 
@@ -83,7 +83,7 @@ rpm -ivh http://yum.puppetlabs.com/puppetlabs-release-el-6.noarch.rpm
   <p>Enable the EPEL (Extra Packages for Enterprise Linux) and the Foreman repos:</p>
 
 {% highlight bash %}
-rpm -ivh http://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
+yum -y install http://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
 yum -y install http://yum.theforeman.org/releases/{{page.version}}/el6/x86_64/foreman-release.rpm
 {% endhighlight %}
 </div>
@@ -103,7 +103,7 @@ yum -y install epel-release http://yum.theforeman.org/releases/{{page.version}}/
   </p>
 
 {% highlight bash %}
-rpm -ivh http://yum.puppetlabs.com/puppetlabs-release-el-7.noarch.rpm
+yum -y install http://yum.puppetlabs.com/puppetlabs-release-el-7.noarch.rpm
 {% endhighlight %}
 </div>
 
@@ -111,7 +111,7 @@ rpm -ivh http://yum.puppetlabs.com/puppetlabs-release-el-7.noarch.rpm
   <p>Enable the EPEL (Extra Packages for Enterprise Linux) and the Foreman repos:</p>
 
 {% highlight bash %}
-rpm -ivh http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+yum -y install http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 yum -y install http://yum.theforeman.org/releases/{{page.version}}/el7/x86_64/foreman-release.rpm
 {% endhighlight %}
 </div>
@@ -120,7 +120,8 @@ yum -y install http://yum.theforeman.org/releases/{{page.version}}/el7/x86_64/fo
   <p>Enable the EPEL (Extra Packages for Enterprise Linux) and the Foreman repos:</p>
 
 {% highlight bash %}
-yum -y install epel-release http://yum.theforeman.org/releases/{{page.version}}/el7/x86_64/foreman-release.rpm
+yum -y install http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+yum -y install http://yum.theforeman.org/releases/{{page.version}}/el7/x86_64/foreman-release.rpm
 {% endhighlight %}
 </div>
 
@@ -131,7 +132,7 @@ yum -y install epel-release http://yum.theforeman.org/releases/{{page.version}}/
   </p>
 
 {% highlight bash %}
-rpm -ivh http://yum.puppetlabs.com/puppetlabs-release-fedora-19.noarch.rpm
+yum -y install http://yum.puppetlabs.com/puppetlabs-release-fedora-19.noarch.rpm
 {% endhighlight %}
 
   <p>Enable the Foreman repo:</p>

--- a/_includes/manuals/1.11/2.1_quickstart_installation.md
+++ b/_includes/manuals/1.11/2.1_quickstart_installation.md
@@ -71,7 +71,7 @@ yum-config-manager --enable rhel-7-server-optional-rpms rhel-server-rhscl-7-rpms
   </p>
 
 {% highlight bash %}
-rpm -ivh https://yum.puppetlabs.com/puppetlabs-release-el-6.noarch.rpm
+yum -y install https://yum.puppetlabs.com/puppetlabs-release-el-6.noarch.rpm
 {% endhighlight %}
 </div>
 
@@ -79,7 +79,7 @@ rpm -ivh https://yum.puppetlabs.com/puppetlabs-release-el-6.noarch.rpm
   <p>Enable the EPEL (Extra Packages for Enterprise Linux) and the Foreman repos:</p>
 
 {% highlight bash %}
-rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
+yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
 yum -y install https://yum.theforeman.org/releases/{{page.version}}/el6/x86_64/foreman-release.rpm
 {% endhighlight %}
 </div>
@@ -88,7 +88,8 @@ yum -y install https://yum.theforeman.org/releases/{{page.version}}/el6/x86_64/f
   <p>Enable the EPEL (Extra Packages for Enterprise Linux) and the Foreman repos:</p>
 
 {% highlight bash %}
-yum -y install epel-release https://yum.theforeman.org/releases/{{page.version}}/el6/x86_64/foreman-release.rpm
+yum -y install http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+yum -y install https://yum.theforeman.org/releases/{{page.version}}/el6/x86_64/foreman-release.rpm
 {% endhighlight %}
 </div>
 
@@ -99,7 +100,7 @@ yum -y install epel-release https://yum.theforeman.org/releases/{{page.version}}
   </p>
 
 {% highlight bash %}
-rpm -ivh https://yum.puppetlabs.com/puppetlabs-release-el-7.noarch.rpm
+yum -y install https://yum.puppetlabs.com/puppetlabs-release-el-7.noarch.rpm
 {% endhighlight %}
 </div>
 
@@ -107,7 +108,7 @@ rpm -ivh https://yum.puppetlabs.com/puppetlabs-release-el-7.noarch.rpm
   <p>Enable the EPEL (Extra Packages for Enterprise Linux) and the Foreman repos:</p>
 
 {% highlight bash %}
-rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 yum -y install https://yum.theforeman.org/releases/{{page.version}}/el7/x86_64/foreman-release.rpm
 {% endhighlight %}
 </div>
@@ -127,7 +128,7 @@ yum -y install epel-release https://yum.theforeman.org/releases/{{page.version}}
   </p>
 
 {% highlight bash %}
-rpm -ivh https://yum.puppetlabs.com/puppetlabs-release-fedora-21.noarch.rpm
+yum -y install https://yum.puppetlabs.com/puppetlabs-release-fedora-21.noarch.rpm
 {% endhighlight %}
 
   <p>Enable the Foreman repo:</p>

--- a/_includes/manuals/1.12/2.1_quickstart_installation.md
+++ b/_includes/manuals/1.12/2.1_quickstart_installation.md
@@ -74,7 +74,7 @@ yum-config-manager --enable rhel-7-server-optional-rpms
   </p>
 
 {% highlight bash %}
-rpm -ivh https://yum.puppetlabs.com/puppetlabs-release-pc1-el-6.noarch.rpm
+yum -y install https://yum.puppetlabs.com/puppetlabs-release-pc1-el-6.noarch.rpm
 {% endhighlight %}
 
   <p>
@@ -82,7 +82,7 @@ rpm -ivh https://yum.puppetlabs.com/puppetlabs-release-pc1-el-6.noarch.rpm
   </p>
 
 {% highlight bash %}
-rpm -ivh https://yum.puppetlabs.com/puppetlabs-release-el-6.noarch.rpm
+yum -y install https://yum.puppetlabs.com/puppetlabs-release-el-6.noarch.rpm
 {% endhighlight %}
 </div>
 
@@ -90,7 +90,7 @@ rpm -ivh https://yum.puppetlabs.com/puppetlabs-release-el-6.noarch.rpm
   <p>Enable the EPEL (Extra Packages for Enterprise Linux) and the Foreman repos:</p>
 
 {% highlight bash %}
-rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
+yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
 yum -y install https://yum.theforeman.org/releases/{{page.version}}/el6/x86_64/foreman-release.rpm
 {% endhighlight %}
 </div>
@@ -99,7 +99,8 @@ yum -y install https://yum.theforeman.org/releases/{{page.version}}/el6/x86_64/f
   <p>Enable the EPEL (Extra Packages for Enterprise Linux) and the Foreman repos:</p>
 
 {% highlight bash %}
-yum -y install epel-release https://yum.theforeman.org/releases/{{page.version}}/el6/x86_64/foreman-release.rpm
+yum -y install http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+yum -y install https://yum.theforeman.org/releases/{{page.version}}/el6/x86_64/foreman-release.rpm
 {% endhighlight %}
 </div>
 
@@ -112,7 +113,7 @@ yum -y install epel-release https://yum.theforeman.org/releases/{{page.version}}
   </p>
 
 {% highlight bash %}
-rpm -ivh https://yum.puppetlabs.com/puppetlabs-release-pc1-el-7.noarch.rpm
+yum -y install https://yum.puppetlabs.com/puppetlabs-release-pc1-el-7.noarch.rpm
 {% endhighlight %}
 
   <p>
@@ -120,7 +121,7 @@ rpm -ivh https://yum.puppetlabs.com/puppetlabs-release-pc1-el-7.noarch.rpm
   </p>
 
 {% highlight bash %}
-rpm -ivh https://yum.puppetlabs.com/puppetlabs-release-el-7.noarch.rpm
+yum -y install https://yum.puppetlabs.com/puppetlabs-release-el-7.noarch.rpm
 {% endhighlight %}
 </div>
 
@@ -128,7 +129,7 @@ rpm -ivh https://yum.puppetlabs.com/puppetlabs-release-el-7.noarch.rpm
   <p>Enable the EPEL (Extra Packages for Enterprise Linux) and the Foreman repos:</p>
 
 {% highlight bash %}
-rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 yum -y install https://yum.theforeman.org/releases/{{page.version}}/el7/x86_64/foreman-release.rpm
 {% endhighlight %}
 </div>

--- a/_includes/manuals/1.13/2.1_quickstart_installation.md
+++ b/_includes/manuals/1.13/2.1_quickstart_installation.md
@@ -54,7 +54,7 @@ yum-config-manager --enable rhel-7-server-optional-rpms
   </p>
 
 {% highlight bash %}
-rpm -ivh https://yum.puppetlabs.com/puppetlabs-release-pc1-el-7.noarch.rpm
+yum -y install https://yum.puppetlabs.com/puppetlabs-release-pc1-el-7.noarch.rpm
 {% endhighlight %}
 
   <p>
@@ -62,7 +62,7 @@ rpm -ivh https://yum.puppetlabs.com/puppetlabs-release-pc1-el-7.noarch.rpm
   </p>
 
 {% highlight bash %}
-rpm -ivh https://yum.puppetlabs.com/puppetlabs-release-el-7.noarch.rpm
+yum -y install https://yum.puppetlabs.com/puppetlabs-release-el-7.noarch.rpm
 {% endhighlight %}
 </div>
 
@@ -70,7 +70,7 @@ rpm -ivh https://yum.puppetlabs.com/puppetlabs-release-el-7.noarch.rpm
   <p>Enable the EPEL (Extra Packages for Enterprise Linux) and the Foreman repos:</p>
 
 {% highlight bash %}
-rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 yum -y install https://yum.theforeman.org/releases/{{page.version}}/el7/x86_64/foreman-release.rpm
 {% endhighlight %}
 </div>
@@ -79,7 +79,8 @@ yum -y install https://yum.theforeman.org/releases/{{page.version}}/el7/x86_64/f
   <p>Enable the EPEL (Extra Packages for Enterprise Linux) and the Foreman repos:</p>
 
 {% highlight bash %}
-yum -y install epel-release https://yum.theforeman.org/releases/{{page.version}}/el7/x86_64/foreman-release.rpm
+yum -y install http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+yum -y install https://yum.theforeman.org/releases/{{page.version}}/el7/x86_64/foreman-release.rpm
 {% endhighlight %}
 </div>
 

--- a/_includes/manuals/1.14/2.1_quickstart_installation.md
+++ b/_includes/manuals/1.14/2.1_quickstart_installation.md
@@ -54,7 +54,7 @@ yum-config-manager --enable rhel-7-server-optional-rpms
   </p>
 
 {% highlight bash %}
-rpm -ivh https://yum.puppetlabs.com/puppetlabs-release-pc1-el-7.noarch.rpm
+yum -y install https://yum.puppetlabs.com/puppetlabs-release-pc1-el-7.noarch.rpm
 {% endhighlight %}
 
   <p>
@@ -62,7 +62,7 @@ rpm -ivh https://yum.puppetlabs.com/puppetlabs-release-pc1-el-7.noarch.rpm
   </p>
 
 {% highlight bash %}
-rpm -ivh https://yum.puppetlabs.com/puppetlabs-release-el-7.noarch.rpm
+yum -y install https://yum.puppetlabs.com/puppetlabs-release-el-7.noarch.rpm
 {% endhighlight %}
 </div>
 
@@ -70,7 +70,7 @@ rpm -ivh https://yum.puppetlabs.com/puppetlabs-release-el-7.noarch.rpm
   <p>Enable the EPEL (Extra Packages for Enterprise Linux) and the Foreman repos:</p>
 
 {% highlight bash %}
-rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 yum -y install https://yum.theforeman.org/releases/{{page.version}}/el7/x86_64/foreman-release.rpm
 {% endhighlight %}
 </div>
@@ -79,7 +79,8 @@ yum -y install https://yum.theforeman.org/releases/{{page.version}}/el7/x86_64/f
   <p>Enable the EPEL (Extra Packages for Enterprise Linux) and the Foreman repos:</p>
 
 {% highlight bash %}
-yum -y install epel-release https://yum.theforeman.org/releases/{{page.version}}/el7/x86_64/foreman-release.rpm
+yum -y install http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+yum -y install https://yum.theforeman.org/releases/{{page.version}}/el7/x86_64/foreman-release.rpm
 {% endhighlight %}
 </div>
 

--- a/_includes/manuals/1.9/2.1_quickstart_installation.md
+++ b/_includes/manuals/1.9/2.1_quickstart_installation.md
@@ -120,7 +120,8 @@ yum -y install http://yum.theforeman.org/releases/{{page.version}}/el7/x86_64/fo
   <p>Enable the EPEL (Extra Packages for Enterprise Linux) and the Foreman repos:</p>
 
 {% highlight bash %}
-yum -y install epel-release http://yum.theforeman.org/releases/{{page.version}}/el7/x86_64/foreman-release.rpm
+rpm -ivh http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+yum -y install http://yum.theforeman.org/releases/{{page.version}}/el7/x86_64/foreman-release.rpm
 {% endhighlight %}
 </div>
 


### PR DESCRIPTION
The previous message of 'yum install epel-release' works on CentOS7, but
not on all EL7 derivatives (e.g - Oracle Linux doesn't provide it). It's
changed to a method that should work everywhere