### PR TITLE
Fix spelling of "Administer"

### DIFF
--- a/_includes/manuals/1.15/4.2.6_matchers.md
+++ b/_includes/manuals/1.15/4.2.6_matchers.md
@@ -21,7 +21,7 @@ Example attributes that may be listed are:
 * `location` or `organization` - full name of the location/organization, including parents ("Company/Subsidiary")
 * `is_virtual` - a fact [supplied by Facter](https://docs.puppetlabs.com/facter/latest/core_facts.html#isvirtual)
 
-The default order is set under *Adminster > Settings > Puppet > Default_variables_Lookup_Path* and is "fqdn", "hostgroup", "os", "domain".
+The default order is set under *Administer > Settings > Puppet > Default_variables_Lookup_Path* and is "fqdn", "hostgroup", "os", "domain".
 
 Note that there's a name conflict between the "operatingsystem" fact and Foreman's attribute "operatingsystem" (same as "os" above), and Foreman's attribute will be the one that is used, so will include the version number.
 

--- a/_includes/manuals/1.15/4.3.6_smartproxy_puppet.md
+++ b/_includes/manuals/1.15/4.3.6_smartproxy_puppet.md
@@ -150,7 +150,7 @@ Available providers are:
 * `puppet_proxy_salt` - uses `salt puppet.run`
 * `puppet_proxy_customrun` - calls a custom command with args
 
-Once a provider is configured, in Foreman itself, enable "puppetrun" under *Adminster > Settings > Puppet* to activate the "Run Puppet" button on individual host pages.
+Once a provider is configured, in Foreman itself, enable "puppetrun" under *Administer > Settings > Puppet* to activate the "Run Puppet" button on individual host pages.
 
 ##### puppetrun (deprecated)
 


### PR DESCRIPTION
Fix spelling of Adminster-> Administer (only in the 1.15 tree).