### PR TITLE
Add more ERB template info, link to editor Help tab

### DIFF
--- a/_includes/manuals/1.14/4.4.3_prov_templates.md
+++ b/_includes/manuals/1.14/4.4.3_prov_templates.md
@@ -18,11 +18,26 @@ In practice, most environments only make use of the first 3. The *Create Host* a
 
 ##### Editing Templates
 
-Clicking a template will take you to the edit page. All templates are
-ERB-enabled, and you can access many variables about the to-be-installed-host
-within the template. See [**Template Writing**](http://theforeman.org/projects/foreman/wiki/TemplateWriting) for ideas.
+Templates can be edited from the *Hosts > Provisioning templates* menu, or from an existing host page under its *Templates* tab (which shows the templates in use).
 
-As noted in [**4.1.4 Auditing**](manuals/{{page.version}}/index.html#4.1.4Auditing), changes to the templates are logged as diffs - you can browse the history of changes to the templates from the History tab within the Edit Template page. You can also revert changes here.
+The templates use the ERB (Embedded Ruby) templating language, allowing data from the host in Foreman to be added to the template output and for conditional content. The default templates make heavy use of the ERB feature, adding and changing the template behavior based on parameters, the operating system, or the networking configuration assigned to the host.
+
+There are two general types of ERB syntax in templates. The `<%=` prefix outputs the value of the following expression into the rendered template, e.g. to output the hostname:
+
+    <%= @host.name %>
+
+The `<%` prefix without the equals sign (`=`) is a general code block that may contain conditionals, variable assignments, or loops which are not output when rendered. Comments may also be in these blocks, prefixed with `#`.
+
+    <%
+    a_variable = @host.name
+    %>
+    <%= a_variable %>
+
+Other examples of ERB syntax are given on the *Help* tab of the template editor, and many more examples are available on the [Template Writing](http://theforeman.org/projects/foreman/wiki/TemplateWriting) wiki page. The *Help* tab also lists available *Global methods (functions)* provided by Foreman such as `foreman_url` (the URL for unattended calls to Foreman), and `template_name`.
+
+The methods available on the provided `@host` variable are limited by default (when `safemode_render` is enabled) to prevent exploitation of Foreman through templates. The permitted methods on all types of objects can be found in the *Safe mode methods and variables* table under the *Help* tab.
+
+As noted in section [4.1.4 Auditing](manuals/{{page.version}}/index.html#4.1.4Auditing), changes to the templates are logged as diffs - you can browse the history of changes to the templates from the *History* tab within the *Edit Template* page. You can also revert changes here.
 
 #### Template Association
 


### PR DESCRIPTION
Help tab is preferred for more detailed information, such as names of
helpers, variables and permitted methods.