### PR TITLE
use HTTPS for all GitHub links

### DIFF
--- a/_includes/manuals/1.1/3.5.1_initial_setup.md
+++ b/_includes/manuals/1.1/3.5.1_initial_setup.md
@@ -39,7 +39,7 @@ and point your browser to `http://foreman:3000`
 
 If you would like to keep the server running, its recommend to setup
 passenger or use the RPM. Example usage with passenger can be found on
-[GitHub](http://github.com/theforeman/puppet-foreman/blob/master/templates/foreman-vhost.conf.erb).
+[GitHub](https://github.com/theforeman/puppet-foreman/blob/master/templates/foreman-vhost.conf.erb).
 
 #### Getting your Puppet Reports into Foreman
 

--- a/_includes/manuals/1.10/3.4_install_from_source.md
+++ b/_includes/manuals/1.10/3.4_install_from_source.md
@@ -66,13 +66,6 @@ to get latest "stable" version do:
 git clone https://github.com/theforeman/foreman.git -b {{page.version}}-stable
 {% endhighlight %}
 
-If you are behind a proxy or firewall and don't have access to Github
-using the git protocol, use http protocol instead:
-
-{% highlight bash %}
-git clone http://github.com/theforeman/foreman.git foreman -b {{page.version}}-stable
-{% endhighlight %}
-
 ### CLI (Hammer)
 
 To install hammer from git checkouts, you will just need ```rake``` installed on your system.

--- a/_includes/manuals/1.10/3.5.1_initial_setup.md
+++ b/_includes/manuals/1.10/3.5.1_initial_setup.md
@@ -36,7 +36,7 @@ and point your browser to `http://foreman:3000`
 
 If you would like to keep the server running, its recommend to setup
 passenger or use the RPM. Example usage with passenger can be found on
-[GitHub](http://github.com/theforeman/puppet-foreman/blob/master/templates/foreman-vhost.conf.erb).
+[GitHub](https://github.com/theforeman/puppet-foreman/blob/master/templates/foreman-vhost.conf.erb).
 
 #### Getting your Puppet Reports into Foreman
 

--- a/_includes/manuals/1.11/3.4_install_from_source.md
+++ b/_includes/manuals/1.11/3.4_install_from_source.md
@@ -64,13 +64,6 @@ to get latest "stable" version do:
 git clone https://github.com/theforeman/foreman.git -b {{page.version}}-stable
 {% endhighlight %}
 
-If you are behind a proxy or firewall and don't have access to Github
-using the git protocol, use http protocol instead:
-
-{% highlight bash %}
-git clone https://github.com/theforeman/foreman.git foreman -b {{page.version}}-stable
-{% endhighlight %}
-
 ### CLI (Hammer)
 
 To install hammer from git checkouts, you will just need ```rake``` installed on your system.

--- a/_includes/manuals/1.11/3.5.1_initial_setup.md
+++ b/_includes/manuals/1.11/3.5.1_initial_setup.md
@@ -36,7 +36,7 @@ and point your browser to `http://foreman:3000`
 
 If you would like to keep the server running, its recommend to setup
 passenger or use the RPM. Example usage with passenger can be found on
-[GitHub](http://github.com/theforeman/puppet-foreman/blob/master/templates/foreman-vhost.conf.erb).
+[GitHub](https://github.com/theforeman/puppet-foreman/blob/master/templates/foreman-vhost.conf.erb).
 
 #### Getting your Puppet Reports into Foreman
 

--- a/_includes/manuals/1.12/3.4_install_from_source.md
+++ b/_includes/manuals/1.12/3.4_install_from_source.md
@@ -64,13 +64,6 @@ to get latest "stable" version do:
 git clone https://github.com/theforeman/foreman.git -b {{page.version}}-stable
 {% endhighlight %}
 
-If you are behind a proxy or firewall and don't have access to Github
-using the git protocol, use http protocol instead:
-
-{% highlight bash %}
-git clone https://github.com/theforeman/foreman.git foreman -b {{page.version}}-stable
-{% endhighlight %}
-
 ### CLI (Hammer)
 
 To install hammer from git checkouts, you will just need ```rake``` installed on your system.

--- a/_includes/manuals/1.12/3.5.1_initial_setup.md
+++ b/_includes/manuals/1.12/3.5.1_initial_setup.md
@@ -36,7 +36,7 @@ and point your browser to `http://foreman:3000`
 
 If you would like to keep the server running, its recommend to setup
 passenger or use the RPM. Example usage with passenger can be found on
-[GitHub](http://github.com/theforeman/puppet-foreman/blob/master/templates/foreman-vhost.conf.erb).
+[GitHub](https://github.com/theforeman/puppet-foreman/blob/master/templates/foreman-vhost.conf.erb).
 
 #### Getting your Puppet Reports into Foreman
 

--- a/_includes/manuals/1.13/3.4_install_from_source.md
+++ b/_includes/manuals/1.13/3.4_install_from_source.md
@@ -63,13 +63,6 @@ to get latest "stable" version do:
 git clone https://github.com/theforeman/foreman.git -b {{page.version}}-stable
 {% endhighlight %}
 
-If you are behind a proxy or firewall and don't have access to Github
-using the git protocol, use http protocol instead:
-
-{% highlight bash %}
-git clone https://github.com/theforeman/foreman.git foreman -b {{page.version}}-stable
-{% endhighlight %}
-
 ### CLI (Hammer)
 
 To install hammer from git checkouts, you will just need ```rake``` installed on your system.

--- a/_includes/manuals/1.13/3.5.1_initial_setup.md
+++ b/_includes/manuals/1.13/3.5.1_initial_setup.md
@@ -36,7 +36,7 @@ and point your browser to `http://foreman:3000`
 
 If you would like to keep the server running, its recommend to setup
 passenger or use the RPM. Example usage with passenger can be found on
-[GitHub](http://github.com/theforeman/puppet-foreman/blob/master/templates/foreman-vhost.conf.erb).
+[GitHub](https://github.com/theforeman/puppet-foreman/blob/master/templates/foreman-vhost.conf.erb).
 
 #### Getting your Puppet Reports into Foreman
 

--- a/_includes/manuals/1.14/3.4_install_from_source.md
+++ b/_includes/manuals/1.14/3.4_install_from_source.md
@@ -63,13 +63,6 @@ to get latest "stable" version do:
 git clone https://github.com/theforeman/foreman.git -b {{page.version}}-stable
 {% endhighlight %}
 
-If you are behind a proxy or firewall and don't have access to Github
-using the git protocol, use http protocol instead:
-
-{% highlight bash %}
-git clone https://github.com/theforeman/foreman.git foreman -b {{page.version}}-stable
-{% endhighlight %}
-
 ### CLI (Hammer)
 
 To install hammer from git checkouts, you will just need ```rake``` installed on your system.

--- a/_includes/manuals/1.14/3.5.1_initial_setup.md
+++ b/_includes/manuals/1.14/3.5.1_initial_setup.md
@@ -36,7 +36,7 @@ and point your browser to `http://foreman:3000`
 
 If you would like to keep the server running, its recommend to setup
 passenger or use the RPM. Example usage with passenger can be found on
-[GitHub](http://github.com/theforeman/puppet-foreman/blob/master/templates/foreman-vhost.conf.erb).
+[GitHub](https://github.com/theforeman/puppet-foreman/blob/master/templates/foreman-vhost.conf.erb).
 
 #### Getting your Puppet Reports into Foreman
 

--- a/_includes/manuals/1.15/3.4_install_from_source.md
+++ b/_includes/manuals/1.15/3.4_install_from_source.md
@@ -63,13 +63,6 @@ to get latest "stable" version do:
 git clone https://github.com/theforeman/foreman.git -b {{page.version}}-stable
 {% endhighlight %}
 
-If you are behind a proxy or firewall and don't have access to Github
-using the git protocol, use http protocol instead:
-
-{% highlight bash %}
-git clone https://github.com/theforeman/foreman.git foreman -b {{page.version}}-stable
-{% endhighlight %}
-
 ### CLI (Hammer)
 
 To install hammer from git checkouts, you will just need ```rake``` installed on your system.

--- a/_includes/manuals/1.15/3.5.1_initial_setup.md
+++ b/_includes/manuals/1.15/3.5.1_initial_setup.md
@@ -36,7 +36,7 @@ and point your browser to `http://foreman:3000`
 
 If you would like to keep the server running, its recommend to setup
 passenger or use the RPM. Example usage with passenger can be found on
-[GitHub](http://github.com/theforeman/puppet-foreman/blob/master/templates/foreman-vhost.conf.erb).
+[GitHub](https://github.com/theforeman/puppet-foreman/blob/master/templates/foreman-vhost.conf.erb).
 
 #### Getting your Puppet Reports into Foreman
 

--- a/_includes/manuals/1.2/3.5.1_initial_setup.md
+++ b/_includes/manuals/1.2/3.5.1_initial_setup.md
@@ -38,7 +38,7 @@ and point your browser to `http://foreman:3000`
 
 If you would like to keep the server running, its recommend to setup
 passenger or use the RPM. Example usage with passenger can be found on
-[GitHub](http://github.com/theforeman/puppet-foreman/blob/master/templates/foreman-vhost.conf.erb).
+[GitHub](https://github.com/theforeman/puppet-foreman/blob/master/templates/foreman-vhost.conf.erb).
 
 #### Getting your Puppet Reports into Foreman
 

--- a/_includes/manuals/1.3/3.4_install_from_source.md
+++ b/_includes/manuals/1.3/3.4_install_from_source.md
@@ -57,13 +57,6 @@ to get latest "stable" version do:
 git clone https://github.com/theforeman/foreman.git -b {{page.version}}-stable
 {% endhighlight %}
 
-If you are behind a proxy or firewall and don't have access to Github
-using the git protocol, use http protocol instead:
-
-{% highlight bash %}
-git clone http://github.com/theforeman/foreman.git foreman -b {{page.version}}-stable
-{% endhighlight %}
-
 ### CLI (Hammer)
 
 To install hammer from git checkouts, you will just need ```rake``` installed on your system.

--- a/_includes/manuals/1.3/3.5.1_initial_setup.md
+++ b/_includes/manuals/1.3/3.5.1_initial_setup.md
@@ -35,7 +35,7 @@ and point your browser to `http://foreman:3000`
 
 If you would like to keep the server running, its recommend to setup
 passenger or use the RPM. Example usage with passenger can be found on
-[GitHub](http://github.com/theforeman/puppet-foreman/blob/master/templates/foreman-vhost.conf.erb).
+[GitHub](https://github.com/theforeman/puppet-foreman/blob/master/templates/foreman-vhost.conf.erb).
 
 #### Getting your Puppet Reports into Foreman
 

--- a/_includes/manuals/1.4/3.4_install_from_source.md
+++ b/_includes/manuals/1.4/3.4_install_from_source.md
@@ -57,13 +57,6 @@ to get latest "stable" version do:
 git clone https://github.com/theforeman/foreman.git -b {{page.version}}-stable
 {% endhighlight %}
 
-If you are behind a proxy or firewall and don't have access to Github
-using the git protocol, use http protocol instead:
-
-{% highlight bash %}
-git clone http://github.com/theforeman/foreman.git foreman -b {{page.version}}-stable
-{% endhighlight %}
-
 ### CLI (Hammer)
 
 To install hammer from git checkouts, you will just need ```rake``` installed on your system.

--- a/_includes/manuals/1.4/3.5.1_initial_setup.md
+++ b/_includes/manuals/1.4/3.5.1_initial_setup.md
@@ -36,7 +36,7 @@ and point your browser to `http://foreman:3000`
 
 If you would like to keep the server running, its recommend to setup
 passenger or use the RPM. Example usage with passenger can be found on
-[GitHub](http://github.com/theforeman/puppet-foreman/blob/master/templates/foreman-vhost.conf.erb).
+[GitHub](https://github.com/theforeman/puppet-foreman/blob/master/templates/foreman-vhost.conf.erb).
 
 #### Getting your Puppet Reports into Foreman
 

--- a/_includes/manuals/1.5/3.4_install_from_source.md
+++ b/_includes/manuals/1.5/3.4_install_from_source.md
@@ -57,13 +57,6 @@ to get latest "stable" version do:
 git clone https://github.com/theforeman/foreman.git -b {{page.version}}-stable
 {% endhighlight %}
 
-If you are behind a proxy or firewall and don't have access to Github
-using the git protocol, use http protocol instead:
-
-{% highlight bash %}
-git clone http://github.com/theforeman/foreman.git foreman -b {{page.version}}-stable
-{% endhighlight %}
-
 ### CLI (Hammer)
 
 To install hammer from git checkouts, you will just need ```rake``` installed on your system.

--- a/_includes/manuals/1.5/3.5.1_initial_setup.md
+++ b/_includes/manuals/1.5/3.5.1_initial_setup.md
@@ -36,7 +36,7 @@ and point your browser to `http://foreman:3000`
 
 If you would like to keep the server running, its recommend to setup
 passenger or use the RPM. Example usage with passenger can be found on
-[GitHub](http://github.com/theforeman/puppet-foreman/blob/master/templates/foreman-vhost.conf.erb).
+[GitHub](https://github.com/theforeman/puppet-foreman/blob/master/templates/foreman-vhost.conf.erb).
 
 #### Getting your Puppet Reports into Foreman
 

--- a/_includes/manuals/1.6/3.4_install_from_source.md
+++ b/_includes/manuals/1.6/3.4_install_from_source.md
@@ -57,13 +57,6 @@ to get latest "stable" version do:
 git clone https://github.com/theforeman/foreman.git -b {{page.version}}-stable
 {% endhighlight %}
 
-If you are behind a proxy or firewall and don't have access to Github
-using the git protocol, use http protocol instead:
-
-{% highlight bash %}
-git clone http://github.com/theforeman/foreman.git foreman -b {{page.version}}-stable
-{% endhighlight %}
-
 ### CLI (Hammer)
 
 To install hammer from git checkouts, you will just need ```rake``` installed on your system.

--- a/_includes/manuals/1.6/3.5.1_initial_setup.md
+++ b/_includes/manuals/1.6/3.5.1_initial_setup.md
@@ -36,7 +36,7 @@ and point your browser to `http://foreman:3000`
 
 If you would like to keep the server running, its recommend to setup
 passenger or use the RPM. Example usage with passenger can be found on
-[GitHub](http://github.com/theforeman/puppet-foreman/blob/master/templates/foreman-vhost.conf.erb).
+[GitHub](https://github.com/theforeman/puppet-foreman/blob/master/templates/foreman-vhost.conf.erb).
 
 #### Getting your Puppet Reports into Foreman
 

--- a/_includes/manuals/1.7/3.4_install_from_source.md
+++ b/_includes/manuals/1.7/3.4_install_from_source.md
@@ -57,13 +57,6 @@ to get latest "stable" version do:
 git clone https://github.com/theforeman/foreman.git -b {{page.version}}-stable
 {% endhighlight %}
 
-If you are behind a proxy or firewall and don't have access to Github
-using the git protocol, use http protocol instead:
-
-{% highlight bash %}
-git clone http://github.com/theforeman/foreman.git foreman -b {{page.version}}-stable
-{% endhighlight %}
-
 ### CLI (Hammer)
 
 To install hammer from git checkouts, you will just need ```rake``` installed on your system.

--- a/_includes/manuals/1.7/3.5.1_initial_setup.md
+++ b/_includes/manuals/1.7/3.5.1_initial_setup.md
@@ -36,7 +36,7 @@ and point your browser to `http://foreman:3000`
 
 If you would like to keep the server running, its recommend to setup
 passenger or use the RPM. Example usage with passenger can be found on
-[GitHub](http://github.com/theforeman/puppet-foreman/blob/master/templates/foreman-vhost.conf.erb).
+[GitHub](https://github.com/theforeman/puppet-foreman/blob/master/templates/foreman-vhost.conf.erb).
 
 #### Getting your Puppet Reports into Foreman
 

--- a/_includes/manuals/1.8/3.4_install_from_source.md
+++ b/_includes/manuals/1.8/3.4_install_from_source.md
@@ -61,13 +61,6 @@ to get latest "stable" version do:
 git clone https://github.com/theforeman/foreman.git -b {{page.version}}-stable
 {% endhighlight %}
 
-If you are behind a proxy or firewall and don't have access to Github
-using the git protocol, use http protocol instead:
-
-{% highlight bash %}
-git clone http://github.com/theforeman/foreman.git foreman -b {{page.version}}-stable
-{% endhighlight %}
-
 ### CLI (Hammer)
 
 To install hammer from git checkouts, you will just need ```rake``` installed on your system.

--- a/_includes/manuals/1.8/3.5.1_initial_setup.md
+++ b/_includes/manuals/1.8/3.5.1_initial_setup.md
@@ -36,7 +36,7 @@ and point your browser to `http://foreman:3000`
 
 If you would like to keep the server running, its recommend to setup
 passenger or use the RPM. Example usage with passenger can be found on
-[GitHub](http://github.com/theforeman/puppet-foreman/blob/master/templates/foreman-vhost.conf.erb).
+[GitHub](https://github.com/theforeman/puppet-foreman/blob/master/templates/foreman-vhost.conf.erb).
 
 #### Getting your Puppet Reports into Foreman
 

--- a/_includes/manuals/1.9/3.4_install_from_source.md
+++ b/_includes/manuals/1.9/3.4_install_from_source.md
@@ -61,13 +61,6 @@ to get latest "stable" version do:
 git clone https://github.com/theforeman/foreman.git -b {{page.version}}-stable
 {% endhighlight %}
 
-If you are behind a proxy or firewall and don't have access to Github
-using the git protocol, use http protocol instead:
-
-{% highlight bash %}
-git clone http://github.com/theforeman/foreman.git foreman -b {{page.version}}-stable
-{% endhighlight %}
-
 ### CLI (Hammer)
 
 To install hammer from git checkouts, you will just need ```rake``` installed on your system.

--- a/_includes/manuals/1.9/3.5.1_initial_setup.md
+++ b/_includes/manuals/1.9/3.5.1_initial_setup.md
@@ -36,7 +36,7 @@ and point your browser to `http://foreman:3000`
 
 If you would like to keep the server running, its recommend to setup
 passenger or use the RPM. Example usage with passenger can be found on
-[GitHub](http://github.com/theforeman/puppet-foreman/blob/master/templates/foreman-vhost.conf.erb).
+[GitHub](https://github.com/theforeman/puppet-foreman/blob/master/templates/foreman-vhost.conf.erb).
 
 #### Getting your Puppet Reports into Foreman
 

--- a/_posts/2012-10-23-open-source-infrastructure-for-foreman.md
+++ b/_posts/2012-10-23-open-source-infrastructure-for-foreman.md
@@ -21,7 +21,7 @@ the Puppet code locked up, we decided specifically to make it public.
 There are lots of benefits of doing this, but it made sense specifically
 for us so others can help manage the infrastructure on an unfettered
 basis. Lots of other benefits come with [public Puppet
-code](http://github.com/theforeman/foreman-infra), too, like thinking
+code](https://github.com/theforeman/foreman-infra), too, like thinking
 more acutely about storing private information in the repositories and
 reducing the ability of manual changes to cause issues in the test
 environment.  

--- a/_posts/2012-11-01-debian-packaging-transparent-way.md
+++ b/_posts/2012-11-01-debian-packaging-transparent-way.md
@@ -25,7 +25,7 @@ more open.
 ### Packaging in the open
 
 The first piece of the puzzle starts with our foreman-rpms repo
-([github.com/theforeman/foreman-rpms](http://github.com/theforeman/foreman-rpms))  
+([github.com/theforeman/foreman-rpms](https://github.com/theforeman/foreman-rpms))  
 in this repo we store all the packaging data for the foreman packages,
 both deb and rpm. In the case of Debian, you'll see a structure like:  
   
@@ -143,7 +143,7 @@ months time ;)
 If anyone is interested in replicating the whole chain, you can get our
 pbuilder  
 puppet configuration from our infrstructure repo at
-[github.com/theforeman/foreman-infra](http://github.com/theforeman/foreman-infra)  
+[github.com/theforeman/foreman-infra](https://github.com/theforeman/foreman-infra)  
   
 This repo contains the puppet code we use to build the various parts of
 our  

--- a/_posts/2014-10-01-foreman-community-newsletter-september.md
+++ b/_posts/2014-10-01-foreman-community-newsletter-september.md
@@ -41,7 +41,7 @@ fixed in 1.6.1.
 
 ### New plugins
 
-**[foreman\_graphite](http://github.com/theforeman/foreman_graphite)**
+**[foreman\_graphite](https://github.com/theforeman/foreman_graphite)**
 adds graphite support for your Foreman infrastructure instances.
 Configure where to send your performance metrics through a YAML file.  
   
@@ -51,7 +51,7 @@ Authentication is done through SSH keys and parameters to filter subsets
 of hosts are available.  
   
 Rundeck support will be moved out of core for 1.7.
-**[foreman\_host\_rundeck](http://github.com/theforeman/foreman_host_rundeck)**
+**[foreman\_host\_rundeck](https://github.com/theforeman/foreman_host_rundeck)**
 will allow users to get a YAML representation of hosts for Rundeck.  
   
 [**foreman\_salt**](https://github.com/theforeman/foreman_salt/)

--- a/_posts/2015-11-16-foreman-ssl.md
+++ b/_posts/2015-11-16-foreman-ssl.md
@@ -30,7 +30,7 @@ For the following examples, the new certificates live in the following locations
 Foreman
 =======
 
-Foreman is presented via mod_passenger on Apache, so the SSL keys need to be changed in your apache VirtualHost. For me this was `/etc//httpd/conf.d/05-foreman-ssl.conf`.
+Foreman is presented via mod_passenger on Apache, so the SSL keys need to be changed in your apache VirtualHost. For me this was `/etc/httpd/conf.d/05-foreman-ssl.conf`.
 
 The following options need to be changed: `SSLCertificateFile`, `SSLCertificateKeyFile` and `SSLCertificateChainFile`.
 It is important that you do **not** change `SSLCACertificateFile` or `SSLCARevocationFile`, as these are used for client authentication. Your final config should look like this:

--- a/_posts/2016-09-29-foreman-community-newsletter---september-2016.md
+++ b/_posts/2016-09-29-foreman-community-newsletter---september-2016.md
@@ -114,7 +114,7 @@ changes.
 - [foreman_remote_execution](https://github.com/theforeman/foreman_remote_execution) updated to 1.2.1
 - [foreman_templates](https://github.com/theforeman/foreman_templates) updated to 3.0.0
 - [foreman_xen](https://github.com/theforeman/foreman-xen) updated to 0.3.1
-- [hammer_cli](http://github.com/theforeman/hammer-cli) updated to 0.8.0
+- [hammer_cli](https://github.com/theforeman/hammer-cli) updated to 0.8.0
 
 - [smart_proxy_dns_infoblox](https://github.com/theforeman/smart_proxy_dns_infoblox) &
   [smart_proxy_dhcp_infoblox](https://github.com/theforeman/smart_proxy_dhcp_infoblox) now RPM & DEB packaged

--- a/manuals/0.4/2_Quickstart_Guide.md
+++ b/manuals/0.4/2_Quickstart_Guide.md
@@ -17,7 +17,7 @@ export MODULE_PATH="/etc/puppet/modules/common"
 mkdir -p $MODULE_PATH
 for mod in apache foreman foreman_proxy git passenger puppet tftp xinetd; do
   mkdir -p $MODULE_PATH/$mod
-  wget http://github.com/theforeman/puppet-$mod/tarball/master -O - | tar xzvf - -C $MODULE_PATH/$mod --strip-components=1
+  wget https://github.com/theforeman/puppet-$mod/tarball/master -O - | tar xzvf - -C $MODULE_PATH/$mod --strip-components=1
 done;
 {% endhighlight %}
 

--- a/mentoring.md
+++ b/mentoring.md
@@ -107,7 +107,7 @@ currently available projects.
 ## Project Suggestions
 
 Send a pull request with the content of your proposal to [theforeman.org at
-GitHub](http://github.com/theforeman/theforeman.org). See [Dave Neary's
+GitHub](https://github.com/theforeman/theforeman.org). See [Dave Neary's
 post](http://www.outercurve.org/Blogs/EntryId/45/Making-the-most-of-Google-Summer-of-Code-Dave-Neary-guest-blogger)
 for suggestions on how to propose ideas.
 

--- a/plugins/katello/2.4/release_notes/release_notes.md
+++ b/plugins/katello/2.4/release_notes/release_notes.md
@@ -9,7 +9,7 @@ title: Release Notes
 ## Bug Fixes 
 
 ### Dashboard
- * Dashboard gives undefined method `label' for nil:NilClass ([#13823](http://projects.theforeman.org/issues/13823), [dc50145a](http://github.com/katello//commit/dc50145ae2d74847fc6a0563963a50ee7cde2e4d))
+ * Dashboard gives undefined method `label' for nil:NilClass ([#13823](http://projects.theforeman.org/issues/13823), [dc50145a](https://github.com/katello//commit/dc50145ae2d74847fc6a0563963a50ee7cde2e4d))
 
 ### Pulp
  * Task pending on waiting for Pulp to start the task ([#13799](http://projects.theforeman.org/issues/13799))
@@ -20,11 +20,11 @@ title: Release Notes
  * Generate Capsule Metadata and Sync fails - Host did not respond within 20 seconds. Is katello-agent installed and goferd running on the Host ([#11971](http://projects.theforeman.org/issues/11971))
 
 ### API
- * incremental update with puppet fails with error 'undefined method `id_search'  ([#13253](http://projects.theforeman.org/issues/13253), [4192beda](http://github.com/katello//commit/4192beda1ccadd4ba52cbc524732ba68c9be7299))
- * System product content does not show redhat content ([#13010](http://projects.theforeman.org/issues/13010), [2d7c3558](http://github.com/katello//commit/2d7c35580d5fcfad5e0b95114ab62f34494d7dca))
+ * incremental update with puppet fails with error 'undefined method `id_search'  ([#13253](http://projects.theforeman.org/issues/13253), [4192beda](https://github.com/katello//commit/4192beda1ccadd4ba52cbc524732ba68c9be7299))
+ * System product content does not show redhat content ([#13010](http://projects.theforeman.org/issues/13010), [2d7c3558](https://github.com/katello//commit/2d7c35580d5fcfad5e0b95114ab62f34494d7dca))
 
 ### Activation Key
- * Can't delete activation key ([#12984](http://projects.theforeman.org/issues/12984), [de57a7b7](http://github.com/katello//commit/de57a7b79357cc5974f13d0f922e103805940661))
+ * Can't delete activation key ([#12984](http://projects.theforeman.org/issues/12984), [de57a7b7](https://github.com/katello//commit/de57a7b79357cc5974f13d0f922e103805940661))
 
 ### Other
  * After upgrade to foreman 1.10 my smart proxy is no anymore sync and is only sending resetting dropped connection ([#13286](http://projects.theforeman.org/issues/13286))
@@ -41,84 +41,84 @@ title: Release Notes
  * Support number of pulp workers in katello-installer ([#12062](http://projects.theforeman.org/issues/12062))
 
 ### Capsule
- * Content Source should be considered a host proxy ([#11748](http://projects.theforeman.org/issues/11748), [35fe89c6](http://github.com/katello/katello/commit/35fe89c660662148ce14fcc6079509ca45d266ed))
+ * Content Source should be considered a host proxy ([#11748](http://projects.theforeman.org/issues/11748), [35fe89c6](https://github.com/katello/katello/commit/35fe89c660662148ce14fcc6079509ca45d266ed))
 
 ### Web UI
- * Add Package Groups to the UI ([#11337](http://projects.theforeman.org/issues/11337), [745d8f3d](http://github.com/katello/katello/commit/745d8f3db9a180fd21c7fc30cd58fa3ca1ed8378))
+ * Add Package Groups to the UI ([#11337](http://projects.theforeman.org/issues/11337), [745d8f3d](https://github.com/katello/katello/commit/745d8f3db9a180fd21c7fc30cd58fa3ca1ed8378))
  * paginate puppet module list when adding ([#9567](http://projects.theforeman.org/issues/9567))
  * Repo-Sync: Make execution date/time changeable ([#8051](http://projects.theforeman.org/issues/8051))
 
 ### Foreman Integration
- * Content Dashboard should be migrated to Foreman dashboard plugin API ([#11239](http://projects.theforeman.org/issues/11239), [1f898c28](http://github.com/katello/katello/commit/1f898c28874016d648f48f287902ae026222d786))
- * Remove Katello custom configuration loader and use foreman SETTINGS ([#10621](http://projects.theforeman.org/issues/10621), [5582ee9f](http://github.com/katello/katello/commit/5582ee9f3ec8a08d39ecd8256e76c2f3c32f3f19))
+ * Content Dashboard should be migrated to Foreman dashboard plugin API ([#11239](http://projects.theforeman.org/issues/11239), [1f898c28](https://github.com/katello/katello/commit/1f898c28874016d648f48f287902ae026222d786))
+ * Remove Katello custom configuration loader and use foreman SETTINGS ([#10621](http://projects.theforeman.org/issues/10621), [5582ee9f](https://github.com/katello/katello/commit/5582ee9f3ec8a08d39ecd8256e76c2f3c32f3f19))
 
 ### Packaging
- * As a developer, I want to manage katello packaging in the foreman-packaging repo ([#9660](http://projects.theforeman.org/issues/9660), [4bd1ccbc](http://github.com/katello/katello/commit/4bd1ccbcfbd8ba617c51041ea6d46aabc7d91224))
+ * As a developer, I want to manage katello packaging in the foreman-packaging repo ([#9660](http://projects.theforeman.org/issues/9660), [4bd1ccbc](https://github.com/katello/katello/commit/4bd1ccbcfbd8ba617c51041ea6d46aabc7d91224))
 
 ### Database
  * scoped search for content_view_puppet_environment ([#8694](http://projects.theforeman.org/issues/8694))
- * scoped search for activation key ([#8691](http://projects.theforeman.org/issues/8691), [6c6e3e9c](http://github.com/katello/katello/commit/6c6e3e9c466d5b03f33677c99cb96cdcf2d4b53a))
- * Move Distributions from Elasticsearch to the Database ([#7890](http://projects.theforeman.org/issues/7890), [e1e62922](http://github.com/katello/katello/commit/e1e62922525efeb911627a8909d696c91ebc77de))
- * Move Puppet Modules from Elasticsearch to Database ([#7889](http://projects.theforeman.org/issues/7889), [eccdbdeb](http://github.com/katello/katello/commit/eccdbdebb3f859afa83998c44fca20fc441d5505))
- * Move Package Groups from Elasticsearch to Database ([#7888](http://projects.theforeman.org/issues/7888), [75932819](http://github.com/katello/katello/commit/759328197002826d0af94307e1a878b44e2fc1a2))
- * Move Packages from Elasticsearch to the Database ([#7887](http://projects.theforeman.org/issues/7887), [690b777d](http://github.com/katello/katello/commit/690b777d62eee0ef1800ddbab5990ac7fa7a7f03))
+ * scoped search for activation key ([#8691](http://projects.theforeman.org/issues/8691), [6c6e3e9c](https://github.com/katello/katello/commit/6c6e3e9c466d5b03f33677c99cb96cdcf2d4b53a))
+ * Move Distributions from Elasticsearch to the Database ([#7890](http://projects.theforeman.org/issues/7890), [e1e62922](https://github.com/katello/katello/commit/e1e62922525efeb911627a8909d696c91ebc77de))
+ * Move Puppet Modules from Elasticsearch to Database ([#7889](http://projects.theforeman.org/issues/7889), [eccdbdeb](https://github.com/katello/katello/commit/eccdbdebb3f859afa83998c44fca20fc441d5505))
+ * Move Package Groups from Elasticsearch to Database ([#7888](http://projects.theforeman.org/issues/7888), [75932819](https://github.com/katello/katello/commit/759328197002826d0af94307e1a878b44e2fc1a2))
+ * Move Packages from Elasticsearch to the Database ([#7887](http://projects.theforeman.org/issues/7887), [690b777d](https://github.com/katello/katello/commit/690b777d62eee0ef1800ddbab5990ac7fa7a7f03))
 
 ### CLI
- * As a CLI user, I should be able to set content overrides for content-hosts. ([#8481](http://projects.theforeman.org/issues/8481), [6827d362](http://github.com/katello/katello/commit/6827d362212d6e1897ff10f6512bd3996a283310))
+ * As a CLI user, I should be able to set content overrides for content-hosts. ([#8481](http://projects.theforeman.org/issues/8481), [6827d362](https://github.com/katello/katello/commit/6827d362212d6e1897ff10f6512bd3996a283310))
 
 ### Puppet
  * Provide top level Puppet Module Inventory page ([#5369](http://projects.theforeman.org/issues/5369))
 
 ### Other
  * Move hammer modules to ruby193 SCL ([#11259](http://projects.theforeman.org/issues/11259))
- * Add Downstream Strings ([#10974](http://projects.theforeman.org/issues/10974), [0ff39e64](http://github.com/katello/katello/commit/0ff39e64974c2af85e069f72f7574f4cf11e0571))
- * Remove distributors from code base ([#7836](http://projects.theforeman.org/issues/7836), [f80c3bb8](http://github.com/katello/katello.org/commit/f80c3bb83f3a622ad9862b187cfae4d3e28107f5))
+ * Add Downstream Strings ([#10974](http://projects.theforeman.org/issues/10974), [0ff39e64](https://github.com/katello/katello/commit/0ff39e64974c2af85e069f72f7574f4cf11e0571))
+ * Remove distributors from code base ([#7836](http://projects.theforeman.org/issues/7836), [f80c3bb8](https://github.com/katello/katello.org/commit/f80c3bb83f3a622ad9862b187cfae4d3e28107f5))
 
 ## Bug Fixes 
 
 ### Katello Disconnected
- * Moving disconnected satellite to connected causes the enabled reposets to move from RPMs Tab to Others Tab ([#12854](http://projects.theforeman.org/issues/12854), [b80a84fb](http://github.com/katello//commit/b80a84fbd3040e742b976766e88ebf3e270daf88))
+ * Moving disconnected satellite to connected causes the enabled reposets to move from RPMs Tab to Others Tab ([#12854](http://projects.theforeman.org/issues/12854), [b80a84fb](https://github.com/katello//commit/b80a84fbd3040e742b976766e88ebf3e270daf88))
  * katello-disconnected configure --help typo ([#12142](http://projects.theforeman.org/issues/12142))
 
 ### Tooling
  * Katello backup missing foreman cache data ([#12782](http://projects.theforeman.org/issues/12782))
 
 ### Client/Agent
- * Timed out agent/capsule tasks are not cancelled ([#12692](http://projects.theforeman.org/issues/12692), [459c151b](http://github.com/katello//commit/459c151b76d95ab5e8715780cfc4ae96b6f53e2e))
+ * Timed out agent/capsule tasks are not cancelled ([#12692](http://projects.theforeman.org/issues/12692), [459c151b](https://github.com/katello//commit/459c151b76d95ab5e8715780cfc4ae96b6f53e2e))
  * Support heartbeats on dispatch router ([#12026](http://projects.theforeman.org/issues/12026))
 
 ### Installer
  * Missing dependency on CentOS 7.1: python-cherrypy ([#12625](http://projects.theforeman.org/issues/12625))
  * dhcpd.conf file deleted during 'katello-installer --upgrade' when dhcp_managed = false ([#12519](http://projects.theforeman.org/issues/12519))
- * 2.4.0 upgrade does not have new content indexed ([#12510](http://projects.theforeman.org/issues/12510), [da8fcd75](http://github.com/katello//commit/da8fcd750fd22e47c41cd9c7696e7191dfc7d08e))
- * Passenger fails to load on RHEL 6.7 ([#12047](http://projects.theforeman.org/issues/12047), [db486f1b](http://github.com/katello/katello/commit/db486f1b9dd38825af8685c73b548e041d2039af))
+ * 2.4.0 upgrade does not have new content indexed ([#12510](http://projects.theforeman.org/issues/12510), [da8fcd75](https://github.com/katello//commit/da8fcd750fd22e47c41cd9c7696e7191dfc7d08e))
+ * Passenger fails to load on RHEL 6.7 ([#12047](http://projects.theforeman.org/issues/12047), [db486f1b](https://github.com/katello/katello/commit/db486f1b9dd38825af8685c73b548e041d2039af))
  * puppet-pulp: incorrect value for [messaging] topic_exchange ([#12033](http://projects.theforeman.org/issues/12033))
  * rpms and other contnet not accessible over ssl after install ([#11998](http://projects.theforeman.org/issues/11998))
  * Installer is creating a gutterball user account/group, but are not required. ([#11957](http://projects.theforeman.org/issues/11957))
- * cert checker script does not take into account new installs ([#11856](http://projects.theforeman.org/issues/11856), [c4034051](http://github.com/katello/katello-installer/commit/c4034051b39fb3471c01217e51e020c18d255def))
+ * cert checker script does not take into account new installs ([#11856](http://projects.theforeman.org/issues/11856), [c4034051](https://github.com/katello/katello-installer/commit/c4034051b39fb3471c01217e51e020c18d255def))
  * katello candlepin installer wget with proxy ([#11824](http://projects.theforeman.org/issues/11824))
  * Installer does not tell you what cert is missing ([#11751](http://projects.theforeman.org/issues/11751))
- * Installer fails interpreting new plugin params from puppet-foreman ([#11675](http://projects.theforeman.org/issues/11675), [af760308](http://github.com/katello/katello-installer/commit/af7603089d17eb405edda590e8f2a458de16fcf5))
- * Installer package generating rake task does not produce unique builds when run successively ([#11666](http://projects.theforeman.org/issues/11666), [15650b1c](http://github.com/katello/katello-installer/commit/15650b1ce2fdd76a1df8c22295477a3217af19a1))
- * Update puppet-katello to use puppet-pulp 1.0 ([#11609](http://projects.theforeman.org/issues/11609), [6ef5d894](http://github.com/katello/katello-installer/commit/6ef5d894bf8b954ca98225398aa14044d7fb9450))
- * Installer generate source rake task should allow customizing prefix of the git archive ([#11334](http://projects.theforeman.org/issues/11334), [915b6b2f](http://github.com/katello/katello-installer/commit/915b6b2f367446702af30539de9f2a22907efded))
+ * Installer fails interpreting new plugin params from puppet-foreman ([#11675](http://projects.theforeman.org/issues/11675), [af760308](https://github.com/katello/katello-installer/commit/af7603089d17eb405edda590e8f2a458de16fcf5))
+ * Installer package generating rake task does not produce unique builds when run successively ([#11666](http://projects.theforeman.org/issues/11666), [15650b1c](https://github.com/katello/katello-installer/commit/15650b1ce2fdd76a1df8c22295477a3217af19a1))
+ * Update puppet-katello to use puppet-pulp 1.0 ([#11609](http://projects.theforeman.org/issues/11609), [6ef5d894](https://github.com/katello/katello-installer/commit/6ef5d894bf8b954ca98225398aa14044d7fb9450))
+ * Installer generate source rake task should allow customizing prefix of the git archive ([#11334](http://projects.theforeman.org/issues/11334), [915b6b2f](https://github.com/katello/katello-installer/commit/915b6b2f367446702af30539de9f2a22907efded))
  * Add import package group task to katello-installer ([#11327](http://projects.theforeman.org/issues/11327))
  * Katello : Installation of Pulp Capsule fails ([#11041](http://projects.theforeman.org/issues/11041))
 
 ### Subscriptions
- * cannot refresh manifest due to dependent repositories ([#12596](http://projects.theforeman.org/issues/12596), [bd187c08](http://github.com/katello//commit/bd187c08ef94ed9a53ace370593deda472ba4760))
+ * cannot refresh manifest due to dependent repositories ([#12596](http://projects.theforeman.org/issues/12596), [bd187c08](https://github.com/katello//commit/bd187c08ef94ed9a53ace370593deda472ba4760))
  * Cant add a subscription n Times ([#12251](http://projects.theforeman.org/issues/12251))
  * subscription json missing support_type field ([#12032](http://projects.theforeman.org/issues/12032))
  * generated guest subscriptions not shown in UI ([#12031](http://projects.theforeman.org/issues/12031))
- * subscription data not getting updated after candlepin modifies it ([#12030](http://projects.theforeman.org/issues/12030), [64ffadb3](http://github.com/katello//commit/64ffadb312170958895f4e0beea335c353ac4eb6))
+ * subscription data not getting updated after candlepin modifies it ([#12030](http://projects.theforeman.org/issues/12030), [64ffadb3](https://github.com/katello//commit/64ffadb312170958895f4e0beea335c353ac4eb6))
  * subscriptions_controller.rb line 86 should be 'sub' not 'subscription' ([#12029](http://projects.theforeman.org/issues/12029))
 
 ### Foreman Integration
- * DisownForemanTemplates migration fails when Foreman and Katello migrations not interleaved ([#12520](http://projects.theforeman.org/issues/12520), [122627eb](http://github.com/katello//commit/122627eb006faba7d07f340914fc0ebc115ff98c))
- * Cannot subscribe content host during provision ([#12302](http://projects.theforeman.org/issues/12302), [bdf89b5e](http://github.com/katello//commit/bdf89b5e0edf6bd1ce257d075e89f1786a3b809f))
- * Hostgroup Jail missing access to subscription_manager_configuration_url ([#12177](http://projects.theforeman.org/issues/12177), [05046a3b](http://github.com/katello//commit/05046a3b2c3d26b1c23e4cd2826e10667fe3d290))
- * Organization parameters cannot be accessed through API ([#11947](http://projects.theforeman.org/issues/11947), [3636d92b](http://github.com/katello//commit/3636d92b1fe711f43d5ef5ef2180ac535570deb9))
- * 'Name can't be blank' error under parameter tab, on creating a hostgroup with activation-key ([#11928](http://projects.theforeman.org/issues/11928), [77f3fc91](http://github.com/katello/katello/commit/77f3fc91f3427dc4e6db69df941ade76a25eefcf))
+ * DisownForemanTemplates migration fails when Foreman and Katello migrations not interleaved ([#12520](http://projects.theforeman.org/issues/12520), [122627eb](https://github.com/katello//commit/122627eb006faba7d07f340914fc0ebc115ff98c))
+ * Cannot subscribe content host during provision ([#12302](http://projects.theforeman.org/issues/12302), [bdf89b5e](https://github.com/katello//commit/bdf89b5e0edf6bd1ce257d075e89f1786a3b809f))
+ * Hostgroup Jail missing access to subscription_manager_configuration_url ([#12177](http://projects.theforeman.org/issues/12177), [05046a3b](https://github.com/katello//commit/05046a3b2c3d26b1c23e4cd2826e10667fe3d290))
+ * Organization parameters cannot be accessed through API ([#11947](http://projects.theforeman.org/issues/11947), [3636d92b](https://github.com/katello//commit/3636d92b1fe711f43d5ef5ef2180ac535570deb9))
+ * 'Name can't be blank' error under parameter tab, on creating a hostgroup with activation-key ([#11928](http://projects.theforeman.org/issues/11928), [77f3fc91](https://github.com/katello/katello/commit/77f3fc91f3427dc4e6db69df941ade76a25eefcf))
  * Cannot assign puppet classes to new host ([#9609](http://projects.theforeman.org/issues/9609))
 
 ### Activation Key
@@ -128,117 +128,117 @@ title: Release Notes
  * Capsule syncs don't work "ERROR][worker-0] pulp_node.handlers.handler:175 -" ([#12448](http://projects.theforeman.org/issues/12448))
 
 ### Pulp
- * Actions::Katello::Repository::Sync reports success regardless errors ([#12397](http://projects.theforeman.org/issues/12397), [564152be](http://github.com/katello//commit/564152be85f3aae476aa9745a04dfe71e2d512b5))
- * Error when uploading rpms to a new repo, content_unit_class is taken as a string ([#12123](http://projects.theforeman.org/issues/12123), [e9edcbe7](http://github.com/katello/katello/commit/e9edcbe7aebbf60712783e171b8564e046a50c11))
- * Hammer ping output has no response for pulp_auth only on providing wrong credentials ([#11701](http://projects.theforeman.org/issues/11701), [ab33add4](http://github.com/katello/katello/commit/ab33add4663449aac6241132602c3334f4587081))
+ * Actions::Katello::Repository::Sync reports success regardless errors ([#12397](http://projects.theforeman.org/issues/12397), [564152be](https://github.com/katello//commit/564152be85f3aae476aa9745a04dfe71e2d512b5))
+ * Error when uploading rpms to a new repo, content_unit_class is taken as a string ([#12123](http://projects.theforeman.org/issues/12123), [e9edcbe7](https://github.com/katello/katello/commit/e9edcbe7aebbf60712783e171b8564e046a50c11))
+ * Hammer ping output has no response for pulp_auth only on providing wrong credentials ([#11701](http://projects.theforeman.org/issues/11701), [ab33add4](https://github.com/katello/katello/commit/ab33add4663449aac6241132602c3334f4587081))
 
 ### Upgrades
- * import_package_groups rake task fails with ' uninitialized constant Katello::Pulp::PackageGroup::CONTENT_TYPE' ([#12376](http://projects.theforeman.org/issues/12376), [e68d6129](http://github.com/katello//commit/e68d6129d5e6623bc4bb5e53ea1360ec833ca537))
- * 2.4 upgrade fails because answers file references old packages ([#12355](http://projects.theforeman.org/issues/12355), [f5c81ee1](http://github.com/katello//commit/f5c81ee1b16c3e1a6443b138e54bc4ff2c418439))
+ * import_package_groups rake task fails with ' uninitialized constant Katello::Pulp::PackageGroup::CONTENT_TYPE' ([#12376](http://projects.theforeman.org/issues/12376), [e68d6129](https://github.com/katello//commit/e68d6129d5e6623bc4bb5e53ea1360ec833ca537))
+ * 2.4 upgrade fails because answers file references old packages ([#12355](http://projects.theforeman.org/issues/12355), [f5c81ee1](https://github.com/katello//commit/f5c81ee1b16c3e1a6443b138e54bc4ff2c418439))
  * 2.4 Upgrade fails with dependency errors ([#12354](http://projects.theforeman.org/issues/12354))
  * undefined method `type' for #<Katello::Erratum:0x007fa65a818078> ([#12351](http://projects.theforeman.org/issues/12351))
  * Can Upgrade Katello from 2.3 to 2.4 RC ([#12273](http://projects.theforeman.org/issues/12273))
 
 ### Web UI
- * Package installation via Satellite 6.1 is much slower than yum ([#12375](http://projects.theforeman.org/issues/12375), [5210a603](http://github.com/katello//commit/5210a603a8281fb14dd1e9a23012baa123122762))
- * undefined method `type' for #<Katello::Erratum:0x007f607cbdfce8> ([#12247](http://projects.theforeman.org/issues/12247), [c69c0a9e](http://github.com/katello//commit/c69c0a9e2908cfa0a5d86298587399c50afeefe7))
+ * Package installation via Satellite 6.1 is much slower than yum ([#12375](http://projects.theforeman.org/issues/12375), [5210a603](https://github.com/katello//commit/5210a603a8281fb14dd1e9a23012baa123122762))
+ * undefined method `type' for #<Katello::Erratum:0x007f607cbdfce8> ([#12247](http://projects.theforeman.org/issues/12247), [c69c0a9e](https://github.com/katello//commit/c69c0a9e2908cfa0a5d86298587399c50afeefe7))
  * scoped_search - err 500 on searching on invalid field ([#12140](http://projects.theforeman.org/issues/12140))
- * content view filter rule types displaying incorrectly in UI ([#12037](http://projects.theforeman.org/issues/12037), [9098daa3](http://github.com/katello/katello/commit/9098daa397975014448b30dd366ce66514901c89))
- * Any page using Nutupane details page is "bleeding" search parameters ([#11886](http://projects.theforeman.org/issues/11886), [d31d8e5b](http://github.com/katello/katello/commit/d31d8e5bffb40cd863e552cbe96e7c3753694236))
- * content view puppet module 'select new verison' is broken ([#11877](http://projects.theforeman.org/issues/11877), [bb3ab73e](http://github.com/katello//commit/bb3ab73ebcd3c3547410a03f8981c2a1700e799c))
- * Regression with enabling Satellite Tools repository found while using upstream community build ([#11876](http://projects.theforeman.org/issues/11876), [92f120a7](http://github.com/katello/katello/commit/92f120a7be76840260f0f213e3b0d0db94016a11))
- * Sync status displays incorrect status ([#11646](http://projects.theforeman.org/issues/11646), [3aadd66b](http://github.com/katello/katello/commit/3aadd66ba506f03f4fc2b562654aca0e725c2353))
- * Disabling used repository_set removes repo already from candlepin and pulp before chcking it is used ([#11436](http://projects.theforeman.org/issues/11436), [501e4288](http://github.com/katello/katello/commit/501e42883d2a2db014640fdcf824a21bb2541e34))
- * Duplicate content view entries are shown in composite content view -> Add page ([#11315](http://projects.theforeman.org/issues/11315), [494068c7](http://github.com/katello/katello/commit/494068c7c9b18950df035b4844877115349c9f03))
- * subscriptions UI row width is one short ([#11301](http://projects.theforeman.org/issues/11301), [9c106ae2](http://github.com/katello/katello/commit/9c106ae27a8098b286e2db843773d3251b3bb7b9))
- * support level column in activation key subscriptions blank ([#11297](http://projects.theforeman.org/issues/11297), [a5a5cc75](http://github.com/katello/katello/commit/a5a5cc75230af7b3fea3404455913faa0339c600))
- * Content Dashboard:  "Sync Overview" widget has what seems like a permanent spinner, shows no data. ([#11234](http://projects.theforeman.org/issues/11234), [341cbefc](http://github.com/katello/katello/commit/341cbefca4e6d454e4d483dda87689b9d9360543))
- * Incremental update displays errata counts but calls it Host count ([#11224](http://projects.theforeman.org/issues/11224), [16af5b3f](http://github.com/katello/katello/commit/16af5b3faf28821ea96110864e2ec7b77020ce67))
- * Starred environments are NOT suggested for promotion ([#11076](http://projects.theforeman.org/issues/11076), [560a9991](http://github.com/katello/katello/commit/560a9991fb6b1cba305e2a81c5281a2503deae0f))
- * Replace usages of bst-infinite-scroll ([#10827](http://projects.theforeman.org/issues/10827), [c14f6912](http://github.com/katello/katello/commit/c14f6912c1affef56f12d2dde84707247b6b9779))
- * Content > Red Hat Subscriptions landing page/endpoint is not uniform ([#10721](http://projects.theforeman.org/issues/10721), [2c38e068](http://github.com/katello/katello/commit/2c38e0689ff3918cc052e86887a3aaecaf9ee275))
+ * content view filter rule types displaying incorrectly in UI ([#12037](http://projects.theforeman.org/issues/12037), [9098daa3](https://github.com/katello/katello/commit/9098daa397975014448b30dd366ce66514901c89))
+ * Any page using Nutupane details page is "bleeding" search parameters ([#11886](http://projects.theforeman.org/issues/11886), [d31d8e5b](https://github.com/katello/katello/commit/d31d8e5bffb40cd863e552cbe96e7c3753694236))
+ * content view puppet module 'select new verison' is broken ([#11877](http://projects.theforeman.org/issues/11877), [bb3ab73e](https://github.com/katello//commit/bb3ab73ebcd3c3547410a03f8981c2a1700e799c))
+ * Regression with enabling Satellite Tools repository found while using upstream community build ([#11876](http://projects.theforeman.org/issues/11876), [92f120a7](https://github.com/katello/katello/commit/92f120a7be76840260f0f213e3b0d0db94016a11))
+ * Sync status displays incorrect status ([#11646](http://projects.theforeman.org/issues/11646), [3aadd66b](https://github.com/katello/katello/commit/3aadd66ba506f03f4fc2b562654aca0e725c2353))
+ * Disabling used repository_set removes repo already from candlepin and pulp before chcking it is used ([#11436](http://projects.theforeman.org/issues/11436), [501e4288](https://github.com/katello/katello/commit/501e42883d2a2db014640fdcf824a21bb2541e34))
+ * Duplicate content view entries are shown in composite content view -> Add page ([#11315](http://projects.theforeman.org/issues/11315), [494068c7](https://github.com/katello/katello/commit/494068c7c9b18950df035b4844877115349c9f03))
+ * subscriptions UI row width is one short ([#11301](http://projects.theforeman.org/issues/11301), [9c106ae2](https://github.com/katello/katello/commit/9c106ae27a8098b286e2db843773d3251b3bb7b9))
+ * support level column in activation key subscriptions blank ([#11297](http://projects.theforeman.org/issues/11297), [a5a5cc75](https://github.com/katello/katello/commit/a5a5cc75230af7b3fea3404455913faa0339c600))
+ * Content Dashboard:  "Sync Overview" widget has what seems like a permanent spinner, shows no data. ([#11234](http://projects.theforeman.org/issues/11234), [341cbefc](https://github.com/katello/katello/commit/341cbefca4e6d454e4d483dda87689b9d9360543))
+ * Incremental update displays errata counts but calls it Host count ([#11224](http://projects.theforeman.org/issues/11224), [16af5b3f](https://github.com/katello/katello/commit/16af5b3faf28821ea96110864e2ec7b77020ce67))
+ * Starred environments are NOT suggested for promotion ([#11076](http://projects.theforeman.org/issues/11076), [560a9991](https://github.com/katello/katello/commit/560a9991fb6b1cba305e2a81c5281a2503deae0f))
+ * Replace usages of bst-infinite-scroll ([#10827](http://projects.theforeman.org/issues/10827), [c14f6912](https://github.com/katello/katello/commit/c14f6912c1affef56f12d2dde84707247b6b9779))
+ * Content > Red Hat Subscriptions landing page/endpoint is not uniform ([#10721](http://projects.theforeman.org/issues/10721), [2c38e068](https://github.com/katello/katello/commit/2c38e0689ff3918cc052e86887a3aaecaf9ee275))
  * Create New Repository page ([#10457](http://projects.theforeman.org/issues/10457))
 
 ### Documentation
  * katello.org/docs katello installation foreman repository version missing for EL7 ([#12361](http://projects.theforeman.org/issues/12361))
- * CLI installation instructions incorrectly fill in repo urls ([#11787](http://projects.theforeman.org/issues/11787), [b71893dd](http://github.com/katello/katello.org/commit/b71893dd884463b1cd486ad71165c48a04479378))
+ * CLI installation instructions incorrectly fill in repo urls ([#11787](http://projects.theforeman.org/issues/11787), [b71893dd](https://github.com/katello/katello.org/commit/b71893dd884463b1cd486ad71165c48a04479378))
 
 ### API
- * Missing routes on API end points ([#12315](http://projects.theforeman.org/issues/12315), [a54f1f89](http://github.com/katello//commit/a54f1f89dfc742c518935a1b926ba89ed0ad0847))
- * Add product name attribute back to subscription in API ([#12002](http://projects.theforeman.org/issues/12002), [87de65ca](http://github.com/katello/katello/commit/87de65caae66971452670c784e49f123f7f85984))
- * hammer respository-set command name mismatch ([#11968](http://projects.theforeman.org/issues/11968), [db1c4c35](http://github.com/katello/hammer-cli-katello/commit/db1c4c35c91448d6f6cd3c15ec98246a651b492f), [9217a2bb](http://github.com/katello/katello/commit/9217a2bbb716ca8dd1415730ef8372bab3f74416))
- * make it easier to find out a puppet env for a given content_view and lifecycle_environment ([#11717](http://projects.theforeman.org/issues/11717), [7c364ba7](http://github.com/katello/katello/commit/7c364ba747706a8c6fac967a29174452ff36b63f))
- * Deprecate the old sync plan available products route ([#11640](http://projects.theforeman.org/issues/11640), [44398fbd](http://github.com/katello/katello/commit/44398fbdfc363fdf1217605cb609acd908fb8733))
+ * Missing routes on API end points ([#12315](http://projects.theforeman.org/issues/12315), [a54f1f89](https://github.com/katello//commit/a54f1f89dfc742c518935a1b926ba89ed0ad0847))
+ * Add product name attribute back to subscription in API ([#12002](http://projects.theforeman.org/issues/12002), [87de65ca](https://github.com/katello/katello/commit/87de65caae66971452670c784e49f123f7f85984))
+ * hammer respository-set command name mismatch ([#11968](http://projects.theforeman.org/issues/11968), [db1c4c35](https://github.com/katello/hammer-cli-katello/commit/db1c4c35c91448d6f6cd3c15ec98246a651b492f), [9217a2bb](https://github.com/katello/katello/commit/9217a2bbb716ca8dd1415730ef8372bab3f74416))
+ * make it easier to find out a puppet env for a given content_view and lifecycle_environment ([#11717](http://projects.theforeman.org/issues/11717), [7c364ba7](https://github.com/katello/katello/commit/7c364ba747706a8c6fac967a29174452ff36b63f))
+ * Deprecate the old sync plan available products route ([#11640](http://projects.theforeman.org/issues/11640), [44398fbd](https://github.com/katello/katello/commit/44398fbdfc363fdf1217605cb609acd908fb8733))
  * Package group deprecation method needs to be removed ([#11639](http://projects.theforeman.org/issues/11639))
- * --label is ignored by hammer organization create command ([#11626](http://projects.theforeman.org/issues/11626), [a08199b7](http://github.com/katello/katello/commit/a08199b78ceb149992f34cd4f56b0cab829d03fd))
- * hammer: confusing error message on trying to create a product with an already existing label ([#11589](http://projects.theforeman.org/issues/11589), [5778eefd](http://github.com/katello/katello/commit/5778eefd922674c32947264e7f314d52385107e2))
- * Content View histories task can be deleted, causing ISE on versions list ([#10996](http://projects.theforeman.org/issues/10996), [eee31ac5](http://github.com/katello/katello/commit/eee31ac5debab9dc0ef1252156420577d5f93d31))
+ * --label is ignored by hammer organization create command ([#11626](http://projects.theforeman.org/issues/11626), [a08199b7](https://github.com/katello/katello/commit/a08199b78ceb149992f34cd4f56b0cab829d03fd))
+ * hammer: confusing error message on trying to create a product with an already existing label ([#11589](http://projects.theforeman.org/issues/11589), [5778eefd](https://github.com/katello/katello/commit/5778eefd922674c32947264e7f314d52385107e2))
+ * Content View histories task can be deleted, causing ISE on versions list ([#10996](http://projects.theforeman.org/issues/10996), [eee31ac5](https://github.com/katello/katello/commit/eee31ac5debab9dc0ef1252156420577d5f93d31))
 
 ### Database
  * undefined method `type' for #<Katello::Erratum:0x007f607cbdfce8> ([#12223](http://projects.theforeman.org/issues/12223))
- * Migration error on upgrade from clean Katello ([#11736](http://projects.theforeman.org/issues/11736), [b2134a6a](http://github.com/katello/katello/commit/b2134a6a3fb4dd80adcdf6148be64a3d8198fcca))
+ * Migration error on upgrade from clean Katello ([#11736](http://projects.theforeman.org/issues/11736), [b2134a6a](https://github.com/katello/katello/commit/b2134a6a3fb4dd80adcdf6148be64a3d8198fcca))
 
 ### Puppet
  * Update puppet-katello to include new puppet-pulp "is_parent" param ([#12110](http://projects.theforeman.org/issues/12110))
  * pulp-parent-nodes is not installed by default ([#12094](http://projects.theforeman.org/issues/12094))
 
 ### CLI
- * puppet-module list : command does not allow listing modules based on repository name ([#12001](http://projects.theforeman.org/issues/12001), [17ffc1e0](http://github.com/katello/hammer-cli-katello/commit/17ffc1e0c19d153bc18149b3fe5d8f3030a149c5))
- * hammer puppet-module list ignores --repository-id ([#11970](http://projects.theforeman.org/issues/11970), [5e35ee6b](http://github.com/katello/katello/commit/5e35ee6bcf22f860a5281bfc330d71b64c1baf0e))
- * Cannot get content view filter description using hammer info ([#11959](http://projects.theforeman.org/issues/11959), [314d5ee5](http://github.com/katello/hammer-cli-katello/commit/314d5ee5fab9a0ad27147f5a4d33255dbbd86ae8))
+ * puppet-module list : command does not allow listing modules based on repository name ([#12001](http://projects.theforeman.org/issues/12001), [17ffc1e0](https://github.com/katello/hammer-cli-katello/commit/17ffc1e0c19d153bc18149b3fe5d8f3030a149c5))
+ * hammer puppet-module list ignores --repository-id ([#11970](http://projects.theforeman.org/issues/11970), [5e35ee6b](https://github.com/katello/katello/commit/5e35ee6bcf22f860a5281bfc330d71b64c1baf0e))
+ * Cannot get content view filter description using hammer info ([#11959](http://projects.theforeman.org/issues/11959), [314d5ee5](https://github.com/katello/hammer-cli-katello/commit/314d5ee5fab9a0ad27147f5a4d33255dbbd86ae8))
  * Update version of hammer-cli-katello to depend on hammer-cli-foreman ([#11922](http://projects.theforeman.org/issues/11922))
- * Can not extract strings for hammer-cli-katello ([#11801](http://projects.theforeman.org/issues/11801), [ff8ad9f9](http://github.com/katello/hammer-cli-katello/commit/ff8ad9f907f92ea3702ca8d0fba63c613ea74c1d))
- * hammer content-host errata apply is only async operation ([#11750](http://projects.theforeman.org/issues/11750), [fa017a14](http://github.com/katello/hammer-cli-katello/commit/fa017a14a31ebf603e628ac4e7b711af4a9f5902))
- * Do not insert this many spaces in `hammer content-host -h | grep available-incremental-updates` ([#11270](http://projects.theforeman.org/issues/11270), [71fef3d2](http://github.com/katello/katello/commit/71fef3d2b49515a776a3046c8319ca153f35b46d))
- * hammer allows me to enable reposets with incorrect release versions ([#11203](http://projects.theforeman.org/issues/11203), [80795424](http://github.com/katello/katello/commit/807954247725729fecf978fa0b324d708b7c9baf))
+ * Can not extract strings for hammer-cli-katello ([#11801](http://projects.theforeman.org/issues/11801), [ff8ad9f9](https://github.com/katello/hammer-cli-katello/commit/ff8ad9f907f92ea3702ca8d0fba63c613ea74c1d))
+ * hammer content-host errata apply is only async operation ([#11750](http://projects.theforeman.org/issues/11750), [fa017a14](https://github.com/katello/hammer-cli-katello/commit/fa017a14a31ebf603e628ac4e7b711af4a9f5902))
+ * Do not insert this many spaces in `hammer content-host -h | grep available-incremental-updates` ([#11270](http://projects.theforeman.org/issues/11270), [71fef3d2](https://github.com/katello/katello/commit/71fef3d2b49515a776a3046c8319ca153f35b46d))
+ * hammer allows me to enable reposets with incorrect release versions ([#11203](http://projects.theforeman.org/issues/11203), [80795424](https://github.com/katello/katello/commit/807954247725729fecf978fa0b324d708b7c9baf))
 
 ### Packaging
  * katello-service man page lists options not available ([#11826](http://projects.theforeman.org/issues/11826))
  * The default tagger should be VersionTagger in `master` ([#11105](http://projects.theforeman.org/issues/11105))
- * remove deface version restriction ([#11102](http://projects.theforeman.org/issues/11102), [b151de8b](http://github.com/katello/katello/commit/b151de8b3aa4c266d46be2ad91fa7e02d4fee7ac))
+ * remove deface version restriction ([#11102](http://projects.theforeman.org/issues/11102), [b151de8b](https://github.com/katello/katello/commit/b151de8b3aa4c266d46be2ad91fa7e02d4fee7ac))
 
 ### Content Views
- * Content View Publish: Description field is never shown ([#11647](http://projects.theforeman.org/issues/11647), [b8fbbd8e](http://github.com/katello/katello/commit/b8fbbd8ef92a0203990ea92f9be66223ed6be2bb))
+ * Content View Publish: Description field is never shown ([#11647](http://projects.theforeman.org/issues/11647), [b8fbbd8e](https://github.com/katello/katello/commit/b8fbbd8ef92a0203990ea92f9be66223ed6be2bb))
 
 ### Atomic
  * Copy over ostree units when we publish/promote content views ([#11611](http://projects.theforeman.org/issues/11611))
  * Set the relative_path for cloned ostree distributors  ([#11567](http://projects.theforeman.org/issues/11567))
 
 ### Tests
- * Test failures reading Foreman fixtures from Katello engine root ([#11189](http://projects.theforeman.org/issues/11189), [47805116](http://github.com/katello/katello/commit/47805116917c7308ab21133a074429b8d205b752))
+ * Test failures reading Foreman fixtures from Katello engine root ([#11189](http://projects.theforeman.org/issues/11189), [47805116](https://github.com/katello/katello/commit/47805116917c7308ab21133a074429b8d205b752))
 
 ### API doc
- * Typo in validator description ([#8920](http://projects.theforeman.org/issues/8920), [ebb479ca](http://github.com/katello/katello/commit/ebb479ca4046b87e25fcd7ab9dead4bd2f2506e6))
+ * Typo in validator description ([#8920](http://projects.theforeman.org/issues/8920), [ebb479ca](https://github.com/katello/katello/commit/ebb479ca4046b87e25fcd7ab9dead4bd2f2506e6))
 
 ### Other
- * Deleting users who created activation keys deletes all associated keys ([#12804](http://projects.theforeman.org/issues/12804), [01e8b421](http://github.com/katello//commit/01e8b42104c8a5ff532273c52730b680fa34a4a6))
- * Removing a subscription from a content host removes all subscriptions ([#12557](http://projects.theforeman.org/issues/12557), [56aa77b8](http://github.com/katello//commit/56aa77b893d102cfe7e9c51faace468d7b37de48))
- * Marketing products from candlepin showing in database ([#12537](http://projects.theforeman.org/issues/12537), [76449133](http://github.com/katello//commit/764491338a826bd9a8853cdbf947899433db9d3c))
+ * Deleting users who created activation keys deletes all associated keys ([#12804](http://projects.theforeman.org/issues/12804), [01e8b421](https://github.com/katello//commit/01e8b42104c8a5ff532273c52730b680fa34a4a6))
+ * Removing a subscription from a content host removes all subscriptions ([#12557](http://projects.theforeman.org/issues/12557), [56aa77b8](https://github.com/katello//commit/56aa77b893d102cfe7e9c51faace468d7b37de48))
+ * Marketing products from candlepin showing in database ([#12537](http://projects.theforeman.org/issues/12537), [76449133](https://github.com/katello//commit/764491338a826bd9a8853cdbf947899433db9d3c))
  * rubygem hooks is no longer used by katello ([#12511](http://projects.theforeman.org/issues/12511))
  * undefined method `type' for #<Katello::Erratum:0x0000000fcd8b38>  Documentation ([#12335](http://projects.theforeman.org/issues/12335))
- * Smart Proxy: environment permission error attempting to edit a smart proxy (aka capsule) ([#12182](http://projects.theforeman.org/issues/12182), [b813837e](http://github.com/katello//commit/b813837eb29d02db90932345cfe2efccdd247d99))
+ * Smart Proxy: environment permission error attempting to edit a smart proxy (aka capsule) ([#12182](http://projects.theforeman.org/issues/12182), [b813837e](https://github.com/katello//commit/b813837eb29d02db90932345cfe2efccdd247d99))
  * "katello-service restart" is not restarting services in the right order ([#12181](http://projects.theforeman.org/issues/12181))
  *  "katello-service stop" is killing services in the wrong order ([#12137](http://projects.theforeman.org/issues/12137))
- * Dynflow actions fail when Katello is run via Zeus in development ([#12086](http://projects.theforeman.org/issues/12086), [97d1a0e9](http://github.com/katello/katello/commit/97d1a0e925575af6c426b28f5a3207c009d351bb))
- * Adding puppet module to content view in the CLI fails ([#11775](http://projects.theforeman.org/issues/11775), [58bbf1c6](http://github.com/katello/katello/commit/58bbf1c660d10765d863f3b39b0030ceb9f11381))
- * Remove 'apply_info_task_id' from taxonomies ([#11668](http://projects.theforeman.org/issues/11668), [8ed71027](http://github.com/katello/katello/commit/8ed71027b9deedeaa230b38db9a33dd7805d1d79))
- * katello-service do not handle PostgreSQL service ([#11648](http://projects.theforeman.org/issues/11648), [8d8b7155](http://github.com/katello/katello-installer/commit/8d8b715540921b18d79ed61f8a625f09fb03b5db))
- * remove katello authorization class and inclusions ([#11588](http://projects.theforeman.org/issues/11588), [e1f7e10d](http://github.com/katello/katello/commit/e1f7e10de4ddc8b92bc822191d45f0858b9b1073))
- * hamer create a filter with an in correct types returns a bad error message ([#11565](http://projects.theforeman.org/issues/11565), [90d359d0](http://github.com/katello/katello/commit/90d359d0dda6d4defc44783e89283b18feef3e21))
- * Remove haml-rails in favor of ERB ([#11448](http://projects.theforeman.org/issues/11448), [70f91b26](http://github.com/katello/katello/commit/70f91b26dc04765f3b9c9cd14d12996ddace79ec))
- * Content host bulk update does not respect organization_id parameter ([#11370](http://projects.theforeman.org/issues/11370), [582a318a](http://github.com/katello/katello/commit/582a318a376ae07be3373d032c6049ccc05e3d3e))
- * Remove rubygem-justified ([#11348](http://projects.theforeman.org/issues/11348), [83637bb8](http://github.com/katello/katello/commit/83637bb8183fdbe40fcae38618aad69b11e806c9))
- * i18n_data rubygem no longer needed ([#11347](http://projects.theforeman.org/issues/11347), [aa001bb6](http://github.com/katello/katello/commit/aa001bb6c947b2178ec971c003e87f7ba8a2b135))
- * Pulp errors on content view published with including package or package group filters ([#11325](http://projects.theforeman.org/issues/11325), [f997a216](http://github.com/katello/katello/commit/f997a216bbc22c301541b0fa34cccea39a906c5e))
- * sync plan dates saved incorrectly if I dont use the calendar widget ([#11295](http://projects.theforeman.org/issues/11295), [5054658f](http://github.com/katello/katello/commit/5054658fc1f78eca8b318bdcf530fd4ec13c253c))
- * Tests produce warning about use of top level Logging ([#11294](http://projects.theforeman.org/issues/11294), [20c9d8e2](http://github.com/katello/katello/commit/20c9d8e237a721508f70e7d643f3bae410da3c16))
- * Autocomplete on scoped search displays some characters incorrectly ([#11207](http://projects.theforeman.org/issues/11207), [8797538b](http://github.com/katello/katello/commit/8797538b53de6419e2ba57be376251373b1d76d8))
- * hammer content-view --help having wrong description at remove-version subcommand ([#11110](http://projects.theforeman.org/issues/11110), [56058030](http://github.com/katello/hammer-cli-katello/commit/5605803013a517e572845c6ac33ae09743af8064))
+ * Dynflow actions fail when Katello is run via Zeus in development ([#12086](http://projects.theforeman.org/issues/12086), [97d1a0e9](https://github.com/katello/katello/commit/97d1a0e925575af6c426b28f5a3207c009d351bb))
+ * Adding puppet module to content view in the CLI fails ([#11775](http://projects.theforeman.org/issues/11775), [58bbf1c6](https://github.com/katello/katello/commit/58bbf1c660d10765d863f3b39b0030ceb9f11381))
+ * Remove 'apply_info_task_id' from taxonomies ([#11668](http://projects.theforeman.org/issues/11668), [8ed71027](https://github.com/katello/katello/commit/8ed71027b9deedeaa230b38db9a33dd7805d1d79))
+ * katello-service do not handle PostgreSQL service ([#11648](http://projects.theforeman.org/issues/11648), [8d8b7155](https://github.com/katello/katello-installer/commit/8d8b715540921b18d79ed61f8a625f09fb03b5db))
+ * remove katello authorization class and inclusions ([#11588](http://projects.theforeman.org/issues/11588), [e1f7e10d](https://github.com/katello/katello/commit/e1f7e10de4ddc8b92bc822191d45f0858b9b1073))
+ * hamer create a filter with an in correct types returns a bad error message ([#11565](http://projects.theforeman.org/issues/11565), [90d359d0](https://github.com/katello/katello/commit/90d359d0dda6d4defc44783e89283b18feef3e21))
+ * Remove haml-rails in favor of ERB ([#11448](http://projects.theforeman.org/issues/11448), [70f91b26](https://github.com/katello/katello/commit/70f91b26dc04765f3b9c9cd14d12996ddace79ec))
+ * Content host bulk update does not respect organization_id parameter ([#11370](http://projects.theforeman.org/issues/11370), [582a318a](https://github.com/katello/katello/commit/582a318a376ae07be3373d032c6049ccc05e3d3e))
+ * Remove rubygem-justified ([#11348](http://projects.theforeman.org/issues/11348), [83637bb8](https://github.com/katello/katello/commit/83637bb8183fdbe40fcae38618aad69b11e806c9))
+ * i18n_data rubygem no longer needed ([#11347](http://projects.theforeman.org/issues/11347), [aa001bb6](https://github.com/katello/katello/commit/aa001bb6c947b2178ec971c003e87f7ba8a2b135))
+ * Pulp errors on content view published with including package or package group filters ([#11325](http://projects.theforeman.org/issues/11325), [f997a216](https://github.com/katello/katello/commit/f997a216bbc22c301541b0fa34cccea39a906c5e))
+ * sync plan dates saved incorrectly if I dont use the calendar widget ([#11295](http://projects.theforeman.org/issues/11295), [5054658f](https://github.com/katello/katello/commit/5054658fc1f78eca8b318bdcf530fd4ec13c253c))
+ * Tests produce warning about use of top level Logging ([#11294](http://projects.theforeman.org/issues/11294), [20c9d8e2](https://github.com/katello/katello/commit/20c9d8e237a721508f70e7d643f3bae410da3c16))
+ * Autocomplete on scoped search displays some characters incorrectly ([#11207](http://projects.theforeman.org/issues/11207), [8797538b](https://github.com/katello/katello/commit/8797538b53de6419e2ba57be376251373b1d76d8))
+ * hammer content-view --help having wrong description at remove-version subcommand ([#11110](http://projects.theforeman.org/issues/11110), [56058030](https://github.com/katello/hammer-cli-katello/commit/5605803013a517e572845c6ac33ae09743af8064))
  * katello-backup and katello-restore is missing ([#10960](http://projects.theforeman.org/issues/10960))
  * Katello package search fails with 500 Internal Server Error ([#10919](http://projects.theforeman.org/issues/10919))
- * Remove Content search ([#10806](http://projects.theforeman.org/issues/10806), [bee147d7](http://github.com/katello/katello/commit/bee147d7080cda086a5236a35258234430a9f485))
- * Unable to install katello 2.3 ([#10648](http://projects.theforeman.org/issues/10648), [60e258f1](http://github.com/katello/katello-installer/commit/60e258f10cea87a254ed1f378a8069966ac323e8))
- * Auto-attach subscriptions not working for content hosts with custom products only ([#10208](http://projects.theforeman.org/issues/10208), [1a6cf418](http://github.com/katello/katello/commit/1a6cf418e421e3fa8ae3b61af92fbe1721cca923))
- * no indication when lifecycle environment creation fails ([#9965](http://projects.theforeman.org/issues/9965), [2d6af293](http://github.com/katello//commit/2d6af293d0555f32d82818fb6840ceee1c172d46))
+ * Remove Content search ([#10806](http://projects.theforeman.org/issues/10806), [bee147d7](https://github.com/katello/katello/commit/bee147d7080cda086a5236a35258234430a9f485))
+ * Unable to install katello 2.3 ([#10648](http://projects.theforeman.org/issues/10648), [60e258f1](https://github.com/katello/katello-installer/commit/60e258f10cea87a254ed1f378a8069966ac323e8))
+ * Auto-attach subscriptions not working for content hosts with custom products only ([#10208](http://projects.theforeman.org/issues/10208), [1a6cf418](https://github.com/katello/katello/commit/1a6cf418e421e3fa8ae3b61af92fbe1721cca923))
+ * no indication when lifecycle environment creation fails ([#9965](http://projects.theforeman.org/issues/9965), [2d6af293](https://github.com/katello//commit/2d6af293d0555f32d82818fb6840ceee1c172d46))
  * The docker tag list and info commands aren't showing tag ([#9691](http://projects.theforeman.org/issues/9691))
- * Repeating error messages when adding a new organization or location ([#9447](http://projects.theforeman.org/issues/9447), [a1cb786b](http://github.com/katello//commit/a1cb786b4d84fa3de5f498daa46a636d4b66ecd0))
+ * Repeating error messages when adding a new organization or location ([#9447](http://projects.theforeman.org/issues/9447), [a1cb786b](https://github.com/katello//commit/a1cb786b4d84fa3de5f498daa46a636d4b66ecd0))

--- a/plugins/katello/2.4/user_guide/activation_keys/index.md
+++ b/plugins/katello/2.4/user_guide/activation_keys/index.md
@@ -116,7 +116,7 @@ To add Host Collections to a key:
 - select the Host Collections you would like to add
 - click **Add Selected**
 
-![Adding Host Collections to an Activation Key](/plugins/katello/{{ page.version }}/user_guide/activation_keys//activation_key_add_host_collections.png)
+![Adding Host Collections to an Activation Key](/plugins/katello/{{ page.version }}/user_guide/activation_keys/activation_key_add_host_collections.png)
 
 ## Register a Content Host using an Activation Key
 

--- a/plugins/katello/3.1/release_notes/release_notes.md
+++ b/plugins/katello/3.1/release_notes/release_notes.md
@@ -9,146 +9,146 @@ version: 3.1
 ## Features 
 
 ### Tooling
- * Have the katello service script handle pulp_streamer and squid ([#15484](http://projects.theforeman.org/issues/15484), [7ce677fe](http://github.com/katello//commit/7ce677fee8ea5dcbc4d40098f3cc9895ebb99dd7))
+ * Have the katello service script handle pulp_streamer and squid ([#15484](http://projects.theforeman.org/issues/15484), [7ce677fe](https://github.com/katello//commit/7ce677fee8ea5dcbc4d40098f3cc9895ebb99dd7))
 
 ### Installer
- * Make migration generation easier ([#15205](http://projects.theforeman.org/issues/15205), [2af541b4](http://github.com/katello/katello-installer/commit/2af541b44027996ff4703ae97d96004ed5205079))
- * Provide a Rake command to setup a local set of modules similar to how the RPM is built ([#14334](http://projects.theforeman.org/issues/14334), [ada4a4f2](http://github.com/katello/katello-installer/commit/ada4a4f282f99e92646558eebbbc0914084c7c23))
+ * Make migration generation easier ([#15205](http://projects.theforeman.org/issues/15205), [2af541b4](https://github.com/katello/katello-installer/commit/2af541b44027996ff4703ae97d96004ed5205079))
+ * Provide a Rake command to setup a local set of modules similar to how the RPM is built ([#14334](http://projects.theforeman.org/issues/14334), [ada4a4f2](https://github.com/katello/katello-installer/commit/ada4a4f282f99e92646558eebbbc0914084c7c23))
 
 ### CLI
- * Upgrade to rubocop 0.39 ([#15029](http://projects.theforeman.org/issues/15029), [36439787](http://github.com/katello/hammer-cli-katello/commit/364397877e80cf99d098748bb418476f1fea079a))
+ * Upgrade to rubocop 0.39 ([#15029](http://projects.theforeman.org/issues/15029), [36439787](https://github.com/katello/hammer-cli-katello/commit/364397877e80cf99d098748bb418476f1fea079a))
 
 ### Tests
- * Run rubocop on rake files ([#15004](http://projects.theforeman.org/issues/15004), [7e1ce1b8](http://github.com/katello/katello/commit/7e1ce1b87479af7c00508923612849d766cbcd26))
+ * Run rubocop on rake files ([#15004](http://projects.theforeman.org/issues/15004), [7e1ce1b8](https://github.com/katello/katello/commit/7e1ce1b87479af7c00508923612849d766cbcd26))
 
 ### foreman-debug
- * Do not collect squid logs when called from sosreport ([#14608](http://projects.theforeman.org/issues/14608), [32f4434b](http://github.com/katello/katello-packaging/commit/32f4434b668eedf4914a8df82a82de235f1c1826))
+ * Do not collect squid logs when called from sosreport ([#14608](http://projects.theforeman.org/issues/14608), [32f4434b](https://github.com/katello/katello-packaging/commit/32f4434b668eedf4914a8df82a82de235f1c1826))
 
 ### API
- * migrate Release version to host subscriptions controller ([#13903](http://projects.theforeman.org/issues/13903), [536c81e3](http://github.com/katello/katello/commit/536c81e36cd5beb0ceb1d702199c34a8d4a545e4))
+ * migrate Release version to host subscriptions controller ([#13903](http://projects.theforeman.org/issues/13903), [536c81e3](https://github.com/katello/katello/commit/536c81e36cd5beb0ceb1d702199c34a8d4a545e4))
 
 ### Repositories
- * Running Sync status to contain a direct link to sync tasks ([#10315](http://projects.theforeman.org/issues/10315), [c7746d63](http://github.com/katello/katello/commit/c7746d633041f4f0b4faea4e6715289235772e36))
+ * Running Sync status to contain a direct link to sync tasks ([#10315](http://projects.theforeman.org/issues/10315), [c7746d63](https://github.com/katello/katello/commit/c7746d633041f4f0b4faea4e6715289235772e36))
 
 ### Other
- * Add the bin directory and rails script to katello ([#15035](http://projects.theforeman.org/issues/15035), [2d5b1b8e](http://github.com/katello/katello/commit/2d5b1b8e8d2640c83185736ed248f2d7c5976c62))
- * Support rubocop 0.39.0 ([#14950](http://projects.theforeman.org/issues/14950), [bd547d2d](http://github.com/katello/katello/commit/bd547d2dedbe65e96ba958e7f36d8c6e1c763480), [97f83ee6](http://github.com/katello/katello/commit/97f83ee651cd49729d81549edb90cee9e1c8f535), [5e9b7a60](http://github.com/katello/katello/commit/5e9b7a60a2adbb872aa749fd60398ea2b80602ac), [f940aab0](http://github.com/katello/katello/commit/f940aab08dab591e1b3df5bb214a05bc38b738b4), [36c185c5](http://github.com/katello/katello/commit/36c185c50c7040540a2c54b4599f4be84cdeab77))
- * Update Katello to use Task Groups ([#13566](http://projects.theforeman.org/issues/13566), [f803b183](http://github.com/katello/katello/commit/f803b1831438492f7a66d05df47f14c874fff630))
+ * Add the bin directory and rails script to katello ([#15035](http://projects.theforeman.org/issues/15035), [2d5b1b8e](https://github.com/katello/katello/commit/2d5b1b8e8d2640c83185736ed248f2d7c5976c62))
+ * Support rubocop 0.39.0 ([#14950](http://projects.theforeman.org/issues/14950), [bd547d2d](https://github.com/katello/katello/commit/bd547d2dedbe65e96ba958e7f36d8c6e1c763480), [97f83ee6](https://github.com/katello/katello/commit/97f83ee651cd49729d81549edb90cee9e1c8f535), [5e9b7a60](https://github.com/katello/katello/commit/5e9b7a60a2adbb872aa749fd60398ea2b80602ac), [f940aab0](https://github.com/katello/katello/commit/f940aab08dab591e1b3df5bb214a05bc38b738b4), [36c185c5](https://github.com/katello/katello/commit/36c185c50c7040540a2c54b4599f4be84cdeab77))
+ * Update Katello to use Task Groups ([#13566](http://projects.theforeman.org/issues/13566), [f803b183](https://github.com/katello/katello/commit/f803b1831438492f7a66d05df47f14c874fff630))
 
 ## Bug Fixes 
 
 ### Web UI
- * Sync Status page not drawn properly if sync in progress ([#15499](http://projects.theforeman.org/issues/15499), [43ddadae](http://github.com/katello/katello/commit/43ddadaec1d535a5e1a048a053af9d066c447794))
- * Duplicate key on "katello_content_facet_errata_eid_caid" under load ([#15407](http://projects.theforeman.org/issues/15407), [fa3f1fa3](http://github.com/katello//commit/fa3f1fa37c5c347a51cbc02f97c72d9aa5f8d7f4))
- * Available pool quantity is wrong after removed subscribed pool(by virt-who) ([#15394](http://projects.theforeman.org/issues/15394), [e2875646](http://github.com/katello/katello/commit/e28756464517ca7ad971d6669010cd69dfdaf575))
- * "Reset Puppet Environment to match selected Content View" does not work ([#15295](http://projects.theforeman.org/issues/15295), [525a381b](http://github.com/katello/katello/commit/525a381b1c053bde4907fa7ce705b8f6ee394b0b))
- * The page does not load while accessing Content -> "Gpg Keys" when having Any Context set ([#15221](http://projects.theforeman.org/issues/15221), [16d3a1cb](http://github.com/katello/katello/commit/16d3a1cb328dd7609fa593f8ea137d12033ee664))
- * Unnecessary date/time transformation for sync plan start date ([#15180](http://projects.theforeman.org/issues/15180), [0baa312f](http://github.com/katello/katello/commit/0baa312fbfecc4c69befc69230fcdf6612cdc6de))
- * Subscription table has mismatched row colors when there are an odd number of subscriptions under one name ([#11871](http://projects.theforeman.org/issues/11871), [5a4af062](http://github.com/katello//commit/5a4af0626d1692f410448a58bd72660f2b36fcec))
+ * Sync Status page not drawn properly if sync in progress ([#15499](http://projects.theforeman.org/issues/15499), [43ddadae](https://github.com/katello/katello/commit/43ddadaec1d535a5e1a048a053af9d066c447794))
+ * Duplicate key on "katello_content_facet_errata_eid_caid" under load ([#15407](http://projects.theforeman.org/issues/15407), [fa3f1fa3](https://github.com/katello//commit/fa3f1fa37c5c347a51cbc02f97c72d9aa5f8d7f4))
+ * Available pool quantity is wrong after removed subscribed pool(by virt-who) ([#15394](http://projects.theforeman.org/issues/15394), [e2875646](https://github.com/katello/katello/commit/e28756464517ca7ad971d6669010cd69dfdaf575))
+ * "Reset Puppet Environment to match selected Content View" does not work ([#15295](http://projects.theforeman.org/issues/15295), [525a381b](https://github.com/katello/katello/commit/525a381b1c053bde4907fa7ce705b8f6ee394b0b))
+ * The page does not load while accessing Content -> "Gpg Keys" when having Any Context set ([#15221](http://projects.theforeman.org/issues/15221), [16d3a1cb](https://github.com/katello/katello/commit/16d3a1cb328dd7609fa593f8ea137d12033ee664))
+ * Unnecessary date/time transformation for sync plan start date ([#15180](http://projects.theforeman.org/issues/15180), [0baa312f](https://github.com/katello/katello/commit/0baa312fbfecc4c69befc69230fcdf6612cdc6de))
+ * Subscription table has mismatched row colors when there are an odd number of subscriptions under one name ([#11871](http://projects.theforeman.org/issues/11871), [5a4af062](https://github.com/katello//commit/5a4af0626d1692f410448a58bd72660f2b36fcec))
 
 ### CLI
- * content view filter cannot be created ([#15395](http://projects.theforeman.org/issues/15395), [3b381817](http://github.com/katello//commit/3b381817f574e747e0858339e11fb3df158337b1))
- * 'hammer sync-plan info' doesn't return start date ([#15204](http://projects.theforeman.org/issues/15204), [59b43952](http://github.com/katello/katello/commit/59b43952ee3fbaabc48da6542220dac7c8fc0de4))
- * Unable to remove host collection from activation key via hammer ([#15162](http://projects.theforeman.org/issues/15162), [bb736223](http://github.com/katello/katello/commit/bb7362231f550310181495c5026b1192bdc4179d))
- * Some tests in hammer-cli-katello use MiniTest's assert() method improperly ([#15142](http://projects.theforeman.org/issues/15142), [27fe17d0](http://github.com/katello/hammer-cli-katello/commit/27fe17d01b87ba375d70c7c46435b7c543854249))
- * Repository list test references nonexistent option ([#15032](http://projects.theforeman.org/issues/15032), [aa6f1757](http://github.com/katello/hammer-cli-katello/commit/aa6f1757255f96a11f1f741fc9b1fa224c2a55cd))
- * (bats fail) hammer repository upload_content missing --organization param ([#15013](http://projects.theforeman.org/issues/15013), [e8c714b8](http://github.com/katello/hammer-cli-katello/commit/e8c714b826dfa5e5fd35baecc35f95680200ba5f))
- * hammer-cli-katello: 'capsule content synchronize' generates error with 'name' input ([#14871](http://projects.theforeman.org/issues/14871), [a167e20e](http://github.com/katello/hammer-cli-katello/commit/a167e20edc76969a13fdf550788df6406c20bc6e))
- * hammer host errata apply async - always displays success ([#14860](http://projects.theforeman.org/issues/14860), [8fbe49ee](http://github.com/katello/hammer-cli-katello/commit/8fbe49ee79e56c1cc7624562ac5cf190b7fe804e))
+ * content view filter cannot be created ([#15395](http://projects.theforeman.org/issues/15395), [3b381817](https://github.com/katello//commit/3b381817f574e747e0858339e11fb3df158337b1))
+ * 'hammer sync-plan info' doesn't return start date ([#15204](http://projects.theforeman.org/issues/15204), [59b43952](https://github.com/katello/katello/commit/59b43952ee3fbaabc48da6542220dac7c8fc0de4))
+ * Unable to remove host collection from activation key via hammer ([#15162](http://projects.theforeman.org/issues/15162), [bb736223](https://github.com/katello/katello/commit/bb7362231f550310181495c5026b1192bdc4179d))
+ * Some tests in hammer-cli-katello use MiniTest's assert() method improperly ([#15142](http://projects.theforeman.org/issues/15142), [27fe17d0](https://github.com/katello/hammer-cli-katello/commit/27fe17d01b87ba375d70c7c46435b7c543854249))
+ * Repository list test references nonexistent option ([#15032](http://projects.theforeman.org/issues/15032), [aa6f1757](https://github.com/katello/hammer-cli-katello/commit/aa6f1757255f96a11f1f741fc9b1fa224c2a55cd))
+ * (bats fail) hammer repository upload_content missing --organization param ([#15013](http://projects.theforeman.org/issues/15013), [e8c714b8](https://github.com/katello/hammer-cli-katello/commit/e8c714b826dfa5e5fd35baecc35f95680200ba5f))
+ * hammer-cli-katello: 'capsule content synchronize' generates error with 'name' input ([#14871](http://projects.theforeman.org/issues/14871), [a167e20e](https://github.com/katello/hammer-cli-katello/commit/a167e20edc76969a13fdf550788df6406c20bc6e))
+ * hammer host errata apply async - always displays success ([#14860](http://projects.theforeman.org/issues/14860), [8fbe49ee](https://github.com/katello/hammer-cli-katello/commit/8fbe49ee79e56c1cc7624562ac5cf190b7fe804e))
  * hammer capsule content synchronization needs --help to indicate which fields are required and/or optional ([#14656](http://projects.theforeman.org/issues/14656))
- * hammer activation-key --unlimited-content-hosts flag is confusing ([#14333](http://projects.theforeman.org/issues/14333), [fb494a72](http://github.com/katello/hammer-cli-katello/commit/fb494a72c1f4206004490cdfde11d36709aa9267))
+ * hammer activation-key --unlimited-content-hosts flag is confusing ([#14333](http://projects.theforeman.org/issues/14333), [fb494a72](https://github.com/katello/hammer-cli-katello/commit/fb494a72c1f4206004490cdfde11d36709aa9267))
 
 ### Installer
- * katello install failing due to passenger error ([#15393](http://projects.theforeman.org/issues/15393), [56adbf64](http://github.com/katello/katello-installer/commit/56adbf64bdedfdc5a290ed248c77623d080bf227), [55154c9a](http://github.com/katello/katello-installer/commit/55154c9aaf66605538bc32cab7c8b16a4bc9df63))
- * The `try` method is used in katello-installer, but it only exists in Rails, not Ruby ([#15327](http://projects.theforeman.org/issues/15327), [41df3788](http://github.com/katello/katello-installer/commit/41df37885ec5bb663dc9656af0d4f22402838372))
- * There is no nil check for missing kafo params 'capsule_certs' and 'parent_fqdn' ([#15325](http://projects.theforeman.org/issues/15325), [0aa56393](http://github.com/katello/katello-installer/commit/0aa563937629ca8ab66c76e4705b8c917b927550))
- * Capsule upgrade 6.1->6.2 snap 13 incorrectly resets trusted hosts and foreman-url ([#15315](http://projects.theforeman.org/issues/15315), [b2322b35](http://github.com/katello/katello-installer/commit/b2322b35054b13b087a9a2448401f89411dbbf77))
- * Make proxy.rb executable ([#15309](http://projects.theforeman.org/issues/15309), [cee964f1](http://github.com/katello/katello-installer/commit/cee964f18b05844b88261712dbf1a207c14cd9aa))
- * Remove unused sam-installer ([#15208](http://projects.theforeman.org/issues/15208), [4cfddef7](http://github.com/katello/katello-installer/commit/4cfddef7b6fb3796979bd465d162293e3607b34b))
- * Set Client SSL certs via parameters ([#15063](http://projects.theforeman.org/issues/15063), [fe37561e](http://github.com/katello/katello-installer/commit/fe37561e43779b283414405b4d9ad9ad9da9b6bd))
- * capsule-certs-generate does not honour "--parent-fqdn" parameter  ([#14978](http://projects.theforeman.org/issues/14978), [3df90771](http://github.com/katello/katello-installer/commit/3df90771d976ce7cb21419c6e09506843cd031e4))
- * Have Katello-installer check to see if there is a proxy env set before running ([#14956](http://projects.theforeman.org/issues/14956), [af52c83c](http://github.com/katello/katello-installer/commit/af52c83c3e7dc649049191cf4fbecbf83f01042e))
- * deploy candlepin url using fqdn ([#14617](http://projects.theforeman.org/issues/14617), [f18f34db](http://github.com/katello/puppet-katello/commit/f18f34dbca8d77f2e1c229f780775b46dab9fda3))
+ * katello install failing due to passenger error ([#15393](http://projects.theforeman.org/issues/15393), [56adbf64](https://github.com/katello/katello-installer/commit/56adbf64bdedfdc5a290ed248c77623d080bf227), [55154c9a](https://github.com/katello/katello-installer/commit/55154c9aaf66605538bc32cab7c8b16a4bc9df63))
+ * The `try` method is used in katello-installer, but it only exists in Rails, not Ruby ([#15327](http://projects.theforeman.org/issues/15327), [41df3788](https://github.com/katello/katello-installer/commit/41df37885ec5bb663dc9656af0d4f22402838372))
+ * There is no nil check for missing kafo params 'capsule_certs' and 'parent_fqdn' ([#15325](http://projects.theforeman.org/issues/15325), [0aa56393](https://github.com/katello/katello-installer/commit/0aa563937629ca8ab66c76e4705b8c917b927550))
+ * Capsule upgrade 6.1->6.2 snap 13 incorrectly resets trusted hosts and foreman-url ([#15315](http://projects.theforeman.org/issues/15315), [b2322b35](https://github.com/katello/katello-installer/commit/b2322b35054b13b087a9a2448401f89411dbbf77))
+ * Make proxy.rb executable ([#15309](http://projects.theforeman.org/issues/15309), [cee964f1](https://github.com/katello/katello-installer/commit/cee964f18b05844b88261712dbf1a207c14cd9aa))
+ * Remove unused sam-installer ([#15208](http://projects.theforeman.org/issues/15208), [4cfddef7](https://github.com/katello/katello-installer/commit/4cfddef7b6fb3796979bd465d162293e3607b34b))
+ * Set Client SSL certs via parameters ([#15063](http://projects.theforeman.org/issues/15063), [fe37561e](https://github.com/katello/katello-installer/commit/fe37561e43779b283414405b4d9ad9ad9da9b6bd))
+ * capsule-certs-generate does not honour "--parent-fqdn" parameter  ([#14978](http://projects.theforeman.org/issues/14978), [3df90771](https://github.com/katello/katello-installer/commit/3df90771d976ce7cb21419c6e09506843cd031e4))
+ * Have Katello-installer check to see if there is a proxy env set before running ([#14956](http://projects.theforeman.org/issues/14956), [af52c83c](https://github.com/katello/katello-installer/commit/af52c83c3e7dc649049191cf4fbecbf83f01042e))
+ * deploy candlepin url using fqdn ([#14617](http://projects.theforeman.org/issues/14617), [f18f34db](https://github.com/katello/puppet-katello/commit/f18f34dbca8d77f2e1c229f780775b46dab9fda3))
  * [RFE] katello-installer should include --capsule-tftp true by default ([#13546](http://projects.theforeman.org/issues/13546))
- * Katello 3.0 RC5  Upgrade fail  ([#15269](http://projects.theforeman.org/issues/15269), [b5f07391](http://github.com/katello//commit/b5f07391221ca330bade21d1d1614e1e4e2ee4f4))
+ * Katello 3.0 RC5  Upgrade fail  ([#15269](http://projects.theforeman.org/issues/15269), [b5f07391](https://github.com/katello//commit/b5f07391221ca330bade21d1d1614e1e4e2ee4f4))
 
 ### Errata Management
- * errata page broken ([#15389](http://projects.theforeman.org/issues/15389), [42502063](http://github.com/katello/katello/commit/42502063e7a47176dec428b13aade2c6329438de))
- * distinct used when finding applicable errata, causing severe slowdowns on dashboard ([#15253](http://projects.theforeman.org/issues/15253), [4667141b](http://github.com/katello/katello/commit/4667141bff31d8781600a19977f1d529e0218b5b))
+ * errata page broken ([#15389](http://projects.theforeman.org/issues/15389), [42502063](https://github.com/katello/katello/commit/42502063e7a47176dec428b13aade2c6329438de))
+ * distinct used when finding applicable errata, causing severe slowdowns on dashboard ([#15253](http://projects.theforeman.org/issues/15253), [4667141b](https://github.com/katello/katello/commit/4667141bff31d8781600a19977f1d529e0218b5b))
 
 ### Pulp
- * checksum-type does not updated on already synced repository at Capsule. ([#15377](http://projects.theforeman.org/issues/15377), [57ab21e3](http://github.com/katello/katello/commit/57ab21e3d195e977e7844266ecd2572074cf6ef2))
+ * checksum-type does not updated on already synced repository at Capsule. ([#15377](http://projects.theforeman.org/issues/15377), [57ab21e3](https://github.com/katello/katello/commit/57ab21e3d195e977e7844266ecd2572074cf6ef2))
  * Removing a content view, doesn't free disk space ([#15369](http://projects.theforeman.org/issues/15369))
 
 ### Activation Key
- * Activation Key returning all systems under associations tab ([#15347](http://projects.theforeman.org/issues/15347), [515a48bf](http://github.com/katello/katello/commit/515a48bf0618c87c63666f945dcc7ae875c69b61))
+ * Activation Key returning all systems under associations tab ([#15347](http://projects.theforeman.org/issues/15347), [515a48bf](https://github.com/katello/katello/commit/515a48bf0618c87c63666f945dcc7ae875c69b61))
 
 ### Hosts
- * Subscription status is wrong on content host details > subscriptions tab ([#15334](http://projects.theforeman.org/issues/15334), [3c040d05](http://github.com/katello/katello/commit/3c040d05dd25db8c64d91a992b6e75f1d7218f9c))
- * No permissions for power, puppetrun e.t.c in API ([#15236](http://projects.theforeman.org/issues/15236), [5d553340](http://github.com/katello/katello/commit/5d55334096bbf82c7dcb2e7aa4ae098122c24c50))
- * Duplicate entries for hypervisors after renaming content host ([#15197](http://projects.theforeman.org/issues/15197), [78bb525a](http://github.com/katello/katello/commit/78bb525a7814b94680233f7baeb465945fbdff56))
- * Content hosts licensing status is hard to determine from dot colors ([#14992](http://projects.theforeman.org/issues/14992), [bf97d409](http://github.com/katello/katello/commit/bf97d4098fdfed34a40acbd46744b0d690e91d9b))
- * Enable feature to update all packages for a host collection to patch all hosts at once ([#14940](http://projects.theforeman.org/issues/14940), [f85fc0dc](http://github.com/katello/katello/commit/f85fc0dc9212ccba157cfbd0f7c1721b1d04a69b))
- * Katello should be using host.comment instead of content_host.description ([#14822](http://projects.theforeman.org/issues/14822), [155c2f55](http://github.com/katello/katello/commit/155c2f550672057b0ec01a54f0d7afdc6b0519c0))
- * Content Host status is green, but shows "Warning" ([#14372](http://projects.theforeman.org/issues/14372), [d31dff1e](http://github.com/katello/katello/commit/d31dff1eaa26ee3e7390c820457c129a58e5d413))
+ * Subscription status is wrong on content host details > subscriptions tab ([#15334](http://projects.theforeman.org/issues/15334), [3c040d05](https://github.com/katello/katello/commit/3c040d05dd25db8c64d91a992b6e75f1d7218f9c))
+ * No permissions for power, puppetrun e.t.c in API ([#15236](http://projects.theforeman.org/issues/15236), [5d553340](https://github.com/katello/katello/commit/5d55334096bbf82c7dcb2e7aa4ae098122c24c50))
+ * Duplicate entries for hypervisors after renaming content host ([#15197](http://projects.theforeman.org/issues/15197), [78bb525a](https://github.com/katello/katello/commit/78bb525a7814b94680233f7baeb465945fbdff56))
+ * Content hosts licensing status is hard to determine from dot colors ([#14992](http://projects.theforeman.org/issues/14992), [bf97d409](https://github.com/katello/katello/commit/bf97d4098fdfed34a40acbd46744b0d690e91d9b))
+ * Enable feature to update all packages for a host collection to patch all hosts at once ([#14940](http://projects.theforeman.org/issues/14940), [f85fc0dc](https://github.com/katello/katello/commit/f85fc0dc9212ccba157cfbd0f7c1721b1d04a69b))
+ * Katello should be using host.comment instead of content_host.description ([#14822](http://projects.theforeman.org/issues/14822), [155c2f55](https://github.com/katello/katello/commit/155c2f550672057b0ec01a54f0d7afdc6b0519c0))
+ * Content Host status is green, but shows "Warning" ([#14372](http://projects.theforeman.org/issues/14372), [d31dff1e](https://github.com/katello/katello/commit/d31dff1eaa26ee3e7390c820457c129a58e5d413))
 
 ### Subscriptions
- * Hammer subscription list no longer reports subscriptions as uuids ([#15275](http://projects.theforeman.org/issues/15275), [edafb346](http://github.com/katello/hammer-cli-katello/commit/edafb34667e01c6ff9eac4489c2feb6fec081b35))
- * webUI, Subscription Status shows green instead of red if registered system without auto-attach. ([#15209](http://projects.theforeman.org/issues/15209), [c621ef28](http://github.com/katello/katello/commit/c621ef28136fe4391c890dd800e8ae32cdeca73f))
- * removing a vdc subscription causes candlepin listener to fail as the guest subs are removed too ([#15207](http://projects.theforeman.org/issues/15207), [a89f1f0c](http://github.com/katello/katello/commit/a89f1f0c7bb90290c8796282076afae26dc5df7e))
- * content host installed_products array needs to pass product arch and version to candlepin when specified ([#14593](http://projects.theforeman.org/issues/14593), [20efbb2e](http://github.com/katello/katello/commit/20efbb2e5e2e1c781bb9b6dc484cdf7023e782e2))
- * dynflow_executor memory usage continues to grow, causing performance degredation ([#12650](http://projects.theforeman.org/issues/12650), [7f661597](http://github.com/katello/katello/commit/7f6615978d177510dbebadc4f2edb87184420016))
- * manifest import messages no longer displayed in UI ([#11125](http://projects.theforeman.org/issues/11125), [9789f11e](http://github.com/katello/katello/commit/9789f11e41ffcb764484becff14b5047ff70e105))
- * Importing rhsm facts doesn't set the virtual flag ([#15559](http://projects.theforeman.org/issues/15559), [7b2e6900](http://github.com/katello//commit/7b2e6900777630ad186089c52c0f6fd42373f918))
+ * Hammer subscription list no longer reports subscriptions as uuids ([#15275](http://projects.theforeman.org/issues/15275), [edafb346](https://github.com/katello/hammer-cli-katello/commit/edafb34667e01c6ff9eac4489c2feb6fec081b35))
+ * webUI, Subscription Status shows green instead of red if registered system without auto-attach. ([#15209](http://projects.theforeman.org/issues/15209), [c621ef28](https://github.com/katello/katello/commit/c621ef28136fe4391c890dd800e8ae32cdeca73f))
+ * removing a vdc subscription causes candlepin listener to fail as the guest subs are removed too ([#15207](http://projects.theforeman.org/issues/15207), [a89f1f0c](https://github.com/katello/katello/commit/a89f1f0c7bb90290c8796282076afae26dc5df7e))
+ * content host installed_products array needs to pass product arch and version to candlepin when specified ([#14593](http://projects.theforeman.org/issues/14593), [20efbb2e](https://github.com/katello/katello/commit/20efbb2e5e2e1c781bb9b6dc484cdf7023e782e2))
+ * dynflow_executor memory usage continues to grow, causing performance degredation ([#12650](http://projects.theforeman.org/issues/12650), [7f661597](https://github.com/katello/katello/commit/7f6615978d177510dbebadc4f2edb87184420016))
+ * manifest import messages no longer displayed in UI ([#11125](http://projects.theforeman.org/issues/11125), [9789f11e](https://github.com/katello/katello/commit/9789f11e41ffcb764484becff14b5047ff70e105))
+ * Importing rhsm facts doesn't set the virtual flag ([#15559](http://projects.theforeman.org/issues/15559), [7b2e6900](https://github.com/katello//commit/7b2e6900777630ad186089c52c0f6fd42373f918))
 
 ### API
- * API /products/:product/repositories fails with undefined method ([#15186](http://projects.theforeman.org/issues/15186), [aad44630](http://github.com/katello/katello/commit/aad446300709ff8dc023a2d93d624a41cd2e5e00))
- * Organization show api broken ([#15185](http://projects.theforeman.org/issues/15185), [77e1ab61](http://github.com/katello/katello/commit/77e1ab6140a5e58661e6742343c533491f0e743f))
- * Adding puppet module to Content View by API does not set version, and therefor exclude it in publishing the module ([#15177](http://projects.theforeman.org/issues/15177), [849f26b6](http://github.com/katello/katello/commit/849f26b6dbd5ac4108ff6373ef9491df9fef5855))
- * Api request fails for GET /katello/api/organizations/:organization_id/environments/:id/repositories  ([#15159](http://projects.theforeman.org/issues/15159), [195b9a69](http://github.com/katello/katello/commit/195b9a69aefaf89f45fae1335a0dbafd74d34cff))
- * PUT /api/v2/host_collections/ do not return 'host_ids' attribute ([#15486](http://projects.theforeman.org/issues/15486), [15c1a2eb](http://github.com/katello/katello/commit/15c1a2eb3552c8379e15248c1e9e10fa6fc846a1))
- * Unable to add puppet module stdlib to my content view through the UI ([#15435](http://projects.theforeman.org/issues/15435), [11a5a536](http://github.com/katello/katello/commit/11a5a536052c575ef081c0c92ae39b3223940b9c))
+ * API /products/:product/repositories fails with undefined method ([#15186](http://projects.theforeman.org/issues/15186), [aad44630](https://github.com/katello/katello/commit/aad446300709ff8dc023a2d93d624a41cd2e5e00))
+ * Organization show api broken ([#15185](http://projects.theforeman.org/issues/15185), [77e1ab61](https://github.com/katello/katello/commit/77e1ab6140a5e58661e6742343c533491f0e743f))
+ * Adding puppet module to Content View by API does not set version, and therefor exclude it in publishing the module ([#15177](http://projects.theforeman.org/issues/15177), [849f26b6](https://github.com/katello/katello/commit/849f26b6dbd5ac4108ff6373ef9491df9fef5855))
+ * Api request fails for GET /katello/api/organizations/:organization_id/environments/:id/repositories  ([#15159](http://projects.theforeman.org/issues/15159), [195b9a69](https://github.com/katello/katello/commit/195b9a69aefaf89f45fae1335a0dbafd74d34cff))
+ * PUT /api/v2/host_collections/ do not return 'host_ids' attribute ([#15486](http://projects.theforeman.org/issues/15486), [15c1a2eb](https://github.com/katello/katello/commit/15c1a2eb3552c8379e15248c1e9e10fa6fc846a1))
+ * Unable to add puppet module stdlib to my content view through the UI ([#15435](http://projects.theforeman.org/issues/15435), [11a5a536](https://github.com/katello/katello/commit/11a5a536052c575ef081c0c92ae39b3223940b9c))
 
 ### API doc
- * Document facet attributes for hosts ([#15165](http://projects.theforeman.org/issues/15165), [29f42a35](http://github.com/katello/katello/commit/29f42a35bb9eddcfc8271bc1e3d1dd569579134d))
+ * Document facet attributes for hosts ([#15165](http://projects.theforeman.org/issues/15165), [29f42a35](https://github.com/katello/katello/commit/29f42a35bb9eddcfc8271bc1e3d1dd569579134d))
 
 ### Capsule
- * capsule-remove doesn't remove foreman-installer configs and old certs which causes failure of next capsule install  ([#14906](http://projects.theforeman.org/issues/14906), [2f31c5f9](http://github.com/katello/katello-installer/commit/2f31c5f9841bc14d2ad70d03e8eea8fd841e0770))
- * Main sync page throws error/warning upon completion of sync if capsules non-responsive ([#14873](http://projects.theforeman.org/issues/14873), [750181d0](http://github.com/katello/katello/commit/750181d05c2e8de93d1a59bc72727c7f26abd58e))
- * Capsule sync progress should be shown only upto 2 decimal places ([#14644](http://projects.theforeman.org/issues/14644), [91e6967e](http://github.com/katello/katello/commit/91e6967e620bd0c637929c9b32db311ea5eec19f))
+ * capsule-remove doesn't remove foreman-installer configs and old certs which causes failure of next capsule install  ([#14906](http://projects.theforeman.org/issues/14906), [2f31c5f9](https://github.com/katello/katello-installer/commit/2f31c5f9841bc14d2ad70d03e8eea8fd841e0770))
+ * Main sync page throws error/warning upon completion of sync if capsules non-responsive ([#14873](http://projects.theforeman.org/issues/14873), [750181d0](https://github.com/katello/katello/commit/750181d05c2e8de93d1a59bc72727c7f26abd58e))
+ * Capsule sync progress should be shown only upto 2 decimal places ([#14644](http://projects.theforeman.org/issues/14644), [91e6967e](https://github.com/katello/katello/commit/91e6967e620bd0c637929c9b32db311ea5eec19f))
 
 ### Organizations and Locations
- *  "Content Host Counts" column on the Errata page should only count hosts in the current org ([#14933](http://projects.theforeman.org/issues/14933), [1bddf751](http://github.com/katello/katello/commit/1bddf751ca34d9e786648a2e40e1601769888d2e))
+ *  "Content Host Counts" column on the Errata page should only count hosts in the current org ([#14933](http://projects.theforeman.org/issues/14933), [1bddf751](https://github.com/katello/katello/commit/1bddf751ca34d9e786648a2e40e1601769888d2e))
 
 ### foreman-debug
- * [foreman-debug] collect /etc/qpid-dispatch/qdrouterd.conf ([#14881](http://projects.theforeman.org/issues/14881), [b73086c2](http://github.com/katello/katello-packaging/commit/b73086c208c192d9c0cf7379e6d52910a7c1b35e))
+ * [foreman-debug] collect /etc/qpid-dispatch/qdrouterd.conf ([#14881](http://projects.theforeman.org/issues/14881), [b73086c2](https://github.com/katello/katello-packaging/commit/b73086c208c192d9c0cf7379e6d52910a7c1b35e))
 
 ### Documentation
- * katello-packaging README points to wrong branch ([#14515](http://projects.theforeman.org/issues/14515), [1ada7271](http://github.com/katello/katello-packaging/commit/1ada7271ffdd2439135fb32be68cc1c31f123436))
+ * katello-packaging README points to wrong branch ([#14515](http://projects.theforeman.org/issues/14515), [1ada7271](https://github.com/katello/katello-packaging/commit/1ada7271ffdd2439135fb32be68cc1c31f123436))
 
 ### Performance
- * product API call with 'enabled=true' slow, causing product page to load slowly ([#14259](http://projects.theforeman.org/issues/14259), [98e9acf6](http://github.com/katello/katello/commit/98e9acf6d88d9cdd6c408297494373721965488f))
+ * product API call with 'enabled=true' slow, causing product page to load slowly ([#14259](http://projects.theforeman.org/issues/14259), [98e9acf6](https://github.com/katello/katello/commit/98e9acf6d88d9cdd6c408297494373721965488f))
 
 ### Upgrades
- * On upgraded Viewer role user still can manage Content Views ([#15460](http://projects.theforeman.org/issues/15460), [118ea637](http://github.com/katello//commit/118ea637834534dbe470dee14b868ae74567ccdf))
+ * On upgraded Viewer role user still can manage Content Views ([#15460](http://projects.theforeman.org/issues/15460), [118ea637](https://github.com/katello//commit/118ea637834534dbe470dee14b868ae74567ccdf))
 
 ### Candlepin
- * sub-man registration currently blocks on applicability generation ([#12749](http://projects.theforeman.org/issues/12749), [8305bfbf](http://github.com/katello//commit/8305bfbf8d917b28fe9948dfd1cdcae7de77acbc))
+ * sub-man registration currently blocks on applicability generation ([#12749](http://projects.theforeman.org/issues/12749), [8305bfbf](https://github.com/katello//commit/8305bfbf8d917b28fe9948dfd1cdcae7de77acbc))
 
 ### Other
- * list of packages on About page missing crucial entries ([#15242](http://projects.theforeman.org/issues/15242), [1ade0806](http://github.com/katello/katello/commit/1ade0806bdaa400ac5e063bf0bec47fddc342181))
- *  REST Timeout during manifest import  ([#15170](http://projects.theforeman.org/issues/15170), [022e3d86](http://github.com/katello/puppet-katello/commit/022e3d869580e7bc0931f5e28f9727ebb5b322ee))
- * Remove old broken script files ([#15034](http://projects.theforeman.org/issues/15034), [ebf96ef2](http://github.com/katello/katello/commit/ebf96ef2337018f5a9a260f9b5adf37df542f340))
- * Errant single quote in apidoc for repository create param checksum ([#14975](http://projects.theforeman.org/issues/14975), [0879c327](http://github.com/katello/katello/commit/0879c327e666499243514c1ccb27da80807a41b1))
- * Nightly fails with undefined method 'value' for module ([#14973](http://projects.theforeman.org/issues/14973), [e19e50ab](http://github.com/katello/katello/commit/e19e50abcc41cd7ec268e9024942fa68b88447d0))
- * Docs links in the contributing markdown file are broken ([#14972](http://projects.theforeman.org/issues/14972), [34bfd757](http://github.com/katello/katello/commit/34bfd757773bbd77e8c4c5235d3a739a7a030f48))
- * Uploaded puppet modules from hammer CLI not visible in the UI ([#14949](http://projects.theforeman.org/issues/14949), [4730c9d2](http://github.com/katello/katello/commit/4730c9d2c56c63d85c04672f2a7e9743dc4a65a2))
- * CDN url is allowed to be "https", which only works for one hostname ([#14916](http://projects.theforeman.org/issues/14916), [850a07fe](http://github.com/katello/katello/commit/850a07fec71c55849141c4924c8bd428b927386c))
- * foreman proxy still running on port 8000 needlessly. ([#14750](http://projects.theforeman.org/issues/14750), [01635aa2](http://github.com/katello/katello-installer/commit/01635aa25b4b0642804efc33ce33b9b3eaeefda0))
- * update of subscription facet triggers a second call to dynflow ([#14709](http://projects.theforeman.org/issues/14709), [77b7b555](http://github.com/katello/katello/commit/77b7b555643259212ed0d6879018ec9c84eac2ff))
- * extracting strings is not working due to humanized names ([#14610](http://projects.theforeman.org/issues/14610), [42c1152d](http://github.com/katello/katello/commit/42c1152dbcb3b41d01d4ed3327e86637e39dbdc0))
+ * list of packages on About page missing crucial entries ([#15242](http://projects.theforeman.org/issues/15242), [1ade0806](https://github.com/katello/katello/commit/1ade0806bdaa400ac5e063bf0bec47fddc342181))
+ *  REST Timeout during manifest import  ([#15170](http://projects.theforeman.org/issues/15170), [022e3d86](https://github.com/katello/puppet-katello/commit/022e3d869580e7bc0931f5e28f9727ebb5b322ee))
+ * Remove old broken script files ([#15034](http://projects.theforeman.org/issues/15034), [ebf96ef2](https://github.com/katello/katello/commit/ebf96ef2337018f5a9a260f9b5adf37df542f340))
+ * Errant single quote in apidoc for repository create param checksum ([#14975](http://projects.theforeman.org/issues/14975), [0879c327](https://github.com/katello/katello/commit/0879c327e666499243514c1ccb27da80807a41b1))
+ * Nightly fails with undefined method 'value' for module ([#14973](http://projects.theforeman.org/issues/14973), [e19e50ab](https://github.com/katello/katello/commit/e19e50abcc41cd7ec268e9024942fa68b88447d0))
+ * Docs links in the contributing markdown file are broken ([#14972](http://projects.theforeman.org/issues/14972), [34bfd757](https://github.com/katello/katello/commit/34bfd757773bbd77e8c4c5235d3a739a7a030f48))
+ * Uploaded puppet modules from hammer CLI not visible in the UI ([#14949](http://projects.theforeman.org/issues/14949), [4730c9d2](https://github.com/katello/katello/commit/4730c9d2c56c63d85c04672f2a7e9743dc4a65a2))
+ * CDN url is allowed to be "https", which only works for one hostname ([#14916](http://projects.theforeman.org/issues/14916), [850a07fe](https://github.com/katello/katello/commit/850a07fec71c55849141c4924c8bd428b927386c))
+ * foreman proxy still running on port 8000 needlessly. ([#14750](http://projects.theforeman.org/issues/14750), [01635aa2](https://github.com/katello/katello-installer/commit/01635aa25b4b0642804efc33ce33b9b3eaeefda0))
+ * update of subscription facet triggers a second call to dynflow ([#14709](http://projects.theforeman.org/issues/14709), [77b7b555](https://github.com/katello/katello/commit/77b7b555643259212ed0d6879018ec9c84eac2ff))
+ * extracting strings is not working due to humanized names ([#14610](http://projects.theforeman.org/issues/14610), [42c1152d](https://github.com/katello/katello/commit/42c1152dbcb3b41d01d4ed3327e86637e39dbdc0))
  * hammer ping prompts for admin password ([#14397](http://projects.theforeman.org/issues/14397))
- * Katello's late initialization causes issues when resuming dynflow tasks ([#15114](http://projects.theforeman.org/issues/15114), [28cb3ef5](http://github.com/katello/katello/commit/28cb3ef503df6f53a14e68b0e80d4048d3a37b7a))
+ * Katello's late initialization causes issues when resuming dynflow tasks ([#15114](http://projects.theforeman.org/issues/15114), [28cb3ef5](https://github.com/katello/katello/commit/28cb3ef503df6f53a14e68b0e80d4048d3a37b7a))
 
 
 # Contributors

--- a/plugins/katello/3.2/release_notes/release_notes.md
+++ b/plugins/katello/3.2/release_notes/release_notes.md
@@ -43,275 +43,275 @@ You can remove a version in a similar way:
 ## Features
 
 ### Capsule
- * [RFE] make it possible to run capsule-remove unattended ([#16003](http://projects.theforeman.org/issues/16003), [010d458f](http://github.com/katello/katello-installer/commit/010d458f4ac2fc1569fbf2fcbebaa3dc01a54388))
- * Content Hosts: UI should have some indicator as if/which capsule is providing content ([#15818](http://projects.theforeman.org/issues/15818), [69df0ec0](http://github.com/katello/katello/commit/69df0ec0629dad7ef0262cac2618fe789328fcf3))
+ * [RFE] make it possible to run capsule-remove unattended ([#16003](http://projects.theforeman.org/issues/16003), [010d458f](https://github.com/katello/katello-installer/commit/010d458f4ac2fc1569fbf2fcbebaa3dc01a54388))
+ * Content Hosts: UI should have some indicator as if/which capsule is providing content ([#15818](http://projects.theforeman.org/issues/15818), [69df0ec0](https://github.com/katello/katello/commit/69df0ec0629dad7ef0262cac2618fe789328fcf3))
 
 ### Tooling
- * Update to foreman-tasks 0.8.0 ([#16171](http://projects.theforeman.org/issues/16171), [d385d8ac](http://github.com/katello/katello/commit/d385d8acbfd01ce79c79b2c21624d4d465bd139d), [2145ea4e](http://github.com/katello//commit/2145ea4e6c4d178c5b2a110dd6ee030ffafa26b8))
+ * Update to foreman-tasks 0.8.0 ([#16171](http://projects.theforeman.org/issues/16171), [d385d8ac](https://github.com/katello/katello/commit/d385d8acbfd01ce79c79b2c21624d4d465bd139d), [2145ea4e](https://github.com/katello//commit/2145ea4e6c4d178c5b2a110dd6ee030ffafa26b8))
 
 ### Tests
- * Enable HoundCI for checking rubocop cops ([#16242](http://projects.theforeman.org/issues/16242), [da866bef](http://github.com/katello/katello/commit/da866bef41f74888516fcba776bf45103e652dfa))
- * Add a coverage report to Katello ([#15288](http://projects.theforeman.org/issues/15288), [407d3ae3](http://github.com/katello/katello/commit/407d3ae3baee516d79887d24b739bbbdece464ff))
- * Turn on AssignmentInCondition cop ([#15483](http://projects.theforeman.org/issues/15483), [a7228ec6](http://github.com/katello/katello/commit/a7228ec6c5b2c68d64502fc877d1dfb558480f32))
- * Add code climate and build status badges to Katello README ([#15608](http://projects.theforeman.org/issues/15608), [d51e0587](http://github.com/katello/katello/commit/d51e0587a7efe85583c19ec4c6f2c39701dc0090))
+ * Enable HoundCI for checking rubocop cops ([#16242](http://projects.theforeman.org/issues/16242), [da866bef](https://github.com/katello/katello/commit/da866bef41f74888516fcba776bf45103e652dfa))
+ * Add a coverage report to Katello ([#15288](http://projects.theforeman.org/issues/15288), [407d3ae3](https://github.com/katello/katello/commit/407d3ae3baee516d79887d24b739bbbdece464ff))
+ * Turn on AssignmentInCondition cop ([#15483](http://projects.theforeman.org/issues/15483), [a7228ec6](https://github.com/katello/katello/commit/a7228ec6c5b2c68d64502fc877d1dfb558480f32))
+ * Add code climate and build status badges to Katello README ([#15608](http://projects.theforeman.org/issues/15608), [d51e0587](https://github.com/katello/katello/commit/d51e0587a7efe85583c19ec4c6f2c39701dc0090))
 
 ### Errata Management
- * add a way to manually generate applicability for a host ([#16295](http://projects.theforeman.org/issues/16295), [f9ea2ba2](http://github.com/katello/katello/commit/f9ea2ba27ae62bdddc524c888e2e66fdb17ba950))
+ * add a way to manually generate applicability for a host ([#16295](http://projects.theforeman.org/issues/16295), [f9ea2ba2](https://github.com/katello/katello/commit/f9ea2ba27ae62bdddc524c888e2e66fdb17ba950))
 
 ### Content Views
- * Add content-view published status to " hammer -u admin -p changeme content-view  list" ([#16302](http://projects.theforeman.org/issues/16302), [60ed450e](http://github.com/katello/hammer-cli-katello/commit/60ed450e834583179447fcb203d274c9d49c6c34))
- * [RFE] Content View - package filter version field too short for length of typical version strings ([#16332](http://projects.theforeman.org/issues/16332), [f6930f84](http://github.com/katello/katello/commit/f6930f8463c597fa59d4eb709e740ceac78d010b))
- * Allow adding file type repositories to content views ([#13661](http://projects.theforeman.org/issues/13661), [94e8f780](http://github.com/katello/katello/commit/94e8f7803bf99d74433e6592957c20ddeb5b6df7))
+ * Add content-view published status to " hammer -u admin -p changeme content-view  list" ([#16302](http://projects.theforeman.org/issues/16302), [60ed450e](https://github.com/katello/hammer-cli-katello/commit/60ed450e834583179447fcb203d274c9d49c6c34))
+ * [RFE] Content View - package filter version field too short for length of typical version strings ([#16332](http://projects.theforeman.org/issues/16332), [f6930f84](https://github.com/katello/katello/commit/f6930f8463c597fa59d4eb709e740ceac78d010b))
+ * Allow adding file type repositories to content views ([#13661](http://projects.theforeman.org/issues/13661), [94e8f780](https://github.com/katello/katello/commit/94e8f7803bf99d74433e6592957c20ddeb5b6df7))
 
 ### Hammer
- * - "hammer content-host info" command should have information related to "Content Host Status" ([#14829](http://projects.theforeman.org/issues/14829), [29520f64](http://github.com/katello/hammer-cli-katello/commit/29520f6448a9bf2f68e8e6373b25221a05624696))
- * Create/update composite content-view by content-view Names ([#14604](http://projects.theforeman.org/issues/14604), [fa2c5214](http://github.com/katello/hammer-cli-katello/commit/fa2c52142990af23b7f2d6c26ec18cc5f53d6921))
- * Test with Ruby 2.3 ([#15691](http://projects.theforeman.org/issues/15691), [725801c8](http://github.com/katello/hammer-cli-katello/commit/725801c8bbf0655a94570510e87fa7e034144b61))
- * Listing product content for an activation key does not show correct state in Hammer ([#16000](http://projects.theforeman.org/issues/16000), [41584f75](http://github.com/katello/hammer-cli-katello/commit/41584f751e7c8a082a7c3da7708e897e9c5e62be), [028bd011](http://github.com/katello/katello/commit/028bd0115e60da9253da38b01556d0143087c4ed))
- *  Hostgroup info should show associated cv and lifecycle-environment ([#15990](http://projects.theforeman.org/issues/15990), [5b617f3b](http://github.com/katello/hammer-cli-katello/commit/5b617f3bb888106bd5027a166d42e18c875a8a53))
+ * - "hammer content-host info" command should have information related to "Content Host Status" ([#14829](http://projects.theforeman.org/issues/14829), [29520f64](https://github.com/katello/hammer-cli-katello/commit/29520f6448a9bf2f68e8e6373b25221a05624696))
+ * Create/update composite content-view by content-view Names ([#14604](http://projects.theforeman.org/issues/14604), [fa2c5214](https://github.com/katello/hammer-cli-katello/commit/fa2c52142990af23b7f2d6c26ec18cc5f53d6921))
+ * Test with Ruby 2.3 ([#15691](http://projects.theforeman.org/issues/15691), [725801c8](https://github.com/katello/hammer-cli-katello/commit/725801c8bbf0655a94570510e87fa7e034144b61))
+ * Listing product content for an activation key does not show correct state in Hammer ([#16000](http://projects.theforeman.org/issues/16000), [41584f75](https://github.com/katello/hammer-cli-katello/commit/41584f751e7c8a082a7c3da7708e897e9c5e62be), [028bd011](https://github.com/katello/katello/commit/028bd0115e60da9253da38b01556d0143087c4ed))
+ *  Hostgroup info should show associated cv and lifecycle-environment ([#15990](http://projects.theforeman.org/issues/15990), [5b617f3b](https://github.com/katello/hammer-cli-katello/commit/5b617f3bb888106bd5027a166d42e18c875a8a53))
 
 ### Subscriptions
- * As a UI user i like to select hosts to attach subscriptions ([#10431](http://projects.theforeman.org/issues/10431), [95d7b249](http://github.com/katello/katello/commit/95d7b249824621b8df8dcf7875e12113c687a685))
+ * As a UI user i like to select hosts to attach subscriptions ([#10431](http://projects.theforeman.org/issues/10431), [95d7b249](https://github.com/katello/katello/commit/95d7b249824621b8df8dcf7875e12113c687a685))
 
 ### Atomic
- * UI - As a user I want to be able to search rpm-ostree repos ([#13953](http://projects.theforeman.org/issues/13953), [67d0bd27](http://github.com/katello/katello/commit/67d0bd279e88783cd141bde4f00bf9619a6d06cf))
+ * UI - As a user I want to be able to search rpm-ostree repos ([#13953](http://projects.theforeman.org/issues/13953), [67d0bd27](https://github.com/katello/katello/commit/67d0bd279e88783cd141bde4f00bf9619a6d06cf))
 
 ### Web UI
- * Upgrade katello to new angular/jasmin ([#15085](http://projects.theforeman.org/issues/15085), [35879d13](http://github.com/katello/katello/commit/35879d1300416281a75ed677bede37547b6e9384))
+ * Upgrade katello to new angular/jasmin ([#15085](http://projects.theforeman.org/issues/15085), [35879d13](https://github.com/katello/katello/commit/35879d1300416281a75ed677bede37547b6e9384))
 
 ### Backup & Restore
- * Fully online backup ([#15454](http://projects.theforeman.org/issues/15454), [46e44353](http://github.com/katello//commit/46e44353099568f6321047887404b24500a27e35))
+ * Fully online backup ([#15454](http://projects.theforeman.org/issues/15454), [46e44353](https://github.com/katello//commit/46e44353099568f6321047887404b24500a27e35))
 
 ### API
- * [Sat6] allow multiple rpms to be added via content-view filter rule create API endpoint ([#15536](http://projects.theforeman.org/issues/15536), [ad75723f](http://github.com/katello/katello/commit/ad75723f03b84378feff7cbc983d6caf73acbb15))
- * Use parameter_filter instead of attr_accessible ([#15741](http://projects.theforeman.org/issues/15741), [328ee19a](http://github.com/katello/katello/commit/328ee19afa9b743d6ff25e3c7cabaa20c87b43cc))
+ * [Sat6] allow multiple rpms to be added via content-view filter rule create API endpoint ([#15536](http://projects.theforeman.org/issues/15536), [ad75723f](https://github.com/katello/katello/commit/ad75723f03b84378feff7cbc983d6caf73acbb15))
+ * Use parameter_filter instead of attr_accessible ([#15741](http://projects.theforeman.org/issues/15741), [328ee19a](https://github.com/katello/katello/commit/328ee19afa9b743d6ff25e3c7cabaa20c87b43cc))
 
 ### Repositories
- * Provide API for file type content ([#15630](http://projects.theforeman.org/issues/15630), [8fac5bed](http://github.com/katello/katello/commit/8fac5bed86cfb476e5ec0b3ed539d4769a15c965))
- * Need a quick way to allow "insecure"  syncs ([#15802](http://projects.theforeman.org/issues/15802), [810cc603](http://github.com/katello/katello/commit/810cc603b2a4f8841b7d995f700dc2c50eeed2ca), [34824f25](http://github.com/katello/katello/commit/34824f250d5b35e8088b4463852f2b4c5e422cde))
+ * Provide API for file type content ([#15630](http://projects.theforeman.org/issues/15630), [8fac5bed](https://github.com/katello/katello/commit/8fac5bed86cfb476e5ec0b3ed539d4769a15c965))
+ * Need a quick way to allow "insecure"  syncs ([#15802](http://projects.theforeman.org/issues/15802), [810cc603](https://github.com/katello/katello/commit/810cc603b2a4f8841b7d995f700dc2c50eeed2ca), [34824f25](https://github.com/katello/katello/commit/34824f250d5b35e8088b4463852f2b4c5e422cde))
 
 ### Documentation
- * Remove YARD from Katello ([#15670](http://projects.theforeman.org/issues/15670), [37ff67b3](http://github.com/katello/katello/commit/37ff67b3f2ac3f0c78f45715baa735d93a044cab))
+ * Remove YARD from Katello ([#15670](http://projects.theforeman.org/issues/15670), [37ff67b3](https://github.com/katello/katello/commit/37ff67b3f2ac3f0c78f45715baa735d93a044cab))
 
 ## Bug Fixes
 
 ### Installer
- * Add rubocop to katello-installer ([#16354](http://projects.theforeman.org/issues/16354), [0743b788](http://github.com/katello/katello-installer/commit/0743b788f551c4f117e8493ac25bf5a6c8302181), [34d01ec2](http://github.com/katello/katello-installer/commit/34d01ec28515f15487bcc06b18994d06795c42e8))
+ * Add rubocop to katello-installer ([#16354](http://projects.theforeman.org/issues/16354), [0743b788](https://github.com/katello/katello-installer/commit/0743b788f551c4f117e8493ac25bf5a6c8302181), [34d01ec2](https://github.com/katello/katello-installer/commit/34d01ec28515f15487bcc06b18994d06795c42e8))
 
 ### Upgrades
- * Create a preupgrade script to check systems before upgrades ([#15611](http://projects.theforeman.org/issues/15611), [fea48380](http://github.com/katello/katello/commit/fea48380ff60330b12f3966f82d4353c56dcc152))
+ * Create a preupgrade script to check systems before upgrades ([#15611](http://projects.theforeman.org/issues/15611), [fea48380](https://github.com/katello/katello/commit/fea48380ff60330b12f3966f82d4353c56dcc152))
 
 ### Puppet
- * Support cleaning empty puppet envs with puppet 4 ([#16523](http://projects.theforeman.org/issues/16523), [f7b70e71](http://github.com/katello//commit/f7b70e71ecaf99cd9de375d75d0880d4f3d5c3be), [58469817](http://github.com/katello//commit/5846981719e9bd6a5617daf7078b8729dbb1e5f0))
- * katello installer does not allow for upgrading puppet ([#16053](http://projects.theforeman.org/issues/16053), [8db5561d](http://github.com/katello/katello-installer/commit/8db5561d884b46d0dd81f88a3666f0b1cf3130df), [b192d5e7](http://github.com/katello/katello.org/commit/b192d5e7f500a445ff8b71473f8fbf624e96a280))
- * --clear-puppet-environments does not handle puppet 4 env dir ([#16011](http://projects.theforeman.org/issues/16011), [6cbb35d5](http://github.com/katello/katello-installer/commit/6cbb35d5244cef8799531f82044d3134088de9fe))
- * empty puppet environments are left behind in /etc/puppet/environments ([#15845](http://projects.theforeman.org/issues/15845), [13189a68](http://github.com/katello//commit/13189a683be47c455f7da00d8152baebbffa4e7e))
+ * Support cleaning empty puppet envs with puppet 4 ([#16523](http://projects.theforeman.org/issues/16523), [f7b70e71](https://github.com/katello//commit/f7b70e71ecaf99cd9de375d75d0880d4f3d5c3be), [58469817](https://github.com/katello//commit/5846981719e9bd6a5617daf7078b8729dbb1e5f0))
+ * katello installer does not allow for upgrading puppet ([#16053](http://projects.theforeman.org/issues/16053), [8db5561d](https://github.com/katello/katello-installer/commit/8db5561d884b46d0dd81f88a3666f0b1cf3130df), [b192d5e7](https://github.com/katello/katello.org/commit/b192d5e7f500a445ff8b71473f8fbf624e96a280))
+ * --clear-puppet-environments does not handle puppet 4 env dir ([#16011](http://projects.theforeman.org/issues/16011), [6cbb35d5](https://github.com/katello/katello-installer/commit/6cbb35d5244cef8799531f82044d3134088de9fe))
+ * empty puppet environments are left behind in /etc/puppet/environments ([#15845](http://projects.theforeman.org/issues/15845), [13189a68](https://github.com/katello//commit/13189a683be47c455f7da00d8152baebbffa4e7e))
 
 ### Hammer
- * Support large file uploads in the CLI ([#16457](http://projects.theforeman.org/issues/16457), [f060a2b3](http://github.com/katello/hammer-cli-katello/commit/f060a2b37b07d4280959af4dc5eaec363e709d0e))
- * Following the README in setting up hammer-cli-katello, you get a gem dependency conflict ([#16101](http://projects.theforeman.org/issues/16101), [f46fbd64](http://github.com/katello/hammer-cli-katello/commit/f46fbd641171a0cae871f268230ef484f50bae44), [8f19345a](http://github.com/katello/hammer-cli-katello/commit/8f19345a8e386f43eed359e289e3d66d9ab7cd2e))
- * [Sat6.2] command "hammer activation-key add-host-collection" fails if using option "--host-collection" with organization_id set to default 1 ([#16034](http://projects.theforeman.org/issues/16034), [34ae3d3d](http://github.com/katello/hammer-cli-katello/commit/34ae3d3d6ede2df3aba85db7a7028e6dd0f14a6f))
- * Drop support for Ruby 2.0.0 ([#15949](http://projects.theforeman.org/issues/15949), [44a80a49](http://github.com/katello/hammer-cli-katello/commit/44a80a499d11e4814f42af5f3e945ca98696c8b6))
- * Fix the broken link to Travis in the Readme ([#15934](http://projects.theforeman.org/issues/15934), [5fbe0fab](http://github.com/katello/hammer-cli-katello/commit/5fbe0fabd3c6e81d1e684dcf0eaf14cd32b1d045))
- * Adjust coverage settings in hammer-cli-katello ([#15927](http://projects.theforeman.org/issues/15927), [03f06430](http://github.com/katello/hammer-cli-katello/commit/03f064307418a51e384003cff1e7af2f1d481688))
- * Hammer doesn't handle removal of required :organization_id param on content_view and lifecycle_environment ([#15830](http://projects.theforeman.org/issues/15830), [e0bea267](http://github.com/katello/hammer-cli-katello/commit/e0bea267be201e78d4f732b29233de7334451270))
- * Allow Foreman objects to resolve using `create_search_options_creators_without_katello_api` ([#15701](http://projects.theforeman.org/issues/15701), [18926cd6](http://github.com/katello/hammer-cli-katello/commit/18926cd614495c4c59f043e7151af5e67edea5be), [d270200b](http://github.com/katello/hammer-cli-katello/commit/d270200b47dc3d8574a8fc8c676f8855faa01427))
- * Organization options for content-view and lifecycle-environment should fail gracefully for `hammer hostgroups create/update`   ([#15693](http://projects.theforeman.org/issues/15693), [101e9666](http://github.com/katello/hammer-cli-katello/commit/101e9666d599c9c38f922bde85ebecfa92184a32))
- * hammer content-view create fails when component-ids are specified ([#15678](http://projects.theforeman.org/issues/15678), [d9551dc8](http://github.com/katello/katello/commit/d9551dc8e503c2839626c26aa0ba981b91b3d762))
- * Cannot create new content view ([#15604](http://projects.theforeman.org/issues/15604), [6feaf353](http://github.com/katello/hammer-cli-katello/commit/6feaf35385717242afbe09ba84e9ba6f8b19af6a))
- * Remove Ruby 1.9.3 support from hammer-cli-katello Travis tests ([#15593](http://projects.theforeman.org/issues/15593), [7b95d443](http://github.com/katello/hammer-cli-katello/commit/7b95d4434fa5875d2404c838d4a4a3e782f9773e))
- * Remove `hammer content-host update` - New command is `hammer host update` ([#15589](http://projects.theforeman.org/issues/15589), [2597aaef](http://github.com/katello/hammer-cli-katello/commit/2597aaeffc710066380b5461e0bd757191d24001))
- * [Sat6] allow multiple rpms to be added via hammer content-view filter rule create ([#15537](http://projects.theforeman.org/issues/15537), [6dce9a75](http://github.com/katello/hammer-cli-katello/commit/6dce9a75ba071d9d358baa165ba9b85b1a7766e2))
- * Use fully qualified object ::Foreman in #15420 ([#15443](http://projects.theforeman.org/issues/15443), [39117d81](http://github.com/katello/katello/commit/39117d81e7fb4436e10979f074c2dc0f8b0ba8a1))
- * Update test data with new API ([#15436](http://projects.theforeman.org/issues/15436), [a9fa1808](http://github.com/katello/hammer-cli-katello/commit/a9fa18080b81130c0d2c183daa55fd75e5b027d3))
- * Only require hammer_cli and hammer_cli_foreman from git in development and production ([#15419](http://projects.theforeman.org/issues/15419), [650bb22e](http://github.com/katello/hammer-cli-katello/commit/650bb22e4aaf11e436f27dea603477b6b7c8a6fd))
- * hammer hostgroup update or create command fails when using --organization-ids option fails ([#15313](http://projects.theforeman.org/issues/15313), [2c7c6b6f](http://github.com/katello/hammer-cli-katello/commit/2c7c6b6f8776671509d1e0526b396a736b9a46a1))
- * hammer host-collection add-host/remove-host always return success ([#15291](http://projects.theforeman.org/issues/15291), [2e3e5edf](http://github.com/katello/katello/commit/2e3e5edf4d8a1883aa827a6278ad7cd83bdc00d4))
- * 'hammer activation-key subscriptions' shows already removed subscriptions ([#15272](http://projects.theforeman.org/issues/15272), [9e72e0c8](http://github.com/katello/hammer-cli-katello/commit/9e72e0c8a3759016112b4445d38a2bc55a020aeb))
+ * Support large file uploads in the CLI ([#16457](http://projects.theforeman.org/issues/16457), [f060a2b3](https://github.com/katello/hammer-cli-katello/commit/f060a2b37b07d4280959af4dc5eaec363e709d0e))
+ * Following the README in setting up hammer-cli-katello, you get a gem dependency conflict ([#16101](http://projects.theforeman.org/issues/16101), [f46fbd64](https://github.com/katello/hammer-cli-katello/commit/f46fbd641171a0cae871f268230ef484f50bae44), [8f19345a](https://github.com/katello/hammer-cli-katello/commit/8f19345a8e386f43eed359e289e3d66d9ab7cd2e))
+ * [Sat6.2] command "hammer activation-key add-host-collection" fails if using option "--host-collection" with organization_id set to default 1 ([#16034](http://projects.theforeman.org/issues/16034), [34ae3d3d](https://github.com/katello/hammer-cli-katello/commit/34ae3d3d6ede2df3aba85db7a7028e6dd0f14a6f))
+ * Drop support for Ruby 2.0.0 ([#15949](http://projects.theforeman.org/issues/15949), [44a80a49](https://github.com/katello/hammer-cli-katello/commit/44a80a499d11e4814f42af5f3e945ca98696c8b6))
+ * Fix the broken link to Travis in the Readme ([#15934](http://projects.theforeman.org/issues/15934), [5fbe0fab](https://github.com/katello/hammer-cli-katello/commit/5fbe0fabd3c6e81d1e684dcf0eaf14cd32b1d045))
+ * Adjust coverage settings in hammer-cli-katello ([#15927](http://projects.theforeman.org/issues/15927), [03f06430](https://github.com/katello/hammer-cli-katello/commit/03f064307418a51e384003cff1e7af2f1d481688))
+ * Hammer doesn't handle removal of required :organization_id param on content_view and lifecycle_environment ([#15830](http://projects.theforeman.org/issues/15830), [e0bea267](https://github.com/katello/hammer-cli-katello/commit/e0bea267be201e78d4f732b29233de7334451270))
+ * Allow Foreman objects to resolve using `create_search_options_creators_without_katello_api` ([#15701](http://projects.theforeman.org/issues/15701), [18926cd6](https://github.com/katello/hammer-cli-katello/commit/18926cd614495c4c59f043e7151af5e67edea5be), [d270200b](https://github.com/katello/hammer-cli-katello/commit/d270200b47dc3d8574a8fc8c676f8855faa01427))
+ * Organization options for content-view and lifecycle-environment should fail gracefully for `hammer hostgroups create/update`   ([#15693](http://projects.theforeman.org/issues/15693), [101e9666](https://github.com/katello/hammer-cli-katello/commit/101e9666d599c9c38f922bde85ebecfa92184a32))
+ * hammer content-view create fails when component-ids are specified ([#15678](http://projects.theforeman.org/issues/15678), [d9551dc8](https://github.com/katello/katello/commit/d9551dc8e503c2839626c26aa0ba981b91b3d762))
+ * Cannot create new content view ([#15604](http://projects.theforeman.org/issues/15604), [6feaf353](https://github.com/katello/hammer-cli-katello/commit/6feaf35385717242afbe09ba84e9ba6f8b19af6a))
+ * Remove Ruby 1.9.3 support from hammer-cli-katello Travis tests ([#15593](http://projects.theforeman.org/issues/15593), [7b95d443](https://github.com/katello/hammer-cli-katello/commit/7b95d4434fa5875d2404c838d4a4a3e782f9773e))
+ * Remove `hammer content-host update` - New command is `hammer host update` ([#15589](http://projects.theforeman.org/issues/15589), [2597aaef](https://github.com/katello/hammer-cli-katello/commit/2597aaeffc710066380b5461e0bd757191d24001))
+ * [Sat6] allow multiple rpms to be added via hammer content-view filter rule create ([#15537](http://projects.theforeman.org/issues/15537), [6dce9a75](https://github.com/katello/hammer-cli-katello/commit/6dce9a75ba071d9d358baa165ba9b85b1a7766e2))
+ * Use fully qualified object ::Foreman in #15420 ([#15443](http://projects.theforeman.org/issues/15443), [39117d81](https://github.com/katello/katello/commit/39117d81e7fb4436e10979f074c2dc0f8b0ba8a1))
+ * Update test data with new API ([#15436](http://projects.theforeman.org/issues/15436), [a9fa1808](https://github.com/katello/hammer-cli-katello/commit/a9fa18080b81130c0d2c183daa55fd75e5b027d3))
+ * Only require hammer_cli and hammer_cli_foreman from git in development and production ([#15419](http://projects.theforeman.org/issues/15419), [650bb22e](https://github.com/katello/hammer-cli-katello/commit/650bb22e4aaf11e436f27dea603477b6b7c8a6fd))
+ * hammer hostgroup update or create command fails when using --organization-ids option fails ([#15313](http://projects.theforeman.org/issues/15313), [2c7c6b6f](https://github.com/katello/hammer-cli-katello/commit/2c7c6b6f8776671509d1e0526b396a736b9a46a1))
+ * hammer host-collection add-host/remove-host always return success ([#15291](http://projects.theforeman.org/issues/15291), [2e3e5edf](https://github.com/katello/katello/commit/2e3e5edf4d8a1883aa827a6278ad7cd83bdc00d4))
+ * 'hammer activation-key subscriptions' shows already removed subscriptions ([#15272](http://projects.theforeman.org/issues/15272), [9e72e0c8](https://github.com/katello/hammer-cli-katello/commit/9e72e0c8a3759016112b4445d38a2bc55a020aeb))
  * unable to remove 'version' parameter from command ([#13636](http://projects.theforeman.org/issues/13636))
- * need way to attach a subscription to a content host w/ hammer ([#9669](http://projects.theforeman.org/issues/9669), [14c96768](http://github.com/katello/hammer-cli-katello/commit/14c967686b5ef466cd9f30f180cacd7db56507a5))
+ * need way to attach a subscription to a content host w/ hammer ([#9669](http://projects.theforeman.org/issues/9669), [14c96768](https://github.com/katello/hammer-cli-katello/commit/14c967686b5ef466cd9f30f180cacd7db56507a5))
 
 ### Installer
- * capsule-certs-generate fails for missing parser cache ([#16455](http://projects.theforeman.org/issues/16455), [95eea445](http://github.com/katello/katello-installer/commit/95eea44544c1a2b42a0e9f85f4c49b23884cad47))
- * Installer should support Puppet 3 and Puppet 4 cache directory ([#16334](http://projects.theforeman.org/issues/16334), [e7177df5](http://github.com/katello/katello-installer/commit/e7177df5c0917ea3f00de027d314755e19cfe16d))
- * katello-certs-check output should display a absolute path to certs ([#16280](http://projects.theforeman.org/issues/16280), [e03bc400](http://github.com/katello/katello-installer/commit/e03bc400004ab6343c81e65bb097b45ad744fa5f))
- * Generate katello-installer's parser cache for kafo and include in the source bundle ([#15938](http://projects.theforeman.org/issues/15938), [7e43a9d2](http://github.com/katello/katello-installer/commit/7e43a9d29bd70c33bc1945042c39a46e71cc829a), [9fa93e0a](http://github.com/katello//commit/9fa93e0a6b539210f8b7ff6ced75324ab28fa155))
- * Do not use facter anywhere in katello-installer ([#15911](http://projects.theforeman.org/issues/15911), [57814d72](http://github.com/katello/katello-installer/commit/57814d725eb369211175b609beb9086f107ce8d1))
- * Look at AIO data path for cached data ([#15910](http://projects.theforeman.org/issues/15910), [3edf7534](http://github.com/katello/katello-installer/commit/3edf7534471cbf787be02b39b139e5fe9484661c))
- * puppet-certs doesn't support puppet 4 aio paths for SSL certificates ([#15882](http://projects.theforeman.org/issues/15882), [55b0911f](http://github.com/katello/puppet-certs/commit/55b0911f7d8465a11fca5d45d31a1fee59a3b7f8))
- * katello-installer may fail on machines with low RAM ([#15696](http://projects.theforeman.org/issues/15696), [33f41e6d](http://github.com/katello/katello-installer/commit/33f41e6d1c9df71e213a75f85591407bd79aa68a))
- * rake setup_local creates ./modules/modules ([#15511](http://projects.theforeman.org/issues/15511), [ce810a94](http://github.com/katello/katello-installer/commit/ce810a9473ac17ebf4a5413a646b385d393a0749))
- * Install fails if host puppet certs have already been generated ([#15241](http://projects.theforeman.org/issues/15241), [b54acb74](http://github.com/katello/katello-installer/commit/b54acb744e9de530ec019bcca0f850d11b37d5b8))
+ * capsule-certs-generate fails for missing parser cache ([#16455](http://projects.theforeman.org/issues/16455), [95eea445](https://github.com/katello/katello-installer/commit/95eea44544c1a2b42a0e9f85f4c49b23884cad47))
+ * Installer should support Puppet 3 and Puppet 4 cache directory ([#16334](http://projects.theforeman.org/issues/16334), [e7177df5](https://github.com/katello/katello-installer/commit/e7177df5c0917ea3f00de027d314755e19cfe16d))
+ * katello-certs-check output should display a absolute path to certs ([#16280](http://projects.theforeman.org/issues/16280), [e03bc400](https://github.com/katello/katello-installer/commit/e03bc400004ab6343c81e65bb097b45ad744fa5f))
+ * Generate katello-installer's parser cache for kafo and include in the source bundle ([#15938](http://projects.theforeman.org/issues/15938), [7e43a9d2](https://github.com/katello/katello-installer/commit/7e43a9d29bd70c33bc1945042c39a46e71cc829a), [9fa93e0a](https://github.com/katello//commit/9fa93e0a6b539210f8b7ff6ced75324ab28fa155))
+ * Do not use facter anywhere in katello-installer ([#15911](http://projects.theforeman.org/issues/15911), [57814d72](https://github.com/katello/katello-installer/commit/57814d725eb369211175b609beb9086f107ce8d1))
+ * Look at AIO data path for cached data ([#15910](http://projects.theforeman.org/issues/15910), [3edf7534](https://github.com/katello/katello-installer/commit/3edf7534471cbf787be02b39b139e5fe9484661c))
+ * puppet-certs doesn't support puppet 4 aio paths for SSL certificates ([#15882](http://projects.theforeman.org/issues/15882), [55b0911f](https://github.com/katello/puppet-certs/commit/55b0911f7d8465a11fca5d45d31a1fee59a3b7f8))
+ * katello-installer may fail on machines with low RAM ([#15696](http://projects.theforeman.org/issues/15696), [33f41e6d](https://github.com/katello/katello-installer/commit/33f41e6d1c9df71e213a75f85591407bd79aa68a))
+ * rake setup_local creates ./modules/modules ([#15511](http://projects.theforeman.org/issues/15511), [ce810a94](https://github.com/katello/katello-installer/commit/ce810a9473ac17ebf4a5413a646b385d393a0749))
+ * Install fails if host puppet certs have already been generated ([#15241](http://projects.theforeman.org/issues/15241), [b54acb74](https://github.com/katello/katello-installer/commit/b54acb744e9de530ec019bcca0f850d11b37d5b8))
  * Select Puppet::server_implementation from installer ([#14602](http://projects.theforeman.org/issues/14602))
- * katello-certs-check should print absolute paths to certificates ([#15775](http://projects.theforeman.org/issues/15775), [b57b21e4](http://github.com/katello/katello-installer/commit/b57b21e46f51490bd7d5e1f5f5d18b03fa494ed2))
- * The installer should check that the cert rpms installed on the system are corresponding to those present in ~/ssl-build (or in the capsule certs tar.gz) ([#15538](http://projects.theforeman.org/issues/15538), [df36e803](http://github.com/katello/puppet-certs/commit/df36e803c6d24ac08d780e103cabb36dabf852fa), [e1f168d7](http://github.com/katello/puppet-certs/commit/e1f168d72a9ca9aa573dfd3e5f7cd214ff28e2bd))
- * Making Upgrade from 3.1 RC2 to 3.1 Release ([#16433](http://projects.theforeman.org/issues/16433), [4ea05178](http://github.com/katello/katello.org/commit/4ea05178a0d06e13f4704ea4b189620665532c62))
+ * katello-certs-check should print absolute paths to certificates ([#15775](http://projects.theforeman.org/issues/15775), [b57b21e4](https://github.com/katello/katello-installer/commit/b57b21e46f51490bd7d5e1f5f5d18b03fa494ed2))
+ * The installer should check that the cert rpms installed on the system are corresponding to those present in ~/ssl-build (or in the capsule certs tar.gz) ([#15538](http://projects.theforeman.org/issues/15538), [df36e803](https://github.com/katello/puppet-certs/commit/df36e803c6d24ac08d780e103cabb36dabf852fa), [e1f168d7](https://github.com/katello/puppet-certs/commit/e1f168d72a9ca9aa573dfd3e5f7cd214ff28e2bd))
+ * Making Upgrade from 3.1 RC2 to 3.1 Release ([#16433](http://projects.theforeman.org/issues/16433), [4ea05178](https://github.com/katello/katello.org/commit/4ea05178a0d06e13f4704ea4b189620665532c62))
 
 ### Repositories
- * Handle import upload errors from pulp ([#16451](http://projects.theforeman.org/issues/16451), [f58088de](http://github.com/katello/katello/commit/f58088def544fb08af927568b4b42e321628a1f9))
- * Unable to upload large RPM files from Satellite UI ([#16344](http://projects.theforeman.org/issues/16344), [0127b0ad](http://github.com/katello/katello/commit/0127b0adda4c3a2635031f41617b07c9e0aca597))
- * look for treeinfo files when enabling a repo ([#16278](http://projects.theforeman.org/issues/16278), [821d936d](http://github.com/katello/katello/commit/821d936d3f5f7ffd729a22cc390a18bff0d97515))
- * The refresh_repositsory file is misspelled as refresh_repostiory ([#16157](http://projects.theforeman.org/issues/16157), [be6cc4be](http://github.com/katello/katello/commit/be6cc4be2ab0462082889092d003955ac0075fbe))
- * Unable to sync Docker Containers to Satellite if repository already exists ([#15971](http://projects.theforeman.org/issues/15971), [4f30704e](http://github.com/katello/katello/commit/4f30704e95a9be5d80ef465be24455e372959ee1))
- * Repository > Details: "Last Synced" for an unsynced repo looks silly. ([#15933](http://projects.theforeman.org/issues/15933), [9cff370e](http://github.com/katello/katello/commit/9cff370e8ac9e108848e0ecbc7d95902caec0dc8))
- * Cannot add/remove repositories to a content view ([#15869](http://projects.theforeman.org/issues/15869), [a7dcac7e](http://github.com/katello/katello/commit/a7dcac7ebd20caa34983c7629216f2378b458a76))
- * Enabling a repository needs to fail on pulp error ([#15824](http://projects.theforeman.org/issues/15824), [236caa38](http://github.com/katello/katello/commit/236caa388ad1a31a22305735a1898e1c7716314e))
- * Syncing a PULP_MANIFEST puppet repo over file:// fails with No such file or directory: u'///dir/modules.json' ([#15812](http://projects.theforeman.org/issues/15812), [d72f8c10](http://github.com/katello/katello.org/commit/d72f8c10077e6b2f3286d4aae968a9e41386439a))
- * Incremental update task name should have more info ([#15808](http://projects.theforeman.org/issues/15808), [133a4dde](http://github.com/katello/katello/commit/133a4dde762d85ebd0ca76c4fc5ef33f515e8239))
- * Opening Red Hat Repositories link without an uploaded manifest provides the user with a dead link ([#15803](http://projects.theforeman.org/issues/15803), [c7eb8c52](http://github.com/katello/katello/commit/c7eb8c52545082ef72aa6230d13a0b87fe85fb62))
+ * Handle import upload errors from pulp ([#16451](http://projects.theforeman.org/issues/16451), [f58088de](https://github.com/katello/katello/commit/f58088def544fb08af927568b4b42e321628a1f9))
+ * Unable to upload large RPM files from Satellite UI ([#16344](http://projects.theforeman.org/issues/16344), [0127b0ad](https://github.com/katello/katello/commit/0127b0adda4c3a2635031f41617b07c9e0aca597))
+ * look for treeinfo files when enabling a repo ([#16278](http://projects.theforeman.org/issues/16278), [821d936d](https://github.com/katello/katello/commit/821d936d3f5f7ffd729a22cc390a18bff0d97515))
+ * The refresh_repositsory file is misspelled as refresh_repostiory ([#16157](http://projects.theforeman.org/issues/16157), [be6cc4be](https://github.com/katello/katello/commit/be6cc4be2ab0462082889092d003955ac0075fbe))
+ * Unable to sync Docker Containers to Satellite if repository already exists ([#15971](http://projects.theforeman.org/issues/15971), [4f30704e](https://github.com/katello/katello/commit/4f30704e95a9be5d80ef465be24455e372959ee1))
+ * Repository > Details: "Last Synced" for an unsynced repo looks silly. ([#15933](http://projects.theforeman.org/issues/15933), [9cff370e](https://github.com/katello/katello/commit/9cff370e8ac9e108848e0ecbc7d95902caec0dc8))
+ * Cannot add/remove repositories to a content view ([#15869](http://projects.theforeman.org/issues/15869), [a7dcac7e](https://github.com/katello/katello/commit/a7dcac7ebd20caa34983c7629216f2378b458a76))
+ * Enabling a repository needs to fail on pulp error ([#15824](http://projects.theforeman.org/issues/15824), [236caa38](https://github.com/katello/katello/commit/236caa388ad1a31a22305735a1898e1c7716314e))
+ * Syncing a PULP_MANIFEST puppet repo over file:// fails with No such file or directory: u'///dir/modules.json' ([#15812](http://projects.theforeman.org/issues/15812), [d72f8c10](https://github.com/katello/katello.org/commit/d72f8c10077e6b2f3286d4aae968a9e41386439a))
+ * Incremental update task name should have more info ([#15808](http://projects.theforeman.org/issues/15808), [133a4dde](https://github.com/katello/katello/commit/133a4dde762d85ebd0ca76c4fc5ef33f515e8239))
+ * Opening Red Hat Repositories link without an uploaded manifest provides the user with a dead link ([#15803](http://projects.theforeman.org/issues/15803), [c7eb8c52](https://github.com/katello/katello/commit/c7eb8c52545082ef72aa6230d13a0b87fe85fb62))
 
 ### Documentation
- * doc change for updated memory specs ([#16427](http://projects.theforeman.org/issues/16427), [e3b1057f](http://github.com/katello/katello.org/commit/e3b1057f0c8f5db002d2252ddef94e67ef26d66c))
- * Fix README references to YARD and praise ([#15669](http://projects.theforeman.org/issues/15669), [4e21fa41](http://github.com/katello/katello/commit/4e21fa41d0913e9e2ba065c33c4dabd6085cffef))
- * Fix broken link in the README ([#15609](http://projects.theforeman.org/issues/15609), [1a6e0477](http://github.com/katello/katello/commit/1a6e04773fd3e9bf8637ff67645d04c50584dc22))
- * katello disconnected instructions fail to work due to vhost configuration ([#15702](http://projects.theforeman.org/issues/15702), [3913669a](http://github.com/katello/katello.org/commit/3913669a7a68f77ea882bd49460f6615a3513454))
+ * doc change for updated memory specs ([#16427](http://projects.theforeman.org/issues/16427), [e3b1057f](https://github.com/katello/katello.org/commit/e3b1057f0c8f5db002d2252ddef94e67ef26d66c))
+ * Fix README references to YARD and praise ([#15669](http://projects.theforeman.org/issues/15669), [4e21fa41](https://github.com/katello/katello/commit/4e21fa41d0913e9e2ba065c33c4dabd6085cffef))
+ * Fix broken link in the README ([#15609](http://projects.theforeman.org/issues/15609), [1a6e0477](https://github.com/katello/katello/commit/1a6e04773fd3e9bf8637ff67645d04c50584dc22))
+ * katello disconnected instructions fail to work due to vhost configuration ([#15702](http://projects.theforeman.org/issues/15702), [3913669a](https://github.com/katello/katello.org/commit/3913669a7a68f77ea882bd49460f6615a3513454))
 
 ### GPG Keys
- * Inconsistent with capitalization of GPG keys across navigation, page title, and button ([#16409](http://projects.theforeman.org/issues/16409), [e77758e2](http://github.com/katello/katello/commit/e77758e2f449c0c8e1db68402a687e21a8541c26))
+ * Inconsistent with capitalization of GPG keys across navigation, page title, and button ([#16409](http://projects.theforeman.org/issues/16409), [e77758e2](https://github.com/katello/katello/commit/e77758e2f449c0c8e1db68402a687e21a8541c26))
 
 ### Errata Management
- * Environment and content view not displayed for content host ([#16399](http://projects.theforeman.org/issues/16399), [d157380f](http://github.com/katello/katello/commit/d157380f2477e7e5709c1591717bfaf8940f30c9))
- * dashboard latest errata shows untranslated strings ([#15929](http://projects.theforeman.org/issues/15929), [3f888f37](http://github.com/katello/katello/commit/3f888f374fa85f78c4532c41ab96f3f61d66ec96))
- * Cannot apply large sets of errata on errata page because the host search returns a 414 ([#15376](http://projects.theforeman.org/issues/15376), [d099e609](http://github.com/katello/katello/commit/d099e60957b15c2617e7d34ec5f8eb6b0254a9eb))
- * Incremental Update fails with --update-all-systems ([#16232](http://projects.theforeman.org/issues/16232), [d715a3f1](http://github.com/katello/katello/commit/d715a3f13bf648328fe508bb9f601e90b8ceed6b))
+ * Environment and content view not displayed for content host ([#16399](http://projects.theforeman.org/issues/16399), [d157380f](https://github.com/katello/katello/commit/d157380f2477e7e5709c1591717bfaf8940f30c9))
+ * dashboard latest errata shows untranslated strings ([#15929](http://projects.theforeman.org/issues/15929), [3f888f37](https://github.com/katello/katello/commit/3f888f374fa85f78c4532c41ab96f3f61d66ec96))
+ * Cannot apply large sets of errata on errata page because the host search returns a 414 ([#15376](http://projects.theforeman.org/issues/15376), [d099e609](https://github.com/katello/katello/commit/d099e60957b15c2617e7d34ec5f8eb6b0254a9eb))
+ * Incremental Update fails with --update-all-systems ([#16232](http://projects.theforeman.org/issues/16232), [d715a3f1](https://github.com/katello/katello/commit/d715a3f13bf648328fe508bb9f601e90b8ceed6b))
 
 ### Client/Agent
- *  Removing katello-ca-consumer rpm should revert rhsm.conf  ([#16388](http://projects.theforeman.org/issues/16388), [8d75e8c8](http://github.com/katello/puppet-certs/commit/8d75e8c86a4dfd43bec9295dad736e5cf9fa6059))
- * Large virt-who json may cause performance issue ([#16228](http://projects.theforeman.org/issues/16228), [a0ec0f2b](http://github.com/katello/katello/commit/a0ec0f2ba5c49a31799cd37574bfce8e02de9124))
- * calling `enabled_repos` always forces an errata applicability regeneration ([#16209](http://projects.theforeman.org/issues/16209), [184c966c](http://github.com/katello/katello/commit/184c966ca192ae2eacef9e888475c705cf66ac63))
- * provide option to delete host with subscription-manager unregister ([#15455](http://projects.theforeman.org/issues/15455), [71bf4797](http://github.com/katello/katello/commit/71bf4797cadf58ca003e9383a8cc94a46f1ab0db))
- * Re-Registering  host with uppercase hostname errors 'Name has already been taken' ([#15891](http://projects.theforeman.org/issues/15891), [54e881bf](http://github.com/katello/katello/commit/54e881bf55a5e3915121d902adbc02f2e3eef44c))
- * Facts updated twice by checkin ([#16368](http://projects.theforeman.org/issues/16368), [fb6aaf92](http://github.com/katello/katello/commit/fb6aaf928e88ff236068b739148f1ef2b70cae55))
- * unable to process virt-who data, fails with error: "Validation failed: Name is invalid, Name is invalid" ([#16248](http://projects.theforeman.org/issues/16248), [fdecd6dc](http://github.com/katello/katello/commit/fdecd6dc82585e0d9f8ebd5560aaca9ec38ca07d))
+ *  Removing katello-ca-consumer rpm should revert rhsm.conf  ([#16388](http://projects.theforeman.org/issues/16388), [8d75e8c8](https://github.com/katello/puppet-certs/commit/8d75e8c86a4dfd43bec9295dad736e5cf9fa6059))
+ * Large virt-who json may cause performance issue ([#16228](http://projects.theforeman.org/issues/16228), [a0ec0f2b](https://github.com/katello/katello/commit/a0ec0f2ba5c49a31799cd37574bfce8e02de9124))
+ * calling `enabled_repos` always forces an errata applicability regeneration ([#16209](http://projects.theforeman.org/issues/16209), [184c966c](https://github.com/katello/katello/commit/184c966ca192ae2eacef9e888475c705cf66ac63))
+ * provide option to delete host with subscription-manager unregister ([#15455](http://projects.theforeman.org/issues/15455), [71bf4797](https://github.com/katello/katello/commit/71bf4797cadf58ca003e9383a8cc94a46f1ab0db))
+ * Re-Registering  host with uppercase hostname errors 'Name has already been taken' ([#15891](http://projects.theforeman.org/issues/15891), [54e881bf](https://github.com/katello/katello/commit/54e881bf55a5e3915121d902adbc02f2e3eef44c))
+ * Facts updated twice by checkin ([#16368](http://projects.theforeman.org/issues/16368), [fb6aaf92](https://github.com/katello/katello/commit/fb6aaf928e88ff236068b739148f1ef2b70cae55))
+ * unable to process virt-who data, fails with error: "Validation failed: Name is invalid, Name is invalid" ([#16248](http://projects.theforeman.org/issues/16248), [fdecd6dc](https://github.com/katello/katello/commit/fdecd6dc82585e0d9f8ebd5560aaca9ec38ca07d))
 
 ### Web UI
- * Content host detail page says "RAM (GB): 1024 MB" which is bit confusing ("GB" vs. "MB") ([#16370](http://projects.theforeman.org/issues/16370), [21c9750b](http://github.com/katello/katello/commit/21c9750ba80f117474cce1f1dbac78646ab34e49))
- * Update All button is grayed out unless a package is selected. ([#16341](http://projects.theforeman.org/issues/16341), [2062d106](http://github.com/katello/katello/commit/2062d10692d3524273fac45129d6ebcf506b2ca2))
- * Javascript tests are failing on Jenkins ([#16282](http://projects.theforeman.org/issues/16282), [11d70ff4](http://github.com/katello/katello/commit/11d70ff431db6f48b5e9d27e862751dd45c5d1f2))
- * Make manifest upload link on RH repositories page point to the actual manage manifest page. ([#16078](http://projects.theforeman.org/issues/16078), [069e742a](http://github.com/katello/katello/commit/069e742a1c6e216fc0ad91ad162166033bd824ca))
- * Search functionality stop to work after selecting Activation Key Association tab ([#16033](http://projects.theforeman.org/issues/16033), [8ec1a101](http://github.com/katello/katello/commit/8ec1a101d597e4a5f31be338205d5589b8e12ecd))
- * Free up space in content view version UI ([#15986](http://projects.theforeman.org/issues/15986), [4c02361b](http://github.com/katello/katello/commit/4c02361bb5263ede20f4ccb91236a1cfbc65689b))
- * Red Hat Repositories page not loading ([#15832](http://projects.theforeman.org/issues/15832), [a6008343](http://github.com/katello/katello/commit/a6008343a3e4d054b14377c1df3110824594b418))
- * Cron weekly katello-remove-orphans warnings sending mail ([#15823](http://projects.theforeman.org/issues/15823), [0b7806c6](http://github.com/katello//commit/0b7806c65f7d4aab7f65a16f0de5e6a302f0aadf))
- * Handle 'use latest' correctly when removing puppet modules from CVs ([#15817](http://projects.theforeman.org/issues/15817), [8de4f8a9](http://github.com/katello/katello/commit/8de4f8a9d90f4b7639d9ff20763666a198fa487b))
- * Update katello details page to use bastion nutupane action panel loading screen ([#15545](http://projects.theforeman.org/issues/15545), [1de7a9dd](http://github.com/katello/katello/commit/1de7a9ddec1fcc4c3959077ead8516c5d03ea2cb))
- * Content host details page should be explicit about unregistered clients ([#15456](http://projects.theforeman.org/issues/15456), [e550e639](http://github.com/katello/katello/commit/e550e639babc123a6bc31af446f252b579556138))
- * When search results is zero, message returned is misleading ([#14271](http://projects.theforeman.org/issues/14271), [20bac1b0](http://github.com/katello/bastion/commit/20bac1b067f7b63b6244483da9550dee8ac9352e))
- * guest subscriptions have incorrect link to hypervisor ([#14218](http://projects.theforeman.org/issues/14218), [6eaa32d8](http://github.com/katello/katello/commit/6eaa32d8a1567c14daf3e6259976fc460005ff53))
- * no change in status color when assigning subscription to content host ([#12569](http://projects.theforeman.org/issues/12569), [d31947e0](http://github.com/katello/katello/commit/d31947e0f05e89298e8c718fb84245ef2fc27cd9))
+ * Content host detail page says "RAM (GB): 1024 MB" which is bit confusing ("GB" vs. "MB") ([#16370](http://projects.theforeman.org/issues/16370), [21c9750b](https://github.com/katello/katello/commit/21c9750ba80f117474cce1f1dbac78646ab34e49))
+ * Update All button is grayed out unless a package is selected. ([#16341](http://projects.theforeman.org/issues/16341), [2062d106](https://github.com/katello/katello/commit/2062d10692d3524273fac45129d6ebcf506b2ca2))
+ * Javascript tests are failing on Jenkins ([#16282](http://projects.theforeman.org/issues/16282), [11d70ff4](https://github.com/katello/katello/commit/11d70ff431db6f48b5e9d27e862751dd45c5d1f2))
+ * Make manifest upload link on RH repositories page point to the actual manage manifest page. ([#16078](http://projects.theforeman.org/issues/16078), [069e742a](https://github.com/katello/katello/commit/069e742a1c6e216fc0ad91ad162166033bd824ca))
+ * Search functionality stop to work after selecting Activation Key Association tab ([#16033](http://projects.theforeman.org/issues/16033), [8ec1a101](https://github.com/katello/katello/commit/8ec1a101d597e4a5f31be338205d5589b8e12ecd))
+ * Free up space in content view version UI ([#15986](http://projects.theforeman.org/issues/15986), [4c02361b](https://github.com/katello/katello/commit/4c02361bb5263ede20f4ccb91236a1cfbc65689b))
+ * Red Hat Repositories page not loading ([#15832](http://projects.theforeman.org/issues/15832), [a6008343](https://github.com/katello/katello/commit/a6008343a3e4d054b14377c1df3110824594b418))
+ * Cron weekly katello-remove-orphans warnings sending mail ([#15823](http://projects.theforeman.org/issues/15823), [0b7806c6](https://github.com/katello//commit/0b7806c65f7d4aab7f65a16f0de5e6a302f0aadf))
+ * Handle 'use latest' correctly when removing puppet modules from CVs ([#15817](http://projects.theforeman.org/issues/15817), [8de4f8a9](https://github.com/katello/katello/commit/8de4f8a9d90f4b7639d9ff20763666a198fa487b))
+ * Update katello details page to use bastion nutupane action panel loading screen ([#15545](http://projects.theforeman.org/issues/15545), [1de7a9dd](https://github.com/katello/katello/commit/1de7a9ddec1fcc4c3959077ead8516c5d03ea2cb))
+ * Content host details page should be explicit about unregistered clients ([#15456](http://projects.theforeman.org/issues/15456), [e550e639](https://github.com/katello/katello/commit/e550e639babc123a6bc31af446f252b579556138))
+ * When search results is zero, message returned is misleading ([#14271](http://projects.theforeman.org/issues/14271), [20bac1b0](https://github.com/katello/bastion/commit/20bac1b067f7b63b6244483da9550dee8ac9352e))
+ * guest subscriptions have incorrect link to hypervisor ([#14218](http://projects.theforeman.org/issues/14218), [6eaa32d8](https://github.com/katello/katello/commit/6eaa32d8a1567c14daf3e6259976fc460005ff53))
+ * no change in status color when assigning subscription to content host ([#12569](http://projects.theforeman.org/issues/12569), [d31947e0](https://github.com/katello/katello/commit/d31947e0f05e89298e8c718fb84245ef2fc27cd9))
 
 ### API
- * Error undefined method inject' for nil:NilClass when no subscriptions are provided to bulk add/remove APi ([#16369](http://projects.theforeman.org/issues/16369), [d684dd81](http://github.com/katello/katello/commit/d684dd8112e3028af911bf9e2af4a02ff48fe526))
- * /api/v2/hosts/:id does not expose content_source_id ([#15697](http://projects.theforeman.org/issues/15697), [e6a7ba59](http://github.com/katello/katello/commit/e6a7ba59f0b3f713d3a7fdf1a20f2ac58cf01702))
- * Do not require organization_id when searching in content_views#index and katello/environments#index ([#15672](http://projects.theforeman.org/issues/15672), [b2640c53](http://github.com/katello/katello/commit/b2640c53d625eaaab0c1bf9908fbd31b669a4149))
- * API ping don't return information for foreman_auth service ([#15582](http://projects.theforeman.org/issues/15582), [95d7b906](http://github.com/katello/katello/commit/95d7b9067d38f269a5ec121fb73b5c19d4422baf))
- * API Missing route /organizations/:orgid/repositories to list all repos in an organization ([#15487](http://projects.theforeman.org/issues/15487), [1de1c034](http://github.com/katello/katello/commit/1de1c034a8f24b026f48e2b16d23c87d8f54a9f2))
- * full_results parameter is improperly defined in the API documentation ([#15420](http://projects.theforeman.org/issues/15420), [49469e2e](http://github.com/katello/katello/commit/49469e2e05d1036351fa1caee2d607b851442dfa))
+ * Error undefined method inject' for nil:NilClass when no subscriptions are provided to bulk add/remove APi ([#16369](http://projects.theforeman.org/issues/16369), [d684dd81](https://github.com/katello/katello/commit/d684dd8112e3028af911bf9e2af4a02ff48fe526))
+ * /api/v2/hosts/:id does not expose content_source_id ([#15697](http://projects.theforeman.org/issues/15697), [e6a7ba59](https://github.com/katello/katello/commit/e6a7ba59f0b3f713d3a7fdf1a20f2ac58cf01702))
+ * Do not require organization_id when searching in content_views#index and katello/environments#index ([#15672](http://projects.theforeman.org/issues/15672), [b2640c53](https://github.com/katello/katello/commit/b2640c53d625eaaab0c1bf9908fbd31b669a4149))
+ * API ping don't return information for foreman_auth service ([#15582](http://projects.theforeman.org/issues/15582), [95d7b906](https://github.com/katello/katello/commit/95d7b9067d38f269a5ec121fb73b5c19d4422baf))
+ * API Missing route /organizations/:orgid/repositories to list all repos in an organization ([#15487](http://projects.theforeman.org/issues/15487), [1de1c034](https://github.com/katello/katello/commit/1de1c034a8f24b026f48e2b16d23c87d8f54a9f2))
+ * full_results parameter is improperly defined in the API documentation ([#15420](http://projects.theforeman.org/issues/15420), [49469e2e](https://github.com/katello/katello/commit/49469e2e05d1036351fa1caee2d607b851442dfa))
 
 ### Hosts
- * Breaking change in inherited_attributes method  ([#16359](http://projects.theforeman.org/issues/16359), [f4dae3ca](http://github.com/katello/katello/commit/f4dae3ca40e78c0bd4ce6229f73273a252302bd7))
- * strong params filter incorrect for subscription_facet_attributes - cannot update hypervisor_guest_uuids or installed_products ([#16173](http://projects.theforeman.org/issues/16173), [c282e562](http://github.com/katello/katello/commit/c282e562d62efea82212cfb05239ba9a3d06f57e))
- * Unregistering a Content Host can pause ListenOnCandlepinEvents with Candlepin::Consumer: 410 Gone error ([#16170](http://projects.theforeman.org/issues/16170), [883c8066](http://github.com/katello/katello/commit/883c8066488cf12fef0260a26e74107b0a81418c))
- * visiting new host page has js error of "KT is not defined" ([#15512](http://projects.theforeman.org/issues/15512), [2ab1d40b](http://github.com/katello/katello/commit/2ab1d40bc5ba8fd0e63f6b5061b2d133a4ba0cb0))
- * Helper rake tasks not fully updated for Host Unification and Scoped search ([#15721](http://projects.theforeman.org/issues/15721), [5f624ad3](http://github.com/katello/katello/commit/5f624ad37bfefbd7ebde9b37d7bc8a2187e79a83))
+ * Breaking change in inherited_attributes method  ([#16359](http://projects.theforeman.org/issues/16359), [f4dae3ca](https://github.com/katello/katello/commit/f4dae3ca40e78c0bd4ce6229f73273a252302bd7))
+ * strong params filter incorrect for subscription_facet_attributes - cannot update hypervisor_guest_uuids or installed_products ([#16173](http://projects.theforeman.org/issues/16173), [c282e562](https://github.com/katello/katello/commit/c282e562d62efea82212cfb05239ba9a3d06f57e))
+ * Unregistering a Content Host can pause ListenOnCandlepinEvents with Candlepin::Consumer: 410 Gone error ([#16170](http://projects.theforeman.org/issues/16170), [883c8066](https://github.com/katello/katello/commit/883c8066488cf12fef0260a26e74107b0a81418c))
+ * visiting new host page has js error of "KT is not defined" ([#15512](http://projects.theforeman.org/issues/15512), [2ab1d40b](https://github.com/katello/katello/commit/2ab1d40bc5ba8fd0e63f6b5061b2d133a4ba0cb0))
+ * Helper rake tasks not fully updated for Host Unification and Scoped search ([#15721](http://projects.theforeman.org/issues/15721), [5f624ad3](https://github.com/katello/katello/commit/5f624ad37bfefbd7ebde9b37d7bc8a2187e79a83))
 
 ### Content Views
- * Unpublished content views displayed in the content view list on the composite content view page [Web/UI] ([#16346](http://projects.theforeman.org/issues/16346), [eb439b09](http://github.com/katello/katello/commit/eb439b0960d215acab5345e002a524d21a1247ed), [a5ccff01](http://github.com/katello/katello/commit/a5ccff015609ab28169b5bc7d9bf33e75ea4f276))
- * Do not wrap description field in the Content View version listing ([#16331](http://projects.theforeman.org/issues/16331), [1e332614](http://github.com/katello/katello/commit/1e3326148f5e1abafc8101b4bb65f9ede807f730))
- * The "Remove View" button for deleting a content view should say "Delete View" to match the confirmation submit button ([#16271](http://projects.theforeman.org/issues/16271), [b5e80512](http://github.com/katello/katello/commit/b5e805123365f9c8da66555076367ac09ac1fcfa))
- * User shouldn't be allowed to add same package in content-view filter repeatedly ([#16186](http://projects.theforeman.org/issues/16186), [a43dc492](http://github.com/katello/katello/commit/a43dc492bd1a2cf4c112a6ebd2ca6c84de078e45))
- * Probably should condense the list of puppet modules (and maybe other associations) for content view info ([#15987](http://projects.theforeman.org/issues/15987), [dd4aaadf](http://github.com/katello/hammer-cli-katello/commit/dd4aaadf5f7408b93f0c4416543b044129611c28))
- * Cannot delete a RedHat Product or Products with Repositories published in a Content View error does not help user ([#15811](http://projects.theforeman.org/issues/15811), [63d1d08f](http://github.com/katello/katello/commit/63d1d08f6168d26f14f61a8814506769727a50ef))
- * hammer content-view version list ignores --organization{-id} options ([#15796](http://projects.theforeman.org/issues/15796), [8e39aac8](http://github.com/katello/katello/commit/8e39aac83584c0b6c795d91f9e168da7bac1c4ef), [c2956945](http://github.com/katello/hammer-cli-katello/commit/c2956945752778f54251d50c51670af319a65d07))
- * Not able to select/publish " Use Latest Version" of puppet module in content view ([#15579](http://projects.theforeman.org/issues/15579), [57eaec9b](http://github.com/katello/katello/commit/57eaec9b6b8e821c05d519824491598ff9a361b6))
+ * Unpublished content views displayed in the content view list on the composite content view page [Web/UI] ([#16346](http://projects.theforeman.org/issues/16346), [eb439b09](https://github.com/katello/katello/commit/eb439b0960d215acab5345e002a524d21a1247ed), [a5ccff01](https://github.com/katello/katello/commit/a5ccff015609ab28169b5bc7d9bf33e75ea4f276))
+ * Do not wrap description field in the Content View version listing ([#16331](http://projects.theforeman.org/issues/16331), [1e332614](https://github.com/katello/katello/commit/1e3326148f5e1abafc8101b4bb65f9ede807f730))
+ * The "Remove View" button for deleting a content view should say "Delete View" to match the confirmation submit button ([#16271](http://projects.theforeman.org/issues/16271), [b5e80512](https://github.com/katello/katello/commit/b5e805123365f9c8da66555076367ac09ac1fcfa))
+ * User shouldn't be allowed to add same package in content-view filter repeatedly ([#16186](http://projects.theforeman.org/issues/16186), [a43dc492](https://github.com/katello/katello/commit/a43dc492bd1a2cf4c112a6ebd2ca6c84de078e45))
+ * Probably should condense the list of puppet modules (and maybe other associations) for content view info ([#15987](http://projects.theforeman.org/issues/15987), [dd4aaadf](https://github.com/katello/hammer-cli-katello/commit/dd4aaadf5f7408b93f0c4416543b044129611c28))
+ * Cannot delete a RedHat Product or Products with Repositories published in a Content View error does not help user ([#15811](http://projects.theforeman.org/issues/15811), [63d1d08f](https://github.com/katello/katello/commit/63d1d08f6168d26f14f61a8814506769727a50ef))
+ * hammer content-view version list ignores --organization{-id} options ([#15796](http://projects.theforeman.org/issues/15796), [8e39aac8](https://github.com/katello/katello/commit/8e39aac83584c0b6c795d91f9e168da7bac1c4ef), [c2956945](https://github.com/katello/hammer-cli-katello/commit/c2956945752778f54251d50c51670af319a65d07))
+ * Not able to select/publish " Use Latest Version" of puppet module in content view ([#15579](http://projects.theforeman.org/issues/15579), [57eaec9b](https://github.com/katello/katello/commit/57eaec9b6b8e821c05d519824491598ff9a361b6))
 
 ### Atomic
  * Containers hosted on Atomic host not able to access Katello yum repos ([#16343](http://projects.theforeman.org/issues/16343))
 
 ### Foreman Integration
- * need script to unify hosts with shortname and fqdn ([#16270](http://projects.theforeman.org/issues/16270), [3fb17a34](http://github.com/katello/katello/commit/3fb17a34452cc5e3f8d012d8b305c99804e5bb49))
- * Remove System and Hypervsior models/controllers/tests/actions ([#12556](http://projects.theforeman.org/issues/12556), [f5dcf970](http://github.com/katello/katello/commit/f5dcf97068fd119ce7afd226d8d95c23c0c5a1b4), [df4bc4d7](http://github.com/katello/katello/commit/df4bc4d7d6a59cc85d6c2acdcaa27965bab3b5ac), [440b51d5](http://github.com/katello/katello/commit/440b51d54a020885d2680ce9edeef01b477a28b4), [37fa1d79](http://github.com/katello/hammer-cli-katello/commit/37fa1d7951bb3dceb3adf5a626d53416e379bcaa))
+ * need script to unify hosts with shortname and fqdn ([#16270](http://projects.theforeman.org/issues/16270), [3fb17a34](https://github.com/katello/katello/commit/3fb17a34452cc5e3f8d012d8b305c99804e5bb49))
+ * Remove System and Hypervsior models/controllers/tests/actions ([#12556](http://projects.theforeman.org/issues/12556), [f5dcf970](https://github.com/katello/katello/commit/f5dcf97068fd119ce7afd226d8d95c23c0c5a1b4), [df4bc4d7](https://github.com/katello/katello/commit/df4bc4d7d6a59cc85d6c2acdcaa27965bab3b5ac), [440b51d5](https://github.com/katello/katello/commit/440b51d54a020885d2680ce9edeef01b477a28b4), [37fa1d79](https://github.com/katello/hammer-cli-katello/commit/37fa1d7951bb3dceb3adf5a626d53416e379bcaa))
 
 ### Tests
- * Tests are failing with 'LoadError: cannot load such file -- polyglot' ([#16213](http://projects.theforeman.org/issues/16213), [1ce49302](http://github.com/katello/katello/commit/1ce49302b1698a79da76d03de0f1c96dd02caef4))
- * Test failures under Rails 4.2.7.1 ([#16088](http://projects.theforeman.org/issues/16088), [db95d867](http://github.com/katello/katello/commit/db95d8676965d81cb5df35951d8f9edf117785e7))
- * Reduce warnings when running katello tests ([#15588](http://projects.theforeman.org/issues/15588), [4e5d97dc](http://github.com/katello/katello/commit/4e5d97dc73dc3e291d251b91fee215ff87e0d1dd))
- * katello_fixtures directory not cleaned up in /tmp ([#15042](http://projects.theforeman.org/issues/15042), [f3713906](http://github.com/katello/katello/commit/f37139069e84bd70d99b9c99477355d223b45f4c))
+ * Tests are failing with 'LoadError: cannot load such file -- polyglot' ([#16213](http://projects.theforeman.org/issues/16213), [1ce49302](https://github.com/katello/katello/commit/1ce49302b1698a79da76d03de0f1c96dd02caef4))
+ * Test failures under Rails 4.2.7.1 ([#16088](http://projects.theforeman.org/issues/16088), [db95d867](https://github.com/katello/katello/commit/db95d8676965d81cb5df35951d8f9edf117785e7))
+ * Reduce warnings when running katello tests ([#15588](http://projects.theforeman.org/issues/15588), [4e5d97dc](https://github.com/katello/katello/commit/4e5d97dc73dc3e291d251b91fee215ff87e0d1dd))
+ * katello_fixtures directory not cleaned up in /tmp ([#15042](http://projects.theforeman.org/issues/15042), [f3713906](https://github.com/katello/katello/commit/f37139069e84bd70d99b9c99477355d223b45f4c))
 
 ### Activation Key
- * attaching subscription to an activation key causes UI error ([#16189](http://projects.theforeman.org/issues/16189), [db12c23b](http://github.com/katello/katello/commit/db12c23bc7b03037aee88bb533487d1d33690979))
+ * attaching subscription to an activation key causes UI error ([#16189](http://projects.theforeman.org/issues/16189), [db12c23b](https://github.com/katello/katello/commit/db12c23bc7b03037aee88bb533487d1d33690979))
 
 ### Capsule
- * Update Katello to synchronize puppet content to capsule based on capsules puppet path. ([#16456](http://projects.theforeman.org/issues/16456), [c7a3b4f1](http://github.com/katello/katello/commit/c7a3b4f140651896951d1527f39a543037298abe))
- * Capsule auto-synchronization fails with an error 'PLP0034' (Katello::Errors::PulpError ) after publishing content view on satellite 6.2.0 ([#16177](http://projects.theforeman.org/issues/16177), [fd79377c](http://github.com/katello/katello/commit/fd79377cd1577177ce4f89629569ec9578ef1574))
- * Pulp storage error ([#16064](http://projects.theforeman.org/issues/16064), [2bb06e19](http://github.com/katello//commit/2bb06e191813ae14ed0b9400b15e6b0a66e2bb06))
+ * Update Katello to synchronize puppet content to capsule based on capsules puppet path. ([#16456](http://projects.theforeman.org/issues/16456), [c7a3b4f1](https://github.com/katello/katello/commit/c7a3b4f140651896951d1527f39a543037298abe))
+ * Capsule auto-synchronization fails with an error 'PLP0034' (Katello::Errors::PulpError ) after publishing content view on satellite 6.2.0 ([#16177](http://projects.theforeman.org/issues/16177), [fd79377c](https://github.com/katello/katello/commit/fd79377cd1577177ce4f89629569ec9578ef1574))
+ * Pulp storage error ([#16064](http://projects.theforeman.org/issues/16064), [2bb06e19](https://github.com/katello//commit/2bb06e191813ae14ed0b9400b15e6b0a66e2bb06))
 
 ### Subscriptions
- * Add API Bulk Actions for add/remove/auto-attach subscriptions ([#16038](http://projects.theforeman.org/issues/16038), [e51d11fe](http://github.com/katello/katello/commit/e51d11fe0491d76ae8a149242bece9d9f6936f7f))
- * hammer activation-key add-subscription/host subscription attach must accept pool ids ([#16036](http://projects.theforeman.org/issues/16036), [a66ae300](http://github.com/katello/katello/commit/a66ae300e96c40146569f82a7a06ed32df4c5127))
- * Package upload action logs whole input as Parameters ([#15940](http://projects.theforeman.org/issues/15940), [59e9f514](http://github.com/katello/katello/commit/59e9f514afaf79b179e3ee08de122aa1db037494))
+ * Add API Bulk Actions for add/remove/auto-attach subscriptions ([#16038](http://projects.theforeman.org/issues/16038), [e51d11fe](https://github.com/katello/katello/commit/e51d11fe0491d76ae8a149242bece9d9f6936f7f))
+ * hammer activation-key add-subscription/host subscription attach must accept pool ids ([#16036](http://projects.theforeman.org/issues/16036), [a66ae300](https://github.com/katello/katello/commit/a66ae300e96c40146569f82a7a06ed32df4c5127))
+ * Package upload action logs whole input as Parameters ([#15940](http://projects.theforeman.org/issues/15940), [59e9f514](https://github.com/katello/katello/commit/59e9f514afaf79b179e3ee08de122aa1db037494))
 
 ### Docker
- * Enable katello docker registries to use other ports ([#16037](http://projects.theforeman.org/issues/16037), [7be5d7f2](http://github.com/katello/katello/commit/7be5d7f2540b9e60ca0e92b604a275e632f11bc9))
- * docker tag view page shows empty alert ([#15759](http://projects.theforeman.org/issues/15759), [a78a3ee8](http://github.com/katello/katello/commit/a78a3ee8fee2ed651f6635346c4d777063606c5c))
+ * Enable katello docker registries to use other ports ([#16037](http://projects.theforeman.org/issues/16037), [7be5d7f2](https://github.com/katello/katello/commit/7be5d7f2540b9e60ca0e92b604a275e632f11bc9))
+ * docker tag view page shows empty alert ([#15759](http://projects.theforeman.org/issues/15759), [a78a3ee8](https://github.com/katello/katello/commit/a78a3ee8fee2ed651f6635346c4d777063606c5c))
 
 ### Tooling
- * Carry patched version of urrlib3 for lazy sync ([#15982](http://projects.theforeman.org/issues/15982), [b60f4e83](http://github.com/katello//commit/b60f4e8362a66c7864d01c2c10c0c4ff77f30dbe))
+ * Carry patched version of urrlib3 for lazy sync ([#15982](http://projects.theforeman.org/issues/15982), [b60f4e83](https://github.com/katello//commit/b60f4e8362a66c7864d01c2c10c0c4ff77f30dbe))
 
 ### Upgrades
- * upgrade_check fails because of running tasks ([#15945](http://projects.theforeman.org/issues/15945), [a0aeaa25](http://github.com/katello/katello/commit/a0aeaa2517396ef19f92c17d78eb0d3f77a81732))
- * Apache has 7x number of open files on capsule with satellite 6.2 compare to satellite 6.1 ([#15841](http://projects.theforeman.org/issues/15841), [b4ed05ec](http://github.com/katello/puppet-katello/commit/b4ed05ec849864e1b009733f20add03647de7b07))
- * upgrade_check does not correctly determine active tasks ([#15694](http://projects.theforeman.org/issues/15694), [d12e6e67](http://github.com/katello/katello/commit/d12e6e67f8706787f95546e90b4d38865639d669))
- * update_subscription_facet_backend_data step fails on upgrade ([#16117](http://projects.theforeman.org/issues/16117), [dfa26d40](http://github.com/katello/katello/commit/dfa26d40266c2ce59e607077b16c67d9ebda239f))
- * hypervisors are deleted upon upgrade to 3.0 ([#15726](http://projects.theforeman.org/issues/15726), [93a2d186](http://github.com/katello/katello/commit/93a2d186408240489d0402cd331f52f9cd7e77b5))
- * Error rendering info message in migration due to missed escaping ([#15683](http://projects.theforeman.org/issues/15683), [70e6cf78](http://github.com/katello/katello-installer/commit/70e6cf784b4e31564ca18dad795ea806efaa18a1))
- * Upgrade from Katello 3.0 to Katello 3.1 fails on apipie:cache task ([#16441](http://projects.theforeman.org/issues/16441), [a812f1f1](http://github.com/katello/katello/commit/a812f1f1a52d0da71ae73e627bf92f6b94748546))
+ * upgrade_check fails because of running tasks ([#15945](http://projects.theforeman.org/issues/15945), [a0aeaa25](https://github.com/katello/katello/commit/a0aeaa2517396ef19f92c17d78eb0d3f77a81732))
+ * Apache has 7x number of open files on capsule with satellite 6.2 compare to satellite 6.1 ([#15841](http://projects.theforeman.org/issues/15841), [b4ed05ec](https://github.com/katello/puppet-katello/commit/b4ed05ec849864e1b009733f20add03647de7b07))
+ * upgrade_check does not correctly determine active tasks ([#15694](http://projects.theforeman.org/issues/15694), [d12e6e67](https://github.com/katello/katello/commit/d12e6e67f8706787f95546e90b4d38865639d669))
+ * update_subscription_facet_backend_data step fails on upgrade ([#16117](http://projects.theforeman.org/issues/16117), [dfa26d40](https://github.com/katello/katello/commit/dfa26d40266c2ce59e607077b16c67d9ebda239f))
+ * hypervisors are deleted upon upgrade to 3.0 ([#15726](http://projects.theforeman.org/issues/15726), [93a2d186](https://github.com/katello/katello/commit/93a2d186408240489d0402cd331f52f9cd7e77b5))
+ * Error rendering info message in migration due to missed escaping ([#15683](http://projects.theforeman.org/issues/15683), [70e6cf78](https://github.com/katello/katello-installer/commit/70e6cf784b4e31564ca18dad795ea806efaa18a1))
+ * Upgrade from Katello 3.0 to Katello 3.1 fails on apipie:cache task ([#16441](http://projects.theforeman.org/issues/16441), [a812f1f1](https://github.com/katello/katello/commit/a812f1f1a52d0da71ae73e627bf92f6b94748546))
 
 ### Dashboard
- * Content dashboard has wrong links to [Invalid|Insufficient|Current] Subscriptions ([#15941](http://projects.theforeman.org/issues/15941), [73cc4243](http://github.com/katello/katello/commit/73cc424308075f67dcacf39951a0cd39a6685733))
+ * Content dashboard has wrong links to [Invalid|Insufficient|Current] Subscriptions ([#15941](http://projects.theforeman.org/issues/15941), [73cc4243](https://github.com/katello/katello/commit/73cc424308075f67dcacf39951a0cd39a6685733))
 
 ### Candlepin
- * Katello not receiving messages from candlepin ([#15727](http://projects.theforeman.org/issues/15727), [72ad0375](http://github.com/katello/puppet-katello/commit/72ad037539160bb420ed446ff769af6ddc9ab041))
- * virt-who checkin should use default org view and should not overwrite existing registration ([#15725](http://projects.theforeman.org/issues/15725), [6a9661b5](http://github.com/katello/katello/commit/6a9661b5822986ff255631117626145845b81b22))
- * Deleting a product with multiple repos results in candlepin error ([#15482](http://projects.theforeman.org/issues/15482), [7e64292a](http://github.com/katello/katello/commit/7e64292a0d632a51f887d025cdbecb15f0894158))
- * undefined method [] for nil:NilClass related to activation_key pool association ([#15749](http://projects.theforeman.org/issues/15749), [946f3c77](http://github.com/katello/katello/commit/946f3c771d16ca0491b765fc34d222728364b90f))
- * VDC guest subscriptions showing as null in activation key  ([#16398](http://projects.theforeman.org/issues/16398), [fe268976](http://github.com/katello/katello/commit/fe2689762e888eed40fb3f897cd691185ab15488))
+ * Katello not receiving messages from candlepin ([#15727](http://projects.theforeman.org/issues/15727), [72ad0375](https://github.com/katello/puppet-katello/commit/72ad037539160bb420ed446ff769af6ddc9ab041))
+ * virt-who checkin should use default org view and should not overwrite existing registration ([#15725](http://projects.theforeman.org/issues/15725), [6a9661b5](https://github.com/katello/katello/commit/6a9661b5822986ff255631117626145845b81b22))
+ * Deleting a product with multiple repos results in candlepin error ([#15482](http://projects.theforeman.org/issues/15482), [7e64292a](https://github.com/katello/katello/commit/7e64292a0d632a51f887d025cdbecb15f0894158))
+ * undefined method [] for nil:NilClass related to activation_key pool association ([#15749](http://projects.theforeman.org/issues/15749), [946f3c77](https://github.com/katello/katello/commit/946f3c771d16ca0491b765fc34d222728364b90f))
+ * VDC guest subscriptions showing as null in activation key  ([#16398](http://projects.theforeman.org/issues/16398), [fe268976](https://github.com/katello/katello/commit/fe2689762e888eed40fb3f897cd691185ab15488))
 
 ### Roles and Permissions
- * 03-roles.rb seeds katello view_* filters for Viewer role multiple times ([#15427](http://projects.theforeman.org/issues/15427), [7c71d45d](http://github.com/katello/katello/commit/7c71d45dadedbe262d0d2866db69a3f83b52085a))
+ * 03-roles.rb seeds katello view_* filters for Viewer role multiple times ([#15427](http://projects.theforeman.org/issues/15427), [7c71d45d](https://github.com/katello/katello/commit/7c71d45dadedbe262d0d2866db69a3f83b52085a))
 
 ### Pulp
  * Out of Memory error while syncing repo ([#15101](http://projects.theforeman.org/issues/15101))
- * incremental export should be in same format as full export ([#14915](http://projects.theforeman.org/issues/14915), [b261110a](http://github.com/katello/katello/commit/b261110a5fc2eb6aa37d9981b6bc644c020b3542))
- * Users should be warned during upgrade of long running Pulp migrations ([#15660](http://projects.theforeman.org/issues/15660), [ba43845f](http://github.com/katello/katello-installer/commit/ba43845ff5f45706200b7c6b933e0b8cde14b008))
- * Errata Install to Content Host takes too long and doesn't scale well ([#15366](http://projects.theforeman.org/issues/15366), [ab45b88e](http://github.com/katello//commit/ab45b88ed48c522be6b8a97462fc02cd18e61c50))
+ * incremental export should be in same format as full export ([#14915](http://projects.theforeman.org/issues/14915), [b261110a](https://github.com/katello/katello/commit/b261110a5fc2eb6aa37d9981b6bc644c020b3542))
+ * Users should be warned during upgrade of long running Pulp migrations ([#15660](http://projects.theforeman.org/issues/15660), [ba43845f](https://github.com/katello/katello-installer/commit/ba43845ff5f45706200b7c6b933e0b8cde14b008))
+ * Errata Install to Content Host takes too long and doesn't scale well ([#15366](http://projects.theforeman.org/issues/15366), [ab45b88e](https://github.com/katello//commit/ab45b88ed48c522be6b8a97462fc02cd18e61c50))
 
 ### Orchestration
- * ListenOnCandlepinEvents pauses during manifest import ([#15648](http://projects.theforeman.org/issues/15648), [66e98cb7](http://github.com/katello/katello/commit/66e98cb7560420741bf795d2fd4682655af09594))
+ * ListenOnCandlepinEvents pauses during manifest import ([#15648](http://projects.theforeman.org/issues/15648), [66e98cb7](https://github.com/katello/katello/commit/66e98cb7560420741bf795d2fd4682655af09594))
  * katello 3.0 RC failing content promotion but can be resumed manually ([#15428](http://projects.theforeman.org/issues/15428))
 
 ### Other
- * Cannot create new hostgroup via API/CLI ([#16484](http://projects.theforeman.org/issues/16484), [5608b835](http://github.com/katello/katello/commit/5608b835b01dbe39cbea48ffad11396c83fd684d))
- * katello-installer - exclude build dirs from from rubocop checking ([#16469](http://projects.theforeman.org/issues/16469), [1e99296f](http://github.com/katello/katello-installer/commit/1e99296f9129ce45cbf7835a06613a0cb6e581f1))
- * Large files can't be uploaded through content upload APIs ([#16429](http://projects.theforeman.org/issues/16429), [68c5d7d1](http://github.com/katello/katello/commit/68c5d7d13d2337ed03658bd96742af3e1241a166))
- * katello-service tool is missing smart_proxy_dynflow_core ([#16373](http://projects.theforeman.org/issues/16373), [d323d1c3](http://github.com/katello//commit/d323d1c31c1f63276996a515f6dc8a6132a2c594))
- * Cannot create new organization via the web ui ([#16304](http://projects.theforeman.org/issues/16304), [f867be09](http://github.com/katello/katello/commit/f867be09164e9d2b27956fc51f1f1c4dfa847f76))
- * Add description of remove-content to hammer repository help ([#16247](http://projects.theforeman.org/issues/16247), [28ba5d4f](http://github.com/katello/hammer-cli-katello/commit/28ba5d4f38f424745ec8134f0189ebb8c2d76b15))
- * Incorrect Next Sync date calculation in weekly Sync Plan ([#16035](http://projects.theforeman.org/issues/16035), [08e85148](http://github.com/katello/katello/commit/08e851485c73e7a51fcc87de2f422f7c0cbb4aa0))
- * Adjust coverage settings in Katello ([#15998](http://projects.theforeman.org/issues/15998), [6fce27a8](http://github.com/katello/katello/commit/6fce27a88e01c5b627655d579a0b8668f9c6f89c))
- * Autocomplete is not working. ([#15917](http://projects.theforeman.org/issues/15917), [6c5b6f1e](http://github.com/katello/katello/commit/6c5b6f1e34b3e2d4038fa4fad0ffcdd554973a36))
- * Content view version in progress tasks should take me to the task itself ([#15892](http://projects.theforeman.org/issues/15892), [935afb3f](http://github.com/katello/katello/commit/935afb3f05041362cd63854fb911b9eeb0736f26))
- * capsule pulp disk usage is not available on rhel6 ([#15673](http://projects.theforeman.org/issues/15673), [71b1a3b4](http://github.com/katello//commit/71b1a3b463358592633e9ba1b628e45f9aeb37db))
- * New hammer host-collection hosts command does not expose any options ([#15429](http://projects.theforeman.org/issues/15429), [8a8057e2](http://github.com/katello/hammer-cli-katello/commit/8a8057e2ac41a5bb18a528f003aac440792f2306))
- * Add a Readme for test/data directory on how to generate JSON api ([#15305](http://projects.theforeman.org/issues/15305), [1e876e57](http://github.com/katello/hammer-cli-katello/commit/1e876e5755f75ef0b5921825187894a01baa436e))
- * migrate_content_hosts fails with unique constraint violation  ([#16137](http://projects.theforeman.org/issues/16137), [7c6a0017](http://github.com/katello/katello/commit/7c6a00174bb9621acc3fa01314b1375d73991203))
- * No proper subscriptions created for custom products ([#15981](http://projects.theforeman.org/issues/15981), [54c453cd](http://github.com/katello/katello/commit/54c453cdff9f80b200f8939dae3f38809d073e46))
- * Migrate shouldn't ping backends when there are no systems present ([#15826](http://projects.theforeman.org/issues/15826), [f70b73a8](http://github.com/katello/katello/commit/f70b73a8bd0962fa256bf129b5f14990919fc9b5))
- * sync and publish emails are never sent ([#16303](http://projects.theforeman.org/issues/16303), [319c4650](http://github.com/katello/katello/commit/319c4650c8e4a93ae1cd2f06f1481201b8ae5fe4))
+ * Cannot create new hostgroup via API/CLI ([#16484](http://projects.theforeman.org/issues/16484), [5608b835](https://github.com/katello/katello/commit/5608b835b01dbe39cbea48ffad11396c83fd684d))
+ * katello-installer - exclude build dirs from from rubocop checking ([#16469](http://projects.theforeman.org/issues/16469), [1e99296f](https://github.com/katello/katello-installer/commit/1e99296f9129ce45cbf7835a06613a0cb6e581f1))
+ * Large files can't be uploaded through content upload APIs ([#16429](http://projects.theforeman.org/issues/16429), [68c5d7d1](https://github.com/katello/katello/commit/68c5d7d13d2337ed03658bd96742af3e1241a166))
+ * katello-service tool is missing smart_proxy_dynflow_core ([#16373](http://projects.theforeman.org/issues/16373), [d323d1c3](https://github.com/katello//commit/d323d1c31c1f63276996a515f6dc8a6132a2c594))
+ * Cannot create new organization via the web ui ([#16304](http://projects.theforeman.org/issues/16304), [f867be09](https://github.com/katello/katello/commit/f867be09164e9d2b27956fc51f1f1c4dfa847f76))
+ * Add description of remove-content to hammer repository help ([#16247](http://projects.theforeman.org/issues/16247), [28ba5d4f](https://github.com/katello/hammer-cli-katello/commit/28ba5d4f38f424745ec8134f0189ebb8c2d76b15))
+ * Incorrect Next Sync date calculation in weekly Sync Plan ([#16035](http://projects.theforeman.org/issues/16035), [08e85148](https://github.com/katello/katello/commit/08e851485c73e7a51fcc87de2f422f7c0cbb4aa0))
+ * Adjust coverage settings in Katello ([#15998](http://projects.theforeman.org/issues/15998), [6fce27a8](https://github.com/katello/katello/commit/6fce27a88e01c5b627655d579a0b8668f9c6f89c))
+ * Autocomplete is not working. ([#15917](http://projects.theforeman.org/issues/15917), [6c5b6f1e](https://github.com/katello/katello/commit/6c5b6f1e34b3e2d4038fa4fad0ffcdd554973a36))
+ * Content view version in progress tasks should take me to the task itself ([#15892](http://projects.theforeman.org/issues/15892), [935afb3f](https://github.com/katello/katello/commit/935afb3f05041362cd63854fb911b9eeb0736f26))
+ * capsule pulp disk usage is not available on rhel6 ([#15673](http://projects.theforeman.org/issues/15673), [71b1a3b4](https://github.com/katello//commit/71b1a3b463358592633e9ba1b628e45f9aeb37db))
+ * New hammer host-collection hosts command does not expose any options ([#15429](http://projects.theforeman.org/issues/15429), [8a8057e2](https://github.com/katello/hammer-cli-katello/commit/8a8057e2ac41a5bb18a528f003aac440792f2306))
+ * Add a Readme for test/data directory on how to generate JSON api ([#15305](http://projects.theforeman.org/issues/15305), [1e876e57](https://github.com/katello/hammer-cli-katello/commit/1e876e5755f75ef0b5921825187894a01baa436e))
+ * migrate_content_hosts fails with unique constraint violation  ([#16137](http://projects.theforeman.org/issues/16137), [7c6a0017](https://github.com/katello/katello/commit/7c6a00174bb9621acc3fa01314b1375d73991203))
+ * No proper subscriptions created for custom products ([#15981](http://projects.theforeman.org/issues/15981), [54c453cd](https://github.com/katello/katello/commit/54c453cdff9f80b200f8939dae3f38809d073e46))
+ * Migrate shouldn't ping backends when there are no systems present ([#15826](http://projects.theforeman.org/issues/15826), [f70b73a8](https://github.com/katello/katello/commit/f70b73a8bd0962fa256bf129b5f14990919fc9b5))
+ * sync and publish emails are never sent ([#16303](http://projects.theforeman.org/issues/16303), [319c4650](https://github.com/katello/katello/commit/319c4650c8e4a93ae1cd2f06f1481201b8ae5fe4))
 
 ## Deprecation Warnings
 
- * host status .relevant? deprecation warning ([#15398](http://projects.theforeman.org/issues/15398), [6cc8e2f6](http://github.com/katello/katello/commit/6cc8e2f64fbb96e82c71ad4cc56f6ec2608eb440))
+ * host status .relevant? deprecation warning ([#15398](http://projects.theforeman.org/issues/15398), [6cc8e2f6](https://github.com/katello/katello/commit/6cc8e2f64fbb96e82c71ad4cc56f6ec2608eb440))
 
 ## Contributors
 


### PR DESCRIPTION
also drop the comment one can use http to trick firewalls, GitHub does not offer plain http anymore (just redirects)