### PR TITLE
PXE loader option for unattended installation

### DIFF
--- a/_includes/manuals/1.14/4.3.9_smartproxy_tftp.md
+++ b/_includes/manuals/1.14/4.3.9_smartproxy_tftp.md
@@ -22,7 +22,7 @@ Regardless of the filesystem setup is performed, you must also make sure you hav
 
 ##### Automatic Setup
 
-Foreman includes a [TFTP server module](https://github.com/theforeman/puppet-foreman_proxy/blob/master/manifests/tftp.pp) that will perform all of the basic setup.  It defaults to TFTP root of */var/lib/tftpboot*, which may change if necessary.  You will still need to provide the basic TFTP load images in your TFTP root directory.  For vanilla PXE booting, this includes *pxelinux.0*, *menu.c32*, and *chain.c32*.
+Foreman includes a [TFTP server module](https://github.com/theforeman/puppet-foreman_proxy/blob/master/manifests/tftp.pp) that will perform all of the basic setup.  It defaults to TFTP root of */var/lib/tftpboot*, which may change if necessary.  You will still need to provide the basic TFTP load images in your TFTP root directory.  For vanilla PXE booting via PXELinux, this includes *pxelinux.0*, *menu.c32*, and *chain.c32*, for PXEGrub this includes *grub2/* and *grub/* subdirectories.
 
 ##### Manual Setup
 
@@ -33,8 +33,13 @@ The setup is very simple, and may be performed manually if desired.
     * *pxelinux.0*
     * *menu.c32*
     * *chain.c32*
-3. Create the directory */var/lib/tftpboot/boot* and make it writeable by the foreman proxy user (foreman-proxy, for instance, when installing through a rpm package).
-4. Create the directory */var/lib/tftpboot/pxelinux.cfg* and make it writeable by the foreman proxy user (foreman-proxy).
+3. Populate the following prerequisites when PXE Grub bootloader is planned. These files can be found in OS distribution repositories, DVD/CD or packages (e.g. *grub2-efi* on Red Hats which installs into */boot/EFI*). Alternatively, these files can be built from modules using *grub2-mkimage* or *grub-mkimage* and signed for SecureBoot support.
+    * */var/lib/tftpboot/grub2* with *grubx64.efi* or *grubia32.efi*
+    * */var/lib/tftpboot/grub* with *bootx64.efi* or *bootia32.efi*
+4. Create the directory */var/lib/tftpboot/boot* and make it writeable by the foreman proxy user (foreman-proxy, for instance, when installing through a rpm package).
+5. Create the directory */var/lib/tftpboot/pxelinux.cfg* and make it writeable by the foreman proxy user (foreman-proxy).
+6. Make sure */var/lib/tftpboot/grub* and */var/lib/tftpboot/grub2* are both writeable by the foreman proxy user (foreman-proxy).
+7. Verify SELinux labels when using SELinux.
 
 * Note: if CentOS 7 is used, please make sure to edit the URL under Hosts -> Installation Media, to to exclude the $minor version. For example: http://mirror.centos.org/centos/$major/os/$arch
 


### PR DESCRIPTION
#12634 added a PXE loader option to host creation which changes the boot filename specified in the DHCP reservation, to be used to support different architectures and boot modes. This should be documented in the unattended installation section.