### PR TITLE
Add installing yum-utils to katello installation

### DIFF
--- a/plugins/katello/nightly/installation/index.md
+++ b/plugins/katello/nightly/installation/index.md
@@ -88,6 +88,7 @@ Installation may be done manually or via our recommended approach of using [fork
 <div id="rhel7" markdown="1">
 {% highlight bash %}
 yum -y  --disablerepo="*" --enablerepo=rhel-7-server-rpms install yum-utils wget
+yum install -y yum-utils
 yum-config-manager --disable "*"
 yum-config-manager --enable rhel-7-server-rpms
 yum-config-manager --enable rhel-7-server-optional-rpms


### PR DESCRIPTION
We specify using yum-config-manager for RHEL installations,
but that won't be installed by default, so we should ensure
the yum-utils package is on the user's system before
asking them to use yum-config-manager.