### PR TITLE
Instruct to stop Katello before yum update

### DIFF
--- a/plugins/katello/3.5/upgrade/index.md
+++ b/plugins/katello/3.5/upgrade/index.md
@@ -48,6 +48,11 @@ Update the Foreman and Katello release packages:
 
 ## Step 4 - Update Packages
 
+Stop the Katello services
+{% highlight bash %}
+katello-service stop
+{% endhighlight %}
+
 Clean the yum cache
 
 {% highlight bash %}


### PR DESCRIPTION
Step 17 in the [downstream docs](https://access.redhat.com/documentation/en-us/red_hat_satellite/6.2/html/installation_guide/upgrading_satellite_server_and_capsule_server).