### PR TITLE
Add EPEL repo to install before katello-agent

### DIFF
--- a/plugins/katello/3.1/installation/clients.md
+++ b/plugins/katello/3.1/installation/clients.md
@@ -27,18 +27,21 @@ Install the appropriate Katello client release packages.  For CentOS 6, you will
 <div id="el5" markdown="1">
 {% highlight bash %}
 yum install -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/el5/x86_64/katello-client-repos-latest.rpm
+yum -y install http://dl.fedoraproject.org/pub/epel/epel-release-latest-5.noarch.rpm
 {% endhighlight %}
 </div>
 
 <div id="el6" style="display:none;" markdown="1">
 {% highlight bash %}
 wget https://copr.fedoraproject.org/coprs/dgoodwin/subscription-manager/repo/epel-6/dgoodwin-subscription-manager-epel-6.repo -O /etc/yum.repos.d/dgoodwin-subscription-manager-epel-6.repo
+yum -y install http://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
 yum install -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/el6/x86_64/katello-client-repos-latest.rpm
 {% endhighlight %}
 </div>
 
 <div id="el7" style="display:none;" markdown="1">
 {% highlight bash %}
+yum -y install http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 yum install -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/el7/x86_64/katello-client-repos-latest.rpm
 {% endhighlight %}
 </div>

--- a/plugins/katello/3.1/upgrade/clients.md
+++ b/plugins/katello/3.1/upgrade/clients.md
@@ -29,18 +29,21 @@ Update the Katello client release packages:
 <div id="el5" markdown="1">
 {% highlight bash %}
 yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/RHEL/5Server/x86_64/katello-client-repos-latest.rpm
+yum -y install http://dl.fedoraproject.org/pub/epel/epel-release-latest-5.noarch.rpm
 {% endhighlight %}
 </div>
 
 <div id="el6" style="display:none;" markdown="1">
 {% highlight bash %}
 yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/RHEL/6Server/x86_64/katello-client-repos-latest.rpm
+yum -y install http://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
 {% endhighlight %}
 </div>
 
 <div id="el7" style="display:none;" markdown="1">
 {% highlight bash %}
 yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/RHEL/7Server/x86_64/katello-client-repos-latest.rpm
+yum -y install http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 {% endhighlight %}
 </div>
 
@@ -58,7 +61,7 @@ yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.versio
 
 ### Provisioned Clients
 
-If the katello-agent was setup during proviosioning from a locally synced repository then you will need to go through some [initial setup](/plugins/katello/{{ page.version }}/installation/clients.html) to add the {{ page.version }} client repositories to your Katello for each version needed. After you create the new repositories, they will then need to be added to the relevant content view(s) and the older versions removed. At this point, a new version of the content view can be published and promoted to the appropriate environments. Once the new package is available the clients can be updated following the next steps.
+If the katello-agent was setup during provisioning from a locally synced repository then you will need to go through some [initial setup](/plugins/katello/{{ page.version }}/installation/clients.html) to add the {{ page.version }} client repositories to your Katello for each version needed. After you create the new repositories, they will then need to be added to the relevant content view(s) and the older versions removed. At this point, a new version of the content view can be published and promoted to the appropriate environments. Once the new package is available the clients can be updated following the next steps.
 
 ## Step 2: Update Packages
 

--- a/plugins/katello/3.2/installation/clients.md
+++ b/plugins/katello/3.2/installation/clients.md
@@ -27,18 +27,21 @@ Install the appropriate Katello client release packages.  For CentOS 6, you will
 <div id="el5" markdown="1">
 {% highlight bash %}
 yum install -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/el5/x86_64/katello-client-repos-latest.rpm
+yum -y install http://dl.fedoraproject.org/pub/epel/epel-release-latest-5.noarch.rpm
 {% endhighlight %}
 </div>
 
 <div id="el6" style="display:none;" markdown="1">
 {% highlight bash %}
 wget https://copr.fedoraproject.org/coprs/dgoodwin/subscription-manager/repo/epel-6/dgoodwin-subscription-manager-epel-6.repo -O /etc/yum.repos.d/dgoodwin-subscription-manager-epel-6.repo
+yum -y install http://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
 yum install -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/el6/x86_64/katello-client-repos-latest.rpm
 {% endhighlight %}
 </div>
 
 <div id="el7" style="display:none;" markdown="1">
 {% highlight bash %}
+yum -y install http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 yum install -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/el7/x86_64/katello-client-repos-latest.rpm
 {% endhighlight %}
 </div>

--- a/plugins/katello/3.2/upgrade/clients.md
+++ b/plugins/katello/3.2/upgrade/clients.md
@@ -28,18 +28,21 @@ Update the Katello client release packages:
 <div id="el5" markdown="1">
 {% highlight bash %}
 yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/el5/x86_64/katello-client-repos-latest.rpm
+yum -y install http://dl.fedoraproject.org/pub/epel/epel-release-latest-5.noarch.rpm
 {% endhighlight %}
 </div>
 
 <div id="el6" style="display:none;" markdown="1">
 {% highlight bash %}
 yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/el6/x86_64/katello-client-repos-latest.rpm
+yum -y install http://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
 {% endhighlight %}
 </div>
 
 <div id="el7" style="display:none;" markdown="1">
 {% highlight bash %}
 yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/el7/x86_64/katello-client-repos-latest.rpm
+yum -y install http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 {% endhighlight %}
 </div>
 
@@ -51,7 +54,7 @@ yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.versio
 
 ### Provisioned Clients
 
-If the katello-agent was setup during proviosioning from a locally synced repository then you will need to go through some [initial setup](/plugins/katello/{{ page.version }}/installation/clients.html) to add the {{ page.version }} client repositories to your Katello for each version needed. After you create the new repositories, they will then need to be added to the relevant content view(s) and the older versions removed. At this point, a new version of the content view can be published and promoted to the appropriate environments. Once the new package is available the clients can be updated following the next steps.
+If the katello-agent was setup during provisioning from a locally synced repository then you will need to go through some [initial setup](/plugins/katello/{{ page.version }}/installation/clients.html) to add the {{ page.version }} client repositories to your Katello for each version needed. After you create the new repositories, they will then need to be added to the relevant content view(s) and the older versions removed. At this point, a new version of the content view can be published and promoted to the appropriate environments. Once the new package is available the clients can be updated following the next steps.
 
 ## Step 2: Update Packages
 

--- a/plugins/katello/3.3/installation/clients.md
+++ b/plugins/katello/3.3/installation/clients.md
@@ -27,12 +27,14 @@ Install the appropriate Katello client release packages.  For CentOS 6, you will
 <div id="el5" markdown="1">
 {% highlight bash %}
 yum install -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/el5/x86_64/katello-client-repos-latest.rpm
+yum -y install http://dl.fedoraproject.org/pub/epel/epel-release-latest-5.noarch.rpm
 {% endhighlight %}
 </div>
 
 <div id="el6" style="display:none;" markdown="1">
 {% highlight bash %}
 wget https://copr.fedoraproject.org/coprs/dgoodwin/subscription-manager/repo/epel-6/dgoodwin-subscription-manager-epel-6.repo -O /etc/yum.repos.d/dgoodwin-subscription-manager-epel-6.repo
+yum -y install http://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
 yum install -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/el6/x86_64/katello-client-repos-latest.rpm
 {% endhighlight %}
 </div>
@@ -40,6 +42,7 @@ yum install -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.versi
 <div id="el7" style="display:none;" markdown="1">
 {% highlight bash %}
 yum install -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/el7/x86_64/katello-client-repos-latest.rpm
+yum -y install http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 {% endhighlight %}
 </div>
 

--- a/plugins/katello/3.3/upgrade/clients.md
+++ b/plugins/katello/3.3/upgrade/clients.md
@@ -29,18 +29,21 @@ Update the Katello client release packages:
 <div id="el5" markdown="1">
 {% highlight bash %}
 yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/RHEL/5Server/x86_64/katello-client-repos-latest.rpm
+yum -y install http://dl.fedoraproject.org/pub/epel/epel-release-latest-5.noarch.rpm
 {% endhighlight %}
 </div>
 
 <div id="el6" style="display:none;" markdown="1">
 {% highlight bash %}
 yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/RHEL/6Server/x86_64/katello-client-repos-latest.rpm
+yum -y install http://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
 {% endhighlight %}
 </div>
 
 <div id="el7" style="display:none;" markdown="1">
 {% highlight bash %}
 yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/RHEL/7Server/x86_64/katello-client-repos-latest.rpm
+yum -y install http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 {% endhighlight %}
 </div>
 

--- a/plugins/katello/nightly/installation/clients.md
+++ b/plugins/katello/nightly/installation/clients.md
@@ -27,12 +27,14 @@ Install the appropriate Katello client release packages.  For CentOS 6, you will
 <div id="el5" markdown="1">
 {% highlight bash %}
 yum install -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/el5/x86_64/katello-client-repos-latest.rpm
+yum -y install http://dl.fedoraproject.org/pub/epel/epel-release-latest-5.noarch.rpm
 {% endhighlight %}
 </div>
 
 <div id="el6" style="display:none;" markdown="1">
 {% highlight bash %}
 wget https://copr.fedoraproject.org/coprs/dgoodwin/subscription-manager/repo/epel-6/dgoodwin-subscription-manager-epel-6.repo -O /etc/yum.repos.d/dgoodwin-subscription-manager-epel-6.repo
+yum -y install http://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
 yum install -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/el6/x86_64/katello-client-repos-latest.rpm
 {% endhighlight %}
 </div>
@@ -40,6 +42,7 @@ yum install -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.versi
 <div id="el7" style="display:none;" markdown="1">
 {% highlight bash %}
 yum install -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/el7/x86_64/katello-client-repos-latest.rpm
+yum -y install http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 {% endhighlight %}
 </div>
 

--- a/plugins/katello/nightly/upgrade/clients.md
+++ b/plugins/katello/nightly/upgrade/clients.md
@@ -18,9 +18,9 @@ Update the Katello client release packages:
 <p>
   Select your Operating System:
   <select id="operatingSystems">
-     <option value="el5">Enterprise Linux 5 (CentOS, etc.)</option>
-     <option value="el6">Enterprise Linux 6 (CentOS, etc.)</option>
-     <option value="el7">Enterprise Linux 7 (CentOS, etc.)</option>
+     <option value="el5">Enterprise Linux 5 (RHEL, CentOS, etc.)</option>
+     <option value="el6">Enterprise Linux 6 (RHEL, CentOS, etc.)</option>
+     <option value="el7">Enterprise Linux 7 (RHEL, CentOS, etc.)</option>
      <option value="fc20">Fedora 20</option>
      <option value="fc21">Fedora 21</option>
   </select>
@@ -29,18 +29,21 @@ Update the Katello client release packages:
 <div id="el5" markdown="1">
 {% highlight bash %}
 yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/RHEL/5Server/x86_64/katello-client-repos-latest.rpm
+yum -y install http://dl.fedoraproject.org/pub/epel/epel-release-latest-5.noarch.rpm
 {% endhighlight %}
 </div>
 
 <div id="el6" style="display:none;" markdown="1">
 {% highlight bash %}
 yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/RHEL/6Server/x86_64/katello-client-repos-latest.rpm
+yum -y install http://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
 {% endhighlight %}
 </div>
 
 <div id="el7" style="display:none;" markdown="1">
 {% highlight bash %}
 yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/RHEL/7Server/x86_64/katello-client-repos-latest.rpm
+yum -y install http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 {% endhighlight %}
 </div>
 
@@ -58,7 +61,7 @@ yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.versio
 
 ### Provisioned Clients
 
-If the katello-agent was setup during proviosioning from a locally synced repository then you will need to go through some [initial setup](/plugins/katello/{{ page.version }}/installation/clients.html) to add the {{ page.version }} client repositories to your Katello for each version needed. After you create the new repositories, they will then need to be added to the relevant content view(s) and the older versions removed. At this point, a new version of the content view can be published and promoted to the appropriate environments. Once the new package is available the clients can be updated following the next steps.
+If the katello-agent was setup during provisioning from a locally synced repository then you will need to go through some [initial setup](/plugins/katello/{{ page.version }}/installation/clients.html) to add the {{ page.version }} client repositories to your Katello for each version needed. After you create the new repositories, they will then need to be added to the relevant content view(s) and the older versions removed. At this point, a new version of the content view can be published and promoted to the appropriate environments. Once the new package is available the clients can be updated following the next steps.
 
 ## Step 2: Update Packages
 


### PR DESCRIPTION
The agent will not install in RHEL without the optional and extras
repos, with errors such as
https://gist.github.com/dLobatog/f9d3751861d0a1d1045f4831f3d7dca9

This commit adds that information to the installation and upgrade of the
latest versions