### PR TITLE
Fix rendering of sub-headings

### DIFF
--- a/manuals/1.14/index.md
+++ b/manuals/1.14/index.md
@@ -108,6 +108,7 @@ previous_version: "1.13"
 {%include manuals/1.14/4.3.3.1_smartproxy_bmc_ssh.md %}
 
 ### 4.3.4 DHCP
+
 #### 4.3.4.1 dhcp.yml
 {%include manuals/1.14/4.3.4_smartproxy_dhcp.md %}
 #### 4.3.4.2 ISC DHCP
@@ -116,6 +117,7 @@ previous_version: "1.13"
 {%include manuals/1.14/4.3.4.3_ms_dhcp.md %}
 
 ### 4.3.5 DNS
+
 #### 4.3.5.1 dns.yml
 {%include manuals/1.14/4.3.5_smartproxy_dns.md %}
 #### 4.3.5.2 BIND
@@ -129,6 +131,7 @@ previous_version: "1.13"
 {%include manuals/1.14/4.3.7_smartproxy_puppetca.md %}
 
 ### 4.3.8 Realm
+
 #### 4.3.8.1 realm.yml
 {%include manuals/1.14/4.3.8_smartproxy_realm.md %}
 #### 4.3.8.2 FreeIPA Realm


### PR DESCRIPTION
Spacing is required between the level three and four headings.