### PR TITLE
Update index.md

### DIFF
--- a/plugins/katello/3.5/installation/index.md
+++ b/plugins/katello/3.5/installation/index.md
@@ -2,7 +2,7 @@
 layout: plugins/katello/documentation
 title: Katello Installation
 version: 3.5
-foreman_version: 1.15
+foreman_version: 1.16
 latest: 3.5
 script: osmenu.js
 ---


### PR DESCRIPTION
Used the foreman.org site to install Katello on Centos7, I found it fails during dependancy check.
Determined the repo for foreman should be changed from 1.5  to  1.6  which resolves the installation issue.
