### PR TITLE
Show old version warning on quickstart pages

### DIFF
--- a/_layouts/manual.html
+++ b/_layouts/manual.html
@@ -6,7 +6,6 @@ latestversion: "1.14"
 <div id="wrap">
 	<div class="container">
 	  <div class="row">
-			{% unless page.url contains "quickstart_guide" %}
 			<div class="col-md-3">
 				<div id="toc" class="sidebar-nav-fixed pull-right hidden-sm hidden-xs" data-spy="affix" data-offset-top="60" data-offset-bottom="300">
 					{% capture versionmaj %}{{ page.version | split: "." | first | times: 100 }}{% endcapture %}
@@ -27,12 +26,7 @@ latestversion: "1.14"
 					{% endif %}
 				</div>
 			</div>
-			{% endunless %}
-			{% if page.url contains "quickstart_guide" %}
-			<div id="doc" class="col-md-12">
-			{% else %}
 			<div id="doc" class="col-md-9">
-			{% endif %}
 				{{ content }}
 			</div>
 		</div>

--- a/_layouts/quickstart.html
+++ b/_layouts/quickstart.html
@@ -1,0 +1,31 @@
+---
+pagename: Quickstart
+latestversion: "1.14"
+---
+{% include header.html %}
+<div id="wrap">
+	<div class="container">
+		<div class="row">
+			{% capture versionmaj %}{{ page.version | split: "." | first | times: 100 }}{% endcapture %}
+			{% capture versioni %}{{ page.version | split: "." | last | plus: versionmaj }}{% endcapture %}
+			{% capture latestmaj %}{{ layout.latestversion | split: "." | first | times: 100 }}{% endcapture %}
+			{% capture latesti %}{{ layout.latestversion | split: "." | last | plus: latestmaj }}{% endcapture %}
+			{% if versioni < latesti %}
+			<div class="alert alert-warning" style="margin-top:5px">
+				<p style="margin-bottom: 3px"><strong>Newer version available</strong></p>
+				<p style="margin-bottom: 0">This quickstart guide is for Foreman {{ page.version }}, but the <a href="{{ site.baseurl }}manuals/{{ layout.latestversion }}/index.html">latest version is {{ layout.latestversion }}</a>.</p>
+			</div>
+			{% endif %}
+			{% if versioni > latesti %}
+			<div class="alert alert-warning" style="margin-top:5px">
+				<p style="margin-bottom: 3px"><strong>Not yet released</strong></p>
+				<p style="margin-bottom: 0">This quickstart guide is for Foreman {{ page.version }}, but <a href="{{ site.baseurl }}manuals/{{ layout.latestversion }}/index.html">{{ layout.latestversion }}</a> is the current stable version.</p>
+			</div>
+			{% endif %}
+			<div id="doc" class="col-md-12">
+				{{ content }}
+			</div>
+		</div>
+	</div>
+</div>
+{% include footer.html %}

--- a/manuals/1.10/quickstart_guide.md
+++ b/manuals/1.10/quickstart_guide.md
@@ -1,5 +1,5 @@
 ---
-layout: manual
+layout: quickstart
 title: Foreman Quickstart Guide
 version: "1.10"
 ---

--- a/manuals/1.11/quickstart_guide.md
+++ b/manuals/1.11/quickstart_guide.md
@@ -1,5 +1,5 @@
 ---
-layout: manual
+layout: quickstart
 title: Foreman Quickstart Guide
 version: "1.11"
 ---

--- a/manuals/1.12/quickstart_guide.md
+++ b/manuals/1.12/quickstart_guide.md
@@ -1,5 +1,5 @@
 ---
-layout: manual
+layout: quickstart
 title: Foreman Quickstart Guide
 version: "1.12"
 ---

--- a/manuals/1.13/quickstart_guide.md
+++ b/manuals/1.13/quickstart_guide.md
@@ -1,5 +1,5 @@
 ---
-layout: manual
+layout: quickstart
 title: Foreman Quickstart Guide
 version: "1.13"
 ---

--- a/manuals/1.14/quickstart_guide.md
+++ b/manuals/1.14/quickstart_guide.md
@@ -1,5 +1,5 @@
 ---
-layout: manual
+layout: quickstart
 title: Foreman Quickstart Guide
 version: "1.14"
 ---

--- a/manuals/1.2/quickstart_guide.md
+++ b/manuals/1.2/quickstart_guide.md
@@ -1,5 +1,5 @@
 ---
-layout: manual
+layout: quickstart
 title: Foreman Quickstart Guide
 ---
 

--- a/manuals/1.3/quickstart_guide.md
+++ b/manuals/1.3/quickstart_guide.md
@@ -1,5 +1,5 @@
 ---
-layout: manual
+layout: quickstart
 title: Foreman Quickstart Guide
 version: "1.3"
 ---

--- a/manuals/1.4/quickstart_guide.md
+++ b/manuals/1.4/quickstart_guide.md
@@ -1,5 +1,5 @@
 ---
-layout: manual
+layout: quickstart
 title: Foreman Quickstart Guide
 version: "1.4"
 ---

--- a/manuals/1.5/quickstart_guide.md
+++ b/manuals/1.5/quickstart_guide.md
@@ -1,5 +1,5 @@
 ---
-layout: manual
+layout: quickstart
 title: Foreman Quickstart Guide
 version: "1.5"
 ---

--- a/manuals/1.6/quickstart_guide.md
+++ b/manuals/1.6/quickstart_guide.md
@@ -1,5 +1,5 @@
 ---
-layout: manual
+layout: quickstart
 title: Foreman Quickstart Guide
 version: "1.6"
 ---

--- a/manuals/1.7/quickstart_guide.md
+++ b/manuals/1.7/quickstart_guide.md
@@ -1,5 +1,5 @@
 ---
-layout: manual
+layout: quickstart
 title: Foreman Quickstart Guide
 version: "1.7"
 ---

--- a/manuals/1.9/quickstart_guide.md
+++ b/manuals/1.9/quickstart_guide.md
@@ -1,5 +1,5 @@
 ---
-layout: manual
+layout: quickstart
 title: Foreman Quickstart Guide
 version: "1.9"
 ---


### PR DESCRIPTION
I found a user today which was using a very old version of Foreman. The reason is that when you google for terms like "foreman install" , "quick install foreman", etc.. on any search engine, the top results are for old versions. For example:

https://duckduckgo.com/?q=quick+install+foreman&t=ffab&ia=web
https://encrypted.google.com/search?hl=en&q=quick%20install%20foreman

This PR makes the quickstart layout different from the manual layout and adds a warning about it.

![screenshot from 2017-02-04 11-50-04](https://cloud.githubusercontent.com/assets/598891/22617911/24462838-ead0-11e6-8ca6-76c0fe8a9794.png)
![screenshot from 2017-02-04 11-50-28](https://cloud.githubusercontent.com/assets/598891/22617912/2448933e-ead0-11e6-9001-14da438c52ff.png)
