### PR TITLE
Fix broken link in katello docs

### DIFF
--- a/plugins/katello/2.4/user_guide/red_hat_content/index.md
+++ b/plugins/katello/2.4/user_guide/red_hat_content/index.md
@@ -33,7 +33,7 @@ If you are a Red Hat customer, you should have access to the Red Hat Customer Po
 
 To access the Red Hat Customer Portal, [click here](https://access.redhat.com/management)
 
-For details on how to create a subscription manifest, [click here](http://docs.redhat.com/docs/en-US/Red_Hat_Customer_Portal/1/html/Red_Hat_Network_Certificate-based_Subscription_Management/managing-sam.html)
+For details on how to create a subscription manifest, [click here](https://access.redhat.com/documentation/en-US/Red_Hat_Customer_Portal/1/html/Red_Hat_Network_Certificate-based_Subscription_Management/managing-sam.html)
 
 ## Import the Subscription Manifest
 

--- a/plugins/katello/3.0/user_guide/red_hat_content/index.md
+++ b/plugins/katello/3.0/user_guide/red_hat_content/index.md
@@ -32,7 +32,7 @@ If you are a Red Hat customer, you should have access to the Red Hat Customer Po
 
 To access the Red Hat Customer Portal, [click here](https://access.redhat.com/management)
 
-For details on how to create a subscription manifest, [click here](http://docs.redhat.com/plugins/katello/en-US/Red_Hat_Customer_Portal/1/html/Red_Hat_Network_Certificate-based_Subscription_Management/managing-sam.html)
+For details on how to create a subscription manifest, [click here](https://access.redhat.com/documentation/en-US/Red_Hat_Customer_Portal/1/html/Red_Hat_Network_Certificate-based_Subscription_Management/managing-sam.html)
 
 ## Import the Subscription Manifest
 

--- a/plugins/katello/3.1/user_guide/red_hat_content/index.md
+++ b/plugins/katello/3.1/user_guide/red_hat_content/index.md
@@ -32,7 +32,7 @@ If you are a Red Hat customer, you should have access to the Red Hat Customer Po
 
 To access the Red Hat Customer Portal, [click here](https://access.redhat.com/management)
 
-For details on how to create a subscription manifest, [click here](http://docs.redhat.com/plugins/katello/en-US/Red_Hat_Customer_Portal/1/html/Red_Hat_Network_Certificate-based_Subscription_Management/managing-sam.html)
+For details on how to create a subscription manifest, [click here](https://access.redhat.com/documentation/en-US/Red_Hat_Customer_Portal/1/html/Red_Hat_Network_Certificate-based_Subscription_Management/managing-sam.html)
 
 ## Import the Subscription Manifest
 

--- a/plugins/katello/3.2/user_guide/red_hat_content/index.md
+++ b/plugins/katello/3.2/user_guide/red_hat_content/index.md
@@ -32,7 +32,7 @@ If you are a Red Hat customer, you should have access to the Red Hat Customer Po
 
 To access the Red Hat Customer Portal, [click here](https://access.redhat.com/management)
 
-For details on how to create a subscription manifest, [click here](http://docs.redhat.com/plugins/katello/en-US/Red_Hat_Customer_Portal/1/html/Red_Hat_Network_Certificate-based_Subscription_Management/managing-sam.html)
+For details on how to create a subscription manifest, [click here](https://access.redhat.com/documentation/en-US/Red_Hat_Customer_Portal/1/html/Red_Hat_Network_Certificate-based_Subscription_Management/managing-sam.html)
 
 ## Import the Subscription Manifest
 

--- a/plugins/katello/3.3/user_guide/red_hat_content/index.md
+++ b/plugins/katello/3.3/user_guide/red_hat_content/index.md
@@ -32,7 +32,7 @@ If you are a Red Hat customer, you should have access to the Red Hat Customer Po
 
 To access the Red Hat Customer Portal, [click here](https://access.redhat.com/management)
 
-For details on how to create a subscription manifest, [click here](http://docs.redhat.com/plugins/katello/en-US/Red_Hat_Customer_Portal/1/html/Red_Hat_Network_Certificate-based_Subscription_Management/managing-sam.html)
+For details on how to create a subscription manifest, [click here](https://access.redhat.com/documentation/en-US/Red_Hat_Customer_Portal/1/html/Red_Hat_Network_Certificate-based_Subscription_Management/managing-sam.html)
 
 ## Import the Subscription Manifest
 

--- a/plugins/katello/3.4/user_guide/red_hat_content/index.md
+++ b/plugins/katello/3.4/user_guide/red_hat_content/index.md
@@ -32,7 +32,7 @@ If you are a Red Hat customer, you should have access to the Red Hat Customer Po
 
 To access the Red Hat Customer Portal, [click here](https://access.redhat.com/management)
 
-For details on how to create a subscription manifest, [click here](http://docs.redhat.com/plugins/katello/en-US/Red_Hat_Customer_Portal/1/html/Red_Hat_Network_Certificate-based_Subscription_Management/managing-sam.html)
+For details on how to create a subscription manifest, [click here](https://access.redhat.com/documentation/en-US/Red_Hat_Customer_Portal/1/html/Red_Hat_Network_Certificate-based_Subscription_Management/managing-sam.html)
 
 ## Import the Subscription Manifest
 

--- a/plugins/katello/nightly/user_guide/red_hat_content/index.md
+++ b/plugins/katello/nightly/user_guide/red_hat_content/index.md
@@ -32,7 +32,7 @@ If you are a Red Hat customer, you should have access to the Red Hat Customer Po
 
 To access the Red Hat Customer Portal, [click here](https://access.redhat.com/management)
 
-For details on how to create a subscription manifest, [click here](http://docs.redhat.com/plugins/katello/en-US/Red_Hat_Customer_Portal/1/html/Red_Hat_Network_Certificate-based_Subscription_Management/managing-sam.html)
+For details on how to create a subscription manifest, [click here](https://access.redhat.com/documentation/en-US/Red_Hat_Customer_Portal/1/html/Red_Hat_Network_Certificate-based_Subscription_Management/managing-sam.html)
 
 ## Import the Subscription Manifest
 


### PR DESCRIPTION
The link on how to create a manifest zip is broken, this should fix it