### PR TITLE
Add "true" to --certs-regenerate

### DIFF
--- a/plugins/katello/nightly/upgrade/smart_proxy.md
+++ b/plugins/katello/nightly/upgrade/smart_proxy.md
@@ -69,7 +69,7 @@ The installer with the --upgrade flag will run the right database migrations for
 {% highlight bash %}
 foreman-installer --scenario foreman-proxy-content --upgrade\
                   --foreman-proxy-content-certs-tar ~/myproxy.example.com-certs.tar\
-                  --certs-update-all --certs-regenerate --certs-deploy
+                  --certs-update-all --certs-regenerate true --certs-deploy
 {% endhighlight %}
 
 **Congratulations! You have now successfully upgraded your Smart Proxy to {% if page.version %}{{ page.version }} For a rundown of what was added, please see [release notes](/plugins/katello/{{ page.version }}/release_notes/release_notes.html).{% else %}the latest nightly{% endif %}!**


### PR DESCRIPTION
Without this boolean specified, the smart-proxy upgrade fails with "Parameter certs-regenerate is missing a value on the command line"