### PR TITLE
Add a backup advise to quickstart install

### DIFF
--- a/_includes/manuals/1.14/2.1_quickstart_installation.md
+++ b/_includes/manuals/1.14/2.1_quickstart_installation.md
@@ -1,4 +1,4 @@
-[The Foreman installer](/manuals/{{page.version}}/index.html#3.2ForemanInstaller) uses Puppet to install Foreman. This guide assumes that you have a newly installed operating system, on which the installer will setup Foreman, a Puppet master, and the [Smart Proxy](/manuals/{{page.version}}/index.html#4.3SmartProxies) by default.
+[The Foreman installer](/manuals/{{page.version}}/index.html#3.2ForemanInstaller) uses Puppet to install Foreman. This guide assumes that you have a newly installed operating system, on which the installer will setup Foreman, a Puppet master, and the [Smart Proxy](/manuals/{{page.version}}/index.html#4.3SmartProxies) by default. It's **not advisable** to follow the steps below on an existing system, since installer will affect configuration of several components.
 
 #### Select operating system
 
@@ -203,6 +203,7 @@ apt-get update && apt-get -y install foreman-installer
 <div class="quickstart_os quickstart_os_ubuntu1404 quickstart_os_ubuntu1604 alert alert-info">
   Ensure that <code>ping $(hostname -f)</code> shows the real IP address, not 127.0.1.1.  Change or remove this entry from /etc/hosts if present.
 </div>
+
 
 The installation run is non-interactive, but the configuration can be customized by supplying any of the options listed in `foreman-installer --help`, or by running `foreman-installer -i` for interactive mode.  More examples are given in the [Installation Options](/manuals/{{page.version}}/index.html#3.2.2InstallerOptions) section.  Adding `-v` will disable the progress bar and display all changes.  To run the installer, execute:
 

--- a/_includes/manuals/1.14/3.2_foreman_installer.md
+++ b/_includes/manuals/1.14/3.2_foreman_installer.md
@@ -18,3 +18,5 @@ Other modules can be enabled, which will also configure:
 
 * ISC DHCP server
 * BIND DNS server
+
+It's recommended to run the installer on a fresh and clean single-purpose system, since the configurations of the before mentioned components is (at least partially) overwritten by the installer.


### PR DESCRIPTION
This commit adds a hint to install instructions that
advises a systems configuration backup for installations on existing
systems.

I feel that advisories is necessary because of puppetlabs/apache module usage :). Not entirely happing with the wording, but I'm unsure what assumptions the installer revolves around. Is is generally based on the assumption that it's running on a fresh system? If so, the hint should probably read way different.