### PR TITLE
Fix missing releases subdir for foreman-release package download

### DIFF
--- a/plugins/katello/3.4/upgrade/index.md
+++ b/plugins/katello/3.4/upgrade/index.md
@@ -39,7 +39,7 @@ Update the Foreman and Katello release packages:
 
 {% highlight bash %}
   yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el7/x86_64/katello-repos-latest.rpm
-  yum update -y http://yum.theforeman.org/{{ page.foreman_version }}/el7/x86_64/foreman-release.rpm
+  yum update -y http://yum.theforeman.org/releases/{{ page.foreman_version }}/el7/x86_64/foreman-release.rpm
   yum update -y foreman-release-scl
 {% endhighlight %}
 


### PR DESCRIPTION
There is a typo in the katello 3.4 upgrade section "yum update -y http://yum.theforeman.org/1.15/el7/x86_64/foreman-release.rpm" should be "yum update -y http://yum.theforeman.org/releases/1.15/el7/x86_64/foreman-release.rpm" (missing releases subdir)