### PR TITLE
Enable binary callback on Ansible < 2.2 too

### DIFF
--- a/plugins/foreman_ansible/1.x/index.md
+++ b/plugins/foreman_ansible/1.x/index.md
@@ -23,6 +23,7 @@ In order to make Ansible send us data from the hosts, we set up a callback on yo
 * If you use Ansible 2.2+ , our callback is installed with Ansible itself, simply change `/etc/ansible/ansible.cfg` to contain
 
       [defaults]
+      bin_ansible_callbacks = True
       callback_whitelist = foreman
 
 and the callback will be enabled after that.


### PR DESCRIPTION
As evidenced in
https://github.com/theforeman/foreman_ansible/issues/86#issuecomment-309139251
the docs are confusing and may lead to think bin_ansible_callbacks =
True is not needed on Ansible <= 2.2