### PR TITLE
Add ldlinux.c32 into TFTP setup doc

### DIFF
--- a/_includes/manuals/1.16/4.3.9_smartproxy_tftp.md
+++ b/_includes/manuals/1.16/4.3.9_smartproxy_tftp.md
@@ -33,6 +33,7 @@ The setup is very simple, and may be performed manually if desired.
     * *pxelinux.0*
     * *menu.c32*
     * *chain.c32*
+    * *ldlinux.c32* if syslinux provides it
 3. Populate the following prerequisites when PXE Grub bootloader is planned. These files can be found in OS distribution repositories, DVD/CD or packages (e.g. *grub2-efi* on Red Hats which installs into */boot/EFI*). Alternatively, these files can be built from modules using *grub2-mkimage* or *grub-mkimage* and signed for SecureBoot support.
     * */var/lib/tftpboot/grub2* with *grubx64.efi* or *grubia32.efi*
     * */var/lib/tftpboot/grub* with *bootx64.efi* or *bootia32.efi*


### PR DESCRIPTION
Setting up TFTP boot on Fedora 26,
a host was complaining about missing ldlinux.c32.
After I copied the file from syslinux into tftpboot,
host started provisioning as expected.