### PR TITLE
Fix the return button functionality in blog posts.

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -35,7 +35,7 @@
 
       <div class="row">
         <div class="col-md-6 col-sm-6 col-xs-6">
-          <a href="{{site.baseurl}}blog/" class="btn btn-foreman-blue"><span aria-hidden="true">&larr;</span> Return</a>
+          <a href="javascript: history.go(-1)" class="btn btn-foreman-blue"><span aria-hidden="true">&larr;</span> Return</a>
         </div>
         <div class="col-md-6 col-sm-6 col-xs-6 clearfix">
           <div class="pull-right">


### PR DESCRIPTION
At present, consider that i am on the last page and i am reading the first blog on that page. After reading the blog i wish to read the next blog on the same page, if i press "RETURN" button it will take me to the first page and i shall have to traverse again till the last page to read the blog.

This patch takes care of the above problem. 