### PR TITLE
Fix Katello Doc Menu to include 3.3

### DIFF
--- a/_layouts/plugins/katello/documentation.html
+++ b/_layouts/plugins/katello/documentation.html
@@ -1,6 +1,6 @@
 ---
 pagename: Plugin Manuals
-versions: [3.2, 3.1, 3.0, 2.4, nightly]
+versions: [3.3, 3.2, 3.1, 3.0, 2.4, nightly]
 ---
 
 {% include header.html %}


### PR DESCRIPTION
I hope this is the menu for the quick jump between versions inside the katello docs :)