### PR TITLE
blog: add post on Discourse migration

### DIFF
--- a/_includes/alerts.html
+++ b/_includes/alerts.html
@@ -1,5 +1,7 @@
-<!-- <div class='tease'>      -->
-<!--   <p>                    -->
-<!--     something important! -->
-<!--   </p>                   -->
-<!-- </div>                   -->
+ <div class='tease'>
+   <p>
+     <a>On Dec 31st, the Foreman Community will move from using mailing lists to a forum</a>
+     <br/>
+     <a href='/2017/12/foreman-migrates-to-discourse.html'>Learn more on our blog</a>
+   </p>
+ </div>

--- a/_posts/2017-12-11-foreman-migrates-to-discourse.md
+++ b/_posts/2017-12-11-foreman-migrates-to-discourse.md
@@ -1,0 +1,69 @@
+---
+layout: post
+title: Foreman Migrates from Google Groups to Discourse on Dec 31st
+date: 2017-12-13 22:32
+author: Greg Sutcliffe
+excerpt: |
+  Action needed! The mailing lists will be switched to read-only at the end of
+  31st Dec, and from 1st Jan, we will be moving to [Discourse][discourse].
+tags:
+- foreman
+---
+
+As you may be aware from [previous mails][users-list], [YouTube
+content][youtube] and the [newsletter][news], we've been debating for about a
+month on moving to a forum for our community interaction. That debate has run
+it's course, and the conclusion is clear - a move to Discourse is popular.
+
+Accordingly, I am now setting in motion the [plan for the
+migration][migration]. Today, I'm notifying all 3 lists that they will be
+switched to read-only on 31st Dec (3 weeks away).
+
+# What do I need to do?
+
+Firstly, claim your Discourse account (if you haven't yet) - if you've
+ever *posted* to the mailing list, then you already have an account, and
+can use the "Forgot Password" option on your email address to get logged
+in (or use GitHub login, if the email is the same there).
+
+(If you're a lurker and have never posted, then you'll have to create
+the account yourself, sorry. Don't be shy though, now's a good time :P).
+
+Once logged in there's an FAQ banner at the top to help you get started
+(with links to more in-depth topics), and Discobot (the forum bot) will
+message you with some tips too. You can dismiss the banner with the "X"
+once you're done with it.
+
+Any questions, you can [send a message to me][message] on the forum and I'll
+respond as soon as I can (using the forum helps me collect them into an FAQ).
+If you prefer, you can also post in the "Site Feedback" category.
+
+# What happens next?
+
+During the next few weeks I'll be tweaking Discourse to suit our needs
+(groups, tags, settings, etc) and writing docs to help orient new users.
+I'm *very* interested in hearing from the first few users who jump on
+about how easy to find the docs are, and how helpful.
+
+I'll also be updating the Google Groups web interface with a deprecation
+notice, and preparing PRs to the website to point new users at
+Discourse. If you spot anything where we can improve sign-posting for
+people, [get in touch][message].
+
+The lists will remain functional for now, but I would encourage people
+starting *new* threads to consider using the forum. The entire list
+archive will be merged to the forum, so nothing will be lost, but it
+means you get a head start on getting used to Discourse, we can help
+you get oriented, and you can test our docs (and thanks for that!).
+
+Do hang tight, I'm sure *something* unexpected will come up - but we're
+shooting for the quietest time of year, and once we're up and running, I
+think this will be good for all of us. More updates will follow in due
+course :)
+
+[discourse]: https://community.theforeman.org
+[message]: https://community.theforeman.org/u/gwmngilfen/
+[users-list]: https://groups.google.com/d/topic/foreman-users/XXSETIlScX4
+[youtube]: https://www.youtube.com/watch?v=IdV6US_d4-U
+[news]: https://theforeman.org/2017/11/foreman-community-newsletter-november-2017.html
+[migration]: https://community.theforeman.org/t/migration-plan/7550


### PR DESCRIPTION
Basically the same text as the mail I just sent to the mailing lists - just for those who might only be on the rss feed, and for a convenient thing to link to elsewhere. I'll tweet a link to this once it's published.

Will do another PR for adding Discourse links to the website itself.