### PR TITLE
Replicate puppet kick behaviour

### DIFF
--- a/_includes/manuals/1.14/4.3.6_smartproxy_puppet.md
+++ b/_includes/manuals/1.14/4.3.6_smartproxy_puppet.md
@@ -202,7 +202,7 @@ The puppet_proxy_ssh provider uses SSH to connect to the client using SSH keys a
 
 <pre>
 # the command which will be sent to the host
-:command: /usr/bin/puppet agent --onetime --no-usecacheonfailure
+:command: /usr/bin/puppet agent --onetime --no-usecacheonfailure --no-daemonize
 #
 # whether to use sudo before the ssh command
 :use_sudo: false


### PR DESCRIPTION
Expectation of the SSH provider is to provide similar functionality to `puppet kick`. 

Without  `--no-daemonize` this command will start the background daemon, which I believe will then trigger a run every 30 minutes by default. If puppet is already running, for example as a service or started by a previous "Puppet Run" from foreman this will fail to execute as a second daemon cannot be started. 

With `--no-daemonize` the command runs puppet agent once and then leaves the target system  in the same state as when it started, just like puppet kick.

This may only be relevant to puppet installations from the `puppetlabs-release-pc1` on ubuntu 16.04. I don't have any other systems to test this on. This is the observed behaviour on my system: 

```bash
root@testbox:~ systemctl status puppet
* puppet.service - Puppet agent
   Loaded: loaded (/lib/systemd/system/puppet.service; enabled; vendor preset: enabled)
   Active: active (running) since Fri 2017-02-24 09:40:54 GMT; 5min ago
 Main PID: 42861 (puppet)
   CGroup: /system.slice/puppet.service
           -42861 /opt/puppetlabs/puppet/bin/ruby /opt/puppetlabs/puppet/bin/puppet agent --no-daemonize

root@testbox:~ /opt/puppetlabs/puppet/bin/puppet agent --onetime --no-usecacheonfailure --verbose
Error: Could not run: Could not create PID file: /var/run/puppetlabs/agent.pid

root@testbox:~ /opt/puppetlabs/puppet/bin/puppet agent --onetime --no-usecacheonfailure --no-daemonize --verbose
Info: Using configured environment 'production'
##SNIP##
Notice: Applied catalog in 6.01 seconds
```

