### PR TITLE
update config for jekyll 3.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,6 @@ group :therubyracer do
     gem 'therubyracer', :require => 'v8'
 end
 
-gem 'github-pages', '>= 104'
+gem 'github-pages', '>= 147'
 gem 'rake'
 gem 'icalendar'

--- a/_config.yml
+++ b/_config.yml
@@ -36,7 +36,7 @@ navigation:
 - text: Blog
   url: blog/index.html
 
-gems:
+plugins:
   - jekyll-feed
   - jekyll-gist
   - jekyll-paginate


### PR DESCRIPTION
`Deprecation: The 'gems' configuration option has been renamed to 'plugins'. Please update your config file accordingly.` can be be seen, when using newer github-pages versions. This also updates the minimum github-pages version to 147, which was the first to include jekyll 3.5.