### PR TITLE
Fix Katello Puppet integration image links

### DIFF
--- a/plugins/katello/3.2/user_guide/puppet_integration/index.md
+++ b/plugins/katello/3.2/user_guide/puppet_integration/index.md
@@ -14,11 +14,11 @@ To import the puppet forge navigate to
 Content > Products
 
 Click on the *+New Product* button.
- 
+
 Once the product is created, select the product and click the *Create Repository*
 button. Fill out the repostitory as shown:
 
-![Adding a the Pupper Forge](/puppet_forge.png)
+![Adding a the Pupper Forge](/plugins/katello/{{ page.version }}/user_guide/puppet_integration/puppet_forge.png)
 
 This can be done via the CLI:
 

--- a/plugins/katello/nightly/user_guide/puppet_integration/index.md
+++ b/plugins/katello/nightly/user_guide/puppet_integration/index.md
@@ -14,11 +14,11 @@ To import the puppet forge navigate to
 Content > Products
 
 Click on the *+New Product* button.
- 
+
 Once the product is created, select the product and click the *Create Repository*
 button. Fill out the repostitory as shown:
 
-![Adding a the Pupper Forge](/puppet_forge.png)
+![Adding a the Pupper Forge](/plugins/katello/{{ page.version }}/user_guide/puppet_integration/puppet_forge.png)
 
 This can be done via the CLI:
 


### PR DESCRIPTION
The current links didn't display because the URL is wrong