### PR TITLE
Fix URL path to foreman-release.rpm in 3.3 Smart Proxy upgrade process

### DIFF
--- a/plugins/katello/3.3/upgrade/smart_proxy.md
+++ b/plugins/katello/3.3/upgrade/smart_proxy.md
@@ -25,7 +25,7 @@ Update the Foreman and Katello release packages:
 
 {% highlight bash %}
   yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el7/x86_64/katello-repos-latest.rpm
-  yum update -y http://yum.theforeman.org/{{ page.foreman_version }}/el7/x86_64/foreman-release.rpm
+  yum update -y http://yum.theforeman.org/releases/{{ page.foreman_version }}/el7/x86_64/foreman-release.rpm
 {% endhighlight %}
 
 ## Step 3 - Update Packages


### PR DESCRIPTION
http://projects.theforeman.org/issues/19671