### PR TITLE
Fix class import filter regex

### DIFF
--- a/_includes/manuals/1.15/4.2.2_puppet_classes.md
+++ b/_includes/manuals/1.15/4.2.2_puppet_classes.md
@@ -62,7 +62,7 @@ Regular expression features such as negative lookaheads can be used for more adv
 
 {% highlight yaml %}
 :filters:
-  - !ruby/regexp '/^(?!role::.*)$/'
+  - !ruby/regexp '/^(?!role::)/'
 {% endhighlight %}
 
 #### Assigning classes to hosts

--- a/_includes/manuals/1.16/4.2.2_puppet_classes.md
+++ b/_includes/manuals/1.16/4.2.2_puppet_classes.md
@@ -62,7 +62,7 @@ Regular expression features such as negative lookaheads can be used for more adv
 
 {% highlight yaml %}
 :filters:
-  - !ruby/regexp '/^(?!role::.*)$/'
+  - !ruby/regexp '/^(?!role::)/'
 {% endhighlight %}
 
 #### Assigning classes to hosts


### PR DESCRIPTION
This made it work for me. I've only changed 1.15 and 1.16 since I confirmed it on 1.15. Might need to be fixed in older releases as well.