### PR TITLE
Fixes #18839 - Fix old RHEL katello urls

### DIFF
--- a/plugins/katello/3.3/upgrade/clients.md
+++ b/plugins/katello/3.3/upgrade/clients.md
@@ -21,41 +21,41 @@ Update the Katello client release packages:
      <option value="el5">Enterprise Linux 5 (CentOS, etc.)</option>
      <option value="el6">Enterprise Linux 6 (CentOS, etc.)</option>
      <option value="el7">Enterprise Linux 7 (CentOS, etc.)</option>
-     <option value="fc20">Fedora 20</option>
-     <option value="fc21">Fedora 21</option>
+     <option value="fc24">Fedora 24</option>
+     <option value="fc25">Fedora 25</option>
   </select>
 </p>
 
 <div id="el5" markdown="1">
 {% highlight bash %}
-yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/RHEL/5Server/x86_64/katello-client-repos-latest.rpm
+yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/el5/x86_64/katello-client-repos-latest.rpm
 yum -y install http://dl.fedoraproject.org/pub/epel/epel-release-latest-5.noarch.rpm
 {% endhighlight %}
 </div>
 
 <div id="el6" style="display:none;" markdown="1">
 {% highlight bash %}
-yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/RHEL/6Server/x86_64/katello-client-repos-latest.rpm
+yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/el6/x86_64/katello-client-repos-latest.rpm
 yum -y install http://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
 {% endhighlight %}
 </div>
 
 <div id="el7" style="display:none;" markdown="1">
 {% highlight bash %}
-yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/RHEL/7Server/x86_64/katello-client-repos-latest.rpm
+yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/el7/x86_64/katello-client-repos-latest.rpm
 yum -y install http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 {% endhighlight %}
 </div>
 
-<div id="fc20" style="display:none;" markdown="1">
+<div id="fc24" style="display:none;" markdown="1">
 {% highlight bash %}
-yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/RHEL/Fedora/20/x86_64/katello-client-repos-latest.rpm
+yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/fc24/x86_64/katello-client-repos-latest.rpm
 {% endhighlight %}
 </div>
 
-<div id="fc21" style="display:none;" markdown="1">
+<div id="fc25" style="display:none;" markdown="1">
 {% highlight bash %}
-yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/RHEL/Fedora/21/x86_64/katello-client-repos-latest.rpm
+yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/fc25/x86_64/katello-client-repos-latest.rpm
 {% endhighlight %}
 </div>
 

--- a/plugins/katello/3.3/upgrade/index.md
+++ b/plugins/katello/3.3/upgrade/index.md
@@ -38,14 +38,6 @@ yum -y update
 
 Update the Foreman and Katello release packages:
 
-  * RHEL6 / CentOS 6:
-
-{% highlight bash %}
-  yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el6/x86_64/katello-repos-latest.rpm
-  yum update -y http://yum.theforeman.org/releases/{{ page.foreman_version }}/el6/x86_64/foreman-release.rpm
-  yum update -y foreman-release-scl
-{% endhighlight %}
-
   * RHEL7 / CentOS 7:
 
 {% highlight bash %}

--- a/plugins/katello/3.3/upgrade/smart_proxy.md
+++ b/plugins/katello/3.3/upgrade/smart_proxy.md
@@ -21,17 +21,10 @@ yum -y update
 
 Update the Foreman and Katello release packages:
 
-  * RHEL6 / CentOS 6:
-
-{% highlight bash %}
-  yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/RHEL/6Server/x86_64/katello-repos-latest.rpm
-  yum update -y http://yum.theforeman.org/{{ page.foreman_version }}/el6/x86_64/foreman-release.rpm
-{% endhighlight %}
-
   * RHEL7 / CentOS 7:
 
 {% highlight bash %}
-  yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/RHEL/7Server/x86_64/katello-repos-latest.rpm
+  yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el7/x86_64/katello-repos-latest.rpm
   yum update -y http://yum.theforeman.org/{{ page.foreman_version }}/el7/x86_64/foreman-release.rpm
 {% endhighlight %}
 

--- a/plugins/katello/nightly/upgrade/clients.md
+++ b/plugins/katello/nightly/upgrade/clients.md
@@ -21,41 +21,41 @@ Update the Katello client release packages:
      <option value="el5">Enterprise Linux 5 (RHEL, CentOS, etc.)</option>
      <option value="el6">Enterprise Linux 6 (RHEL, CentOS, etc.)</option>
      <option value="el7">Enterprise Linux 7 (RHEL, CentOS, etc.)</option>
-     <option value="fc20">Fedora 20</option>
-     <option value="fc21">Fedora 21</option>
+     <option value="fc24">Fedora 24</option>
+     <option value="fc25">Fedora 25</option>
   </select>
 </p>
 
 <div id="el5" markdown="1">
 {% highlight bash %}
-yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/RHEL/5Server/x86_64/katello-client-repos-latest.rpm
+yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/el5/x86_64/katello-client-repos-latest.rpm
 yum -y install http://dl.fedoraproject.org/pub/epel/epel-release-latest-5.noarch.rpm
 {% endhighlight %}
 </div>
 
 <div id="el6" style="display:none;" markdown="1">
 {% highlight bash %}
-yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/RHEL/6Server/x86_64/katello-client-repos-latest.rpm
+yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/el6/x86_64/katello-client-repos-latest.rpm
 yum -y install http://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
 {% endhighlight %}
 </div>
 
 <div id="el7" style="display:none;" markdown="1">
 {% highlight bash %}
-yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/RHEL/7Server/x86_64/katello-client-repos-latest.rpm
+yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/el7/x86_64/katello-client-repos-latest.rpm
 yum -y install http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 {% endhighlight %}
 </div>
 
-<div id="fc20" style="display:none;" markdown="1">
+<div id="fc24" style="display:none;" markdown="1">
 {% highlight bash %}
-yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/RHEL/Fedora/20/x86_64/katello-client-repos-latest.rpm
+yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/fc24/x86_64/katello-client-repos-latest.rpm
 {% endhighlight %}
 </div>
 
-<div id="fc21" style="display:none;" markdown="1">
+<div id="fc25" style="display:none;" markdown="1">
 {% highlight bash %}
-yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/RHEL/Fedora/21/x86_64/katello-client-repos-latest.rpm
+yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/fc25/x86_64/katello-client-repos-latest.rpm
 {% endhighlight %}
 </div>
 

--- a/plugins/katello/nightly/upgrade/index.md
+++ b/plugins/katello/nightly/upgrade/index.md
@@ -38,18 +38,10 @@ yum -y update
 
 Update the Foreman and Katello release packages:
 
-  * RHEL6 / CentOS 6:
-
-{% highlight bash %}
-  yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/RHEL/6Server/x86_64/katello-repos-latest.rpm
-  yum update -y http://yum.theforeman.org/{{ page.foreman_version }}/el6/x86_64/foreman-release.rpm
-  yum update -y foreman-release-scl
-{% endhighlight %}
-
   * RHEL7 / CentOS 7:
 
 {% highlight bash %}
-  yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/RHEL/7Server/x86_64/katello-repos-latest.rpm
+  yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el7/x86_64/katello-repos-latest.rpm
   yum update -y http://yum.theforeman.org/{{ page.foreman_version }}/el7/x86_64/foreman-release.rpm
   yum update -y foreman-release-scl
 {% endhighlight %}

--- a/plugins/katello/nightly/upgrade/smart_proxy.md
+++ b/plugins/katello/nightly/upgrade/smart_proxy.md
@@ -21,17 +21,10 @@ yum -y update
 
 Update the Foreman and Katello release packages:
 
-  * RHEL6 / CentOS 6:
-
-{% highlight bash %}
-  yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/RHEL/6Server/x86_64/katello-repos-latest.rpm
-  yum update -y http://yum.theforeman.org/{{ page.foreman_version }}/el6/x86_64/foreman-release.rpm
-{% endhighlight %}
-
   * RHEL7 / CentOS 7:
 
 {% highlight bash %}
-  yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/RHEL/7Server/x86_64/katello-repos-latest.rpm
+  yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el7/x86_64/katello-repos-latest.rpm
   yum update -y http://yum.theforeman.org/{{ page.foreman_version }}/el7/x86_64/foreman-release.rpm
 {% endhighlight %}
 


### PR DESCRIPTION
also removes some RHEL 6 instructions
and updates fedora urls