### PR TITLE
Puppet 4.4+ environment_classes in auth.conf

### DIFF
--- a/_includes/manuals/1.14/4.3.6_smartproxy_puppet.md
+++ b/_includes/manuals/1.14/4.3.6_smartproxy_puppet.md
@@ -50,6 +50,10 @@ path /puppet/v3/environments
 method find
 allow *
 
+path /puppet/v3/environment_classes
+method find
+allow *
+
 path /puppet/v3/resource_type
 method search
 allow *
@@ -67,6 +71,16 @@ The [HOCON-formatted auth.conf style](https://docs.puppet.com/puppetserver/lates
     allow: "*"
     sort-order: 500
     name: "puppetlabs environments"
+},
+{
+    match-request: {
+    path: "/puppet/v3/environment_classes"
+       type: path
+       method: get
+    }
+    allow: "*"
+    sort-order: 500
+    name: "puppetlabs environment classes"
 },
 {
     match-request: {


### PR DESCRIPTION
Puppet versions 4.4 and newer need a section to allow
environment_classes in auth.conf.

Adding these rules here will not be a problem for people using Puppet older than 4.4, as those paths will not resolve to anything. For people who use newer Puppet versions, it will allow them to import classes.