### PR TITLE
Changed rpm links from http to https

### DIFF
--- a/plugins/katello/2.4/cli/index.md
+++ b/plugins/katello/2.4/cli/index.md
@@ -37,9 +37,9 @@ yum-config-manager --enable rhel-6-server-optional-rpms
 
 <div id="el6" markdown="1">
 {% highlight bash %}
-yum -y localinstall http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el6/x86_64/katello-repos-latest.rpm
-yum -y localinstall http://yum.theforeman.org/releases/{{ page.foreman_version }}/el6/x86_64/foreman-release.rpm
-yum -y localinstall http://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
+yum -y localinstall https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el6/x86_64/katello-repos-latest.rpm
+yum -y localinstall https://yum.theforeman.org/releases/{{ page.foreman_version }}/el6/x86_64/foreman-release.rpm
+yum -y localinstall https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
 {% endhighlight %}
 </div>
 
@@ -55,9 +55,9 @@ yum-config-manager --enable rhel-7-server-extras-rpms
 
 <div id="el7" style="display: none;" markdown="1">
 {% highlight bash %}
-yum -y localinstall http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el7/x86_64/katello-repos-latest.rpm
-yum -y localinstall http://yum.theforeman.org/releases/{{ page.foreman_version }}/el7/x86_64/foreman-release.rpm
-yum -y localinstall http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+yum -y localinstall https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el7/x86_64/katello-repos-latest.rpm
+yum -y localinstall https://yum.theforeman.org/releases/{{ page.foreman_version }}/el7/x86_64/foreman-release.rpm
+yum -y localinstall https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 {% endhighlight %}
 </div>
 

--- a/plugins/katello/2.4/installation/clients.md
+++ b/plugins/katello/2.4/installation/clients.md
@@ -26,32 +26,32 @@ Install the appropriate Katello client release packages.  For CentOS 6, you will
 
 <div id="el5" markdown="1">
 ```bash
-yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/RHEL/5Server/x86_64/katello-client-repos-latest.rpm
+yum update -y https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/RHEL/5Server/x86_64/katello-client-repos-latest.rpm
 ```
 </div>
 
 <div id="el6" style="display:none;" markdown="1">
 ```bash
 wget https://copr.fedoraproject.org/coprs/dgoodwin/subscription-manager/repo/epel-6/dgoodwin-subscription-manager-epel-6.repo -O /etc/yum.repos.d/dgoodwin-subscription-manager-epel-6.repo
-yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/RHEL/6Server/x86_64/katello-client-repos-latest.rpm
+yum update -y https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/RHEL/6Server/x86_64/katello-client-repos-latest.rpm
 ```
 </div>
 
 <div id="el7" style="display:none;" markdown="1">
 ```bash
-yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/RHEL/7Server/x86_64/katello-client-repos-latest.rpm
+yum update -y https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/RHEL/7Server/x86_64/katello-client-repos-latest.rpm
 ```
 </div>
 
 <div id="fc20" style="display:none;" markdown="1">
 ```bash
-yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/RHEL/Fedora/20/x86_64/katello-client-repos-latest.rpm
+yum update -y https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/RHEL/Fedora/20/x86_64/katello-client-repos-latest.rpm
 ```
 </div>
 
 <div id="fc21" style="display:none;" markdown="1">
 ```bash
-yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/RHEL/Fedora/21/x86_64/katello-client-repos-latest.rpm
+yum update -y https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/RHEL/Fedora/21/x86_64/katello-client-repos-latest.rpm
 ```
 </div>
 

--- a/plugins/katello/2.4/installation/index.md
+++ b/plugins/katello/2.4/installation/index.md
@@ -83,10 +83,10 @@ yum-config-manager --enable rhel-6-server-optional-rpms
 
 <div id="el6" markdown="1">
 ```bash
-yum -y localinstall http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/RHEL/6Server/x86_64/katello-repos-latest.rpm
-yum -y localinstall http://yum.theforeman.org/releases/{{ page.foreman_version }}/el6/x86_64/foreman-release.rpm
-yum -y localinstall http://yum.puppetlabs.com/puppetlabs-release-el-6.noarch.rpm
-yum -y localinstall http://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
+yum -y localinstall https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/RHEL/6Server/x86_64/katello-repos-latest.rpm
+yum -y localinstall https://yum.theforeman.org/releases/{{ page.foreman_version }}/el6/x86_64/foreman-release.rpm
+yum -y localinstall https://yum.puppetlabs.com/puppetlabs-release-el-6.noarch.rpm
+yum -y localinstall https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
 yum -y install foreman-release-scl
 ```
 </div>
@@ -103,10 +103,10 @@ yum-config-manager --enable rhel-7-server-extras-rpms
 
 <div id="el7" style="display: none;" markdown="1">
 ```bash
-yum -y localinstall http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/RHEL/7Server/x86_64/katello-repos-latest.rpm
-yum -y localinstall http://yum.theforeman.org/releases/{{ page.foreman_version }}/el7/x86_64/foreman-release.rpm
-yum -y localinstall http://yum.puppetlabs.com/puppetlabs-release-el-7.noarch.rpm
-yum -y localinstall http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+yum -y localinstall https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/RHEL/7Server/x86_64/katello-repos-latest.rpm
+yum -y localinstall https://yum.theforeman.org/releases/{{ page.foreman_version }}/el7/x86_64/foreman-release.rpm
+yum -y localinstall https://yum.puppetlabs.com/puppetlabs-release-el-7.noarch.rpm
+yum -y localinstall https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 yum -y install foreman-release-scl
 ```
 </div>

--- a/plugins/katello/2.4/troubleshooting/index.md
+++ b/plugins/katello/2.4/troubleshooting/index.md
@@ -197,10 +197,10 @@ Katello 3.0 generates a client cert at installation time which allows usage of p
 
 Sometimes you want to debug why a synchronization of a repository from Katello is failing and rather than dig through log files and error messages it can often be easier to try to sync the repo with the ''grinder'' tool which is what Katello uses to download repositories.  The tool can be ran from a terminal on your Katello server:
 
-    $ grinder yum --label=sync-test --url=http://fedorapeople.org/groups/katello/releases/yum/1.0/RHEL/6Server/x86_64/
+    $ grinder yum --label=sync-test --url=https://fedorapeople.org/groups/katello/releases/yum/1.0/RHEL/6Server/x86_64/
     grinder.RepoFetch: INFO     fetchYumRepo() repo_label = sync-test, repo_url = 
-    http://fedorapeople.org/groups/katello/releases/yum/1.0/RHEL/6Server/x86_64/, basepath = ./, verify_options = {}
-    grinder.RepoFetch: INFO     sync-test, http://fedorapeople.org/groups/katello/releases/yum/1.0/RHEL/6Server/x86_64/, 
+    https://fedorapeople.org/groups/katello/releases/yum/1.0/RHEL/6Server/x86_64/, basepath = ./, verify_options = {}
+    grinder.RepoFetch: INFO     sync-test, https://fedorapeople.org/groups/katello/releases/yum/1.0/RHEL/6Server/x86_64/, 
     Calling RepoFetch with: cacert=<None>, clicert=<None>, clikey=<None>, proxy_url=<None>, proxy_port=<3128>, proxy_user=<None>, 
     proxy_pass=<NOT_LOGGED>, sslverify=<1>, max_speed=<None>, verify_options=<{}>, filter=<None>
     ....

--- a/plugins/katello/2.4/upgrade/capsule.md
+++ b/plugins/katello/2.4/upgrade/capsule.md
@@ -26,15 +26,15 @@ Update the Foreman and Katello release packages:
   * RHEL6 / CentOS 6:
 
 {% highlight bash %}
-  yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/RHEL/6Server/x86_64/katello-repos-latest.rpm
-  yum update -y http://yum.theforeman.org/releases/{{ page.foreman_version }}/el6/x86_64/foreman-release.rpm
+  yum update -y https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/RHEL/6Server/x86_64/katello-repos-latest.rpm
+  yum update -y https://yum.theforeman.org/releases/{{ page.foreman_version }}/el6/x86_64/foreman-release.rpm
 {% endhighlight %}
 
   * RHEL7 / CentOS 7:
 
 {% highlight bash %}
-  yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/RHEL/7Server/x86_64/katello-repos-latest.rpm
-  yum update -y http://yum.theforeman.org/releases/{{ page.foreman_version }}/el7/x86_64/foreman-release.rpm
+  yum update -y https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/RHEL/7Server/x86_64/katello-repos-latest.rpm
+  yum update -y https://yum.theforeman.org/releases/{{ page.foreman_version }}/el7/x86_64/foreman-release.rpm
 {% endhighlight %}
 
 ## Step 3 - Update Packages

--- a/plugins/katello/2.4/upgrade/clients.md
+++ b/plugins/katello/2.4/upgrade/clients.md
@@ -28,31 +28,31 @@ Update the Katello client release packages:
 
 <div id="el5" markdown="1">
 {% highlight bash %}
-yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/RHEL/5Server/x86_64/katello-client-repos-latest.rpm
+yum update -y https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/RHEL/5Server/x86_64/katello-client-repos-latest.rpm
 {% endhighlight %}
 </div>
 
 <div id="el6" style="display:none;" markdown="1">
 {% highlight bash %}
-yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/RHEL/6Server/x86_64/katello-client-repos-latest.rpm
+yum update -y https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/RHEL/6Server/x86_64/katello-client-repos-latest.rpm
 {% endhighlight %}
 </div>
 
 <div id="el7" style="display:none;" markdown="1">
 {% highlight bash %}
-yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/RHEL/7Server/x86_64/katello-client-repos-latest.rpm
+yum update -y https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/RHEL/7Server/x86_64/katello-client-repos-latest.rpm
 {% endhighlight %}
 </div>
 
 <div id="fc20" style="display:none;" markdown="1">
 {% highlight bash %}
-yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/RHEL/Fedora/20/x86_64/katello-client-repos-latest.rpm
+yum update -y https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/RHEL/Fedora/20/x86_64/katello-client-repos-latest.rpm
 {% endhighlight %}
 </div>
 
 <div id="fc21" style="display:none;" markdown="1">
 {% highlight bash %}
-yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/RHEL/Fedora/21/x86_64/katello-client-repos-latest.rpm
+yum update -y https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/RHEL/Fedora/21/x86_64/katello-client-repos-latest.rpm
 {% endhighlight %}
 </div>
 

--- a/plugins/katello/2.4/upgrade/index.md
+++ b/plugins/katello/2.4/upgrade/index.md
@@ -30,15 +30,15 @@ Update the Foreman and Katello release packages:
   * RHEL6 / CentOS 6:
 
 {% highlight bash %}
-  yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/RHEL/6Server/x86_64/katello-repos-latest.rpm
-  yum update -y http://yum.theforeman.org/releases/{{ page.foreman_version }}/el6/x86_64/foreman-release.rpm
+  yum update -y https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/RHEL/6Server/x86_64/katello-repos-latest.rpm
+  yum update -y https://yum.theforeman.org/releases/{{ page.foreman_version }}/el6/x86_64/foreman-release.rpm
 {% endhighlight %}
 
   * RHEL7 / CentOS 7:
 
 {% highlight bash %}
-  yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/RHEL/7Server/x86_64/katello-repos-latest.rpm
-  yum update -y http://yum.theforeman.org/releases/{{ page.foreman_version }}/el7/x86_64/foreman-release.rpm
+  yum update -y https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/RHEL/7Server/x86_64/katello-repos-latest.rpm
+  yum update -y https://yum.theforeman.org/releases/{{ page.foreman_version }}/el7/x86_64/foreman-release.rpm
 {% endhighlight %}
 
 ## Step 4 - Update Packages

--- a/plugins/katello/2.4/user_guide/content/index.md
+++ b/plugins/katello/2.4/user_guide/content/index.md
@@ -40,7 +40,7 @@ Content > Products > Select desired product > Create Repository (right hand side
 Note the following options:
 
 * Publish via HTTP: allows access to the Repository without any restriction.  Unless you desire to restrict access to your content in this Repository, we recommended to leave this checked.
-* URL: If you are syncing from an external Repository (yum or puppet), this would be filled in. This can be changed, added, or removed later.  For example if you are wanting to create a mirror of EPEL, you would set this to 'http://dl.fedoraproject.org/pub/epel/6/x86_64/'.
+* URL: If you are syncing from an external Repository (yum or puppet), this would be filled in. This can be changed, added, or removed later.  For example if you are wanting to create a mirror of EPEL, you would set this to 'https://dl.fedoraproject.org/pub/epel/6/x86_64/'.
 
 ![Creating a Repository](/plugins/katello/{{ page.version }}/user_guide/content/repo_create.png)
 

--- a/plugins/katello/3.0/cli/index.md
+++ b/plugins/katello/3.0/cli/index.md
@@ -37,9 +37,9 @@ yum-config-manager --enable rhel-6-server-optional-rpms
 
 <div id="el6" markdown="1">
 {% highlight bash %}
-yum -y localinstall http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el6/x86_64/katello-repos-latest.rpm
-yum -y localinstall http://yum.theforeman.org/releases/{{ page.foreman_version }}/el6/x86_64/foreman-release.rpm
-yum -y localinstall http://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
+yum -y localinstall https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el6/x86_64/katello-repos-latest.rpm
+yum -y localinstall https://yum.theforeman.org/releases/{{ page.foreman_version }}/el6/x86_64/foreman-release.rpm
+yum -y localinstall https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
 {% endhighlight %}
 </div>
 
@@ -55,9 +55,9 @@ yum-config-manager --enable rhel-7-server-extras-rpms
 
 <div id="el7" style="display: none;" markdown="1">
 {% highlight bash %}
-yum -y localinstall http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el7/x86_64/katello-repos-latest.rpm
-yum -y localinstall http://yum.theforeman.org/releases/{{ page.foreman_version }}/el7/x86_64/foreman-release.rpm
-yum -y localinstall http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+yum -y localinstall https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el7/x86_64/katello-repos-latest.rpm
+yum -y localinstall https://yum.theforeman.org/releases/{{ page.foreman_version }}/el7/x86_64/foreman-release.rpm
+yum -y localinstall https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 {% endhighlight %}
 </div>
 

--- a/plugins/katello/3.0/installation/clients.md
+++ b/plugins/katello/3.0/installation/clients.md
@@ -26,32 +26,32 @@ Install the appropriate Katello client release packages.  For CentOS 6, you will
 
 <div id="el5" markdown="1">
 {% highlight bash %}
-yum install -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/el5/x86_64/katello-client-repos-latest.rpm
+yum install -y https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/el5/x86_64/katello-client-repos-latest.rpm
 {% endhighlight %}
 </div>
 
 <div id="el6" style="display:none;" markdown="1">
 {% highlight bash %}
 wget https://copr.fedoraproject.org/coprs/dgoodwin/subscription-manager/repo/epel-6/dgoodwin-subscription-manager-epel-6.repo -O /etc/yum.repos.d/dgoodwin-subscription-manager-epel-6.repo
-yum install -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/el6/x86_64/katello-client-repos-latest.rpm
+yum install -y https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/el6/x86_64/katello-client-repos-latest.rpm
 {% endhighlight %}
 </div>
 
 <div id="el7" style="display:none;" markdown="1">
 {% highlight bash %}
-yum install -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/el7/x86_64/katello-client-repos-latest.rpm
+yum install -y https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/el7/x86_64/katello-client-repos-latest.rpm
 {% endhighlight %}
 </div>
 
 <div id="fc22" style="display:none;" markdown="1">
 {% highlight bash %}
-yum install -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/RHEL/f22/x86_64/katello-client-repos-latest.rpm
+yum install -y https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/RHEL/f22/x86_64/katello-client-repos-latest.rpm
 {% endhighlight %}
 </div>
 
 <div id="fc23" style="display:none;" markdown="1">
 {% highlight bash %}
-yum install -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/RHEL/f23/x86_64/katello-client-repos-latest.rpm
+yum install -y https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/RHEL/f23/x86_64/katello-client-repos-latest.rpm
 {% endhighlight %}
 </div>
 

--- a/plugins/katello/3.0/installation/index.md
+++ b/plugins/katello/3.0/installation/index.md
@@ -101,10 +101,10 @@ yum-config-manager --enable rhel-6-server-optional-rpms
 
 <div id="el6" markdown="1">
 {% highlight bash %}
-yum -y localinstall http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el6/x86_64/katello-repos-latest.rpm
-yum -y localinstall http://yum.theforeman.org/releases/{{ page.foreman_version }}/el6/x86_64/foreman-release.rpm
-yum -y localinstall http://yum.puppetlabs.com/puppetlabs-release-el-6.noarch.rpm
-yum -y localinstall http://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
+yum -y localinstall https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el6/x86_64/katello-repos-latest.rpm
+yum -y localinstall https://yum.theforeman.org/releases/{{ page.foreman_version }}/el6/x86_64/foreman-release.rpm
+yum -y localinstall https://yum.puppetlabs.com/puppetlabs-release-el-6.noarch.rpm
+yum -y localinstall https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
 yum -y install foreman-release-scl
 {% endhighlight %}
 </div>
@@ -121,10 +121,10 @@ yum-config-manager --enable rhel-7-server-extras-rpms
 
 <div id="el7" style="display: none;" markdown="1">
 {% highlight bash %}
-yum -y localinstall http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el7/x86_64/katello-repos-latest.rpm
-yum -y localinstall http://yum.theforeman.org/releases/{{ page.foreman_version  }}/el7/x86_64/foreman-release.rpm
-yum -y localinstall http://yum.puppetlabs.com/puppetlabs-release-el-7.noarch.rpm
-yum -y localinstall http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+yum -y localinstall https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el7/x86_64/katello-repos-latest.rpm
+yum -y localinstall https://yum.theforeman.org/releases/{{ page.foreman_version  }}/el7/x86_64/foreman-release.rpm
+yum -y localinstall https://yum.puppetlabs.com/puppetlabs-release-el-7.noarch.rpm
+yum -y localinstall https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 yum -y install foreman-release-scl
 {% endhighlight %}
 </div>

--- a/plugins/katello/3.0/troubleshooting/index.md
+++ b/plugins/katello/3.0/troubleshooting/index.md
@@ -197,10 +197,10 @@ Katello 3.0 generates a client cert at installation time which allows usage of p
 
 Sometimes you want to debug why a synchronization of a repository from Katello is failing and rather than dig through log files and error messages it can often be easier to try to sync the repo with the ''grinder'' tool which is what Katello uses to download repositories.  The tool can be ran from a terminal on your Katello server:
 
-    $ grinder yum --label=sync-test --url=http://fedorapeople.org/groups/katello/releases/yum/1.0/RHEL/6Server/x86_64/
+    $ grinder yum --label=sync-test --url=https://fedorapeople.org/groups/katello/releases/yum/1.0/RHEL/6Server/x86_64/
     grinder.RepoFetch: INFO     fetchYumRepo() repo_label = sync-test, repo_url = 
-    http://fedorapeople.org/groups/katello/releases/yum/1.0/RHEL/6Server/x86_64/, basepath = ./, verify_options = {}
-    grinder.RepoFetch: INFO     sync-test, http://fedorapeople.org/groups/katello/releases/yum/1.0/RHEL/6Server/x86_64/, 
+    https://fedorapeople.org/groups/katello/releases/yum/1.0/RHEL/6Server/x86_64/, basepath = ./, verify_options = {}
+    grinder.RepoFetch: INFO     sync-test, https://fedorapeople.org/groups/katello/releases/yum/1.0/RHEL/6Server/x86_64/, 
     Calling RepoFetch with: cacert=<None>, clicert=<None>, clikey=<None>, proxy_url=<None>, proxy_port=<3128>, proxy_user=<None>, 
     proxy_pass=<NOT_LOGGED>, sslverify=<1>, max_speed=<None>, verify_options=<{}>, filter=<None>
     ....

--- a/plugins/katello/3.0/upgrade/capsule.md
+++ b/plugins/katello/3.0/upgrade/capsule.md
@@ -37,15 +37,15 @@ Update the Foreman and Katello release packages:
   * RHEL6 / CentOS 6:
 
 {% highlight bash %}
-  yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/RHEL/6Server/x86_64/katello-repos-latest.rpm
-  yum update -y http://yum.theforeman.org/releases/{{ page.foreman_version }}/el6/x86_64/foreman-release.rpm
+  yum update -y https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/RHEL/6Server/x86_64/katello-repos-latest.rpm
+  yum update -y https://yum.theforeman.org/releases/{{ page.foreman_version }}/el6/x86_64/foreman-release.rpm
 {% endhighlight %}
 
   * RHEL7 / CentOS 7:
 
 {% highlight bash %}
-  yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/RHEL/7Server/x86_64/katello-repos-latest.rpm
-  yum update -y http://yum.theforeman.org/releases/{{ page.foreman_version }}/el7/x86_64/foreman-release.rpm
+  yum update -y https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/RHEL/7Server/x86_64/katello-repos-latest.rpm
+  yum update -y https://yum.theforeman.org/releases/{{ page.foreman_version }}/el7/x86_64/foreman-release.rpm
 {% endhighlight %}
 
 ## Step 3 - Update Packages

--- a/plugins/katello/3.0/upgrade/clients.md
+++ b/plugins/katello/3.0/upgrade/clients.md
@@ -28,31 +28,31 @@ Update the Katello client release packages:
 
 <div id="el5" markdown="1">
 {% highlight bash %}
-yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/RHEL/5Server/x86_64/katello-client-repos-latest.rpm
+yum update -y https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/RHEL/5Server/x86_64/katello-client-repos-latest.rpm
 {% endhighlight %}
 </div>
 
 <div id="el6" style="display:none;" markdown="1">
 {% highlight bash %}
-yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/RHEL/6Server/x86_64/katello-client-repos-latest.rpm
+yum update -y https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/RHEL/6Server/x86_64/katello-client-repos-latest.rpm
 {% endhighlight %}
 </div>
 
 <div id="el7" style="display:none;" markdown="1">
 {% highlight bash %}
-yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/RHEL/7Server/x86_64/katello-client-repos-latest.rpm
+yum update -y https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/RHEL/7Server/x86_64/katello-client-repos-latest.rpm
 {% endhighlight %}
 </div>
 
 <div id="fc20" style="display:none;" markdown="1">
 {% highlight bash %}
-yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/RHEL/Fedora/20/x86_64/katello-client-repos-latest.rpm
+yum update -y https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/RHEL/Fedora/20/x86_64/katello-client-repos-latest.rpm
 {% endhighlight %}
 </div>
 
 <div id="fc21" style="display:none;" markdown="1">
 {% highlight bash %}
-yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/RHEL/Fedora/21/x86_64/katello-client-repos-latest.rpm
+yum update -y https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/RHEL/Fedora/21/x86_64/katello-client-repos-latest.rpm
 {% endhighlight %}
 </div>
 

--- a/plugins/katello/3.0/upgrade/index.md
+++ b/plugins/katello/3.0/upgrade/index.md
@@ -56,15 +56,15 @@ Update the Foreman and Katello release packages:
   * RHEL6 / CentOS 6:
 
 {% highlight bash %}
-  yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el6/x86_64/katello-repos-latest.rpm
-  yum update -y http://yum.theforeman.org/releases/{{ page.foreman_version }}/el6/x86_64/foreman-release.rpm
+  yum update -y https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el6/x86_64/katello-repos-latest.rpm
+  yum update -y https://yum.theforeman.org/releases/{{ page.foreman_version }}/el6/x86_64/foreman-release.rpm
 {% endhighlight %}
 
   * RHEL7 / CentOS 7:
 
 {% highlight bash %}
-  yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el7/x86_64/katello-repos-latest.rpm
-  yum update -y http://yum.theforeman.org/releases/{{ page.foreman_version }}/el7/x86_64/foreman-release.rpm
+  yum update -y https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el7/x86_64/katello-repos-latest.rpm
+  yum update -y https://yum.theforeman.org/releases/{{ page.foreman_version }}/el7/x86_64/foreman-release.rpm
 {% endhighlight %}
 
 ## Step 4 - Update Packages

--- a/plugins/katello/3.0/user_guide/content/index.md
+++ b/plugins/katello/3.0/user_guide/content/index.md
@@ -39,7 +39,7 @@ Content > Products > Select desired product > Create Repository (right hand side
 Note the following options:
 
 * Publish via HTTP: allows access to the Repository without any restriction.  Unless you desire to restrict access to your content in this Repository, we recommended to leave this checked.
-* URL: If you are syncing from an external Repository (yum or puppet), this would be filled in. This can be changed, added, or removed later.  For example if you are wanting to create a mirror of EPEL, you would set this to 'http://dl.fedoraproject.org/pub/epel/6/x86_64/'.
+* URL: If you are syncing from an external Repository (yum or puppet), this would be filled in. This can be changed, added, or removed later.  For example if you are wanting to create a mirror of EPEL, you would set this to 'https://dl.fedoraproject.org/pub/epel/6/x86_64/'.
 
 ![Creating a Repository](/plugins/katello/{{ page.version }}/user_guide/content/repo_create.png)
 

--- a/plugins/katello/3.1/cli/index.md
+++ b/plugins/katello/3.1/cli/index.md
@@ -37,9 +37,9 @@ yum-config-manager --enable rhel-6-server-optional-rpms
 
 <div id="el6" markdown="1">
 {% highlight bash %}
-yum -y localinstall http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el6/x86_64/katello-repos-latest.rpm
-yum -y localinstall http://yum.theforeman.org/releases/{{ page.foreman_version }}/el6/x86_64/foreman-release.rpm
-yum -y localinstall http://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
+yum -y localinstall https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el6/x86_64/katello-repos-latest.rpm
+yum -y localinstall https://yum.theforeman.org/releases/{{ page.foreman_version }}/el6/x86_64/foreman-release.rpm
+yum -y localinstall https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
 {% endhighlight %}
 </div>
 
@@ -55,9 +55,9 @@ yum-config-manager --enable rhel-7-server-extras-rpms
 
 <div id="el7" style="display: none;" markdown="1">
 {% highlight bash %}
-yum -y localinstall http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el7/x86_64/katello-repos-latest.rpm
-yum -y localinstall http://yum.theforeman.org/releases/{{ page.foreman_version }}/el7/x86_64/foreman-release.rpm
-yum -y localinstall http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+yum -y localinstall https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el7/x86_64/katello-repos-latest.rpm
+yum -y localinstall https://yum.theforeman.org/releases/{{ page.foreman_version }}/el7/x86_64/foreman-release.rpm
+yum -y localinstall https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 {% endhighlight %}
 </div>
 

--- a/plugins/katello/3.1/installation/clients.md
+++ b/plugins/katello/3.1/installation/clients.md
@@ -26,35 +26,35 @@ Install the appropriate Katello client release packages.  For CentOS 6, you will
 
 <div id="el5" markdown="1">
 {% highlight bash %}
-yum install -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/el5/x86_64/katello-client-repos-latest.rpm
-yum -y install http://dl.fedoraproject.org/pub/epel/epel-release-latest-5.noarch.rpm
+yum install -y https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/el5/x86_64/katello-client-repos-latest.rpm
+yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-5.noarch.rpm
 {% endhighlight %}
 </div>
 
 <div id="el6" style="display:none;" markdown="1">
 {% highlight bash %}
 wget https://copr.fedoraproject.org/coprs/dgoodwin/subscription-manager/repo/epel-6/dgoodwin-subscription-manager-epel-6.repo -O /etc/yum.repos.d/dgoodwin-subscription-manager-epel-6.repo
-yum -y install http://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
-yum install -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/el6/x86_64/katello-client-repos-latest.rpm
+yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
+yum install -y https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/el6/x86_64/katello-client-repos-latest.rpm
 {% endhighlight %}
 </div>
 
 <div id="el7" style="display:none;" markdown="1">
 {% highlight bash %}
-yum -y install http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
-yum install -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/el7/x86_64/katello-client-repos-latest.rpm
+yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+yum install -y https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/el7/x86_64/katello-client-repos-latest.rpm
 {% endhighlight %}
 </div>
 
 <div id="f22" style="display:none;" markdown="1">
 {% highlight bash %}
-yum install -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/f22/x86_64/katello-client-repos-latest.rpm
+yum install -y https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/f22/x86_64/katello-client-repos-latest.rpm
 {% endhighlight %}
 </div>
 
 <div id="f23" style="display:none;" markdown="1">
 {% highlight bash %}
-yum install -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/f23/x86_64/katello-client-repos-latest.rpm
+yum install -y https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/f23/x86_64/katello-client-repos-latest.rpm
 {% endhighlight %}
 </div>
 

--- a/plugins/katello/3.1/installation/index.md
+++ b/plugins/katello/3.1/installation/index.md
@@ -101,10 +101,10 @@ yum-config-manager --enable rhel-6-server-optional-rpms
 
 <div id="el6" markdown="1">
 {% highlight bash %}
-yum -y localinstall http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el6/x86_64/katello-repos-latest.rpm
-yum -y localinstall http://yum.theforeman.org/releases/{{ page.foreman_version }}/el6/x86_64/foreman-release.rpm
-yum -y localinstall http://yum.puppetlabs.com/puppetlabs-release-el-6.noarch.rpm
-yum -y localinstall http://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
+yum -y localinstall https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el6/x86_64/katello-repos-latest.rpm
+yum -y localinstall https://yum.theforeman.org/releases/{{ page.foreman_version }}/el6/x86_64/foreman-release.rpm
+yum -y localinstall https://yum.puppetlabs.com/puppetlabs-release-el-6.noarch.rpm
+yum -y localinstall https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
 yum -y install foreman-release-scl
 {% endhighlight %}
 </div>
@@ -121,10 +121,10 @@ yum-config-manager --enable rhel-7-server-extras-rpms
 
 <div id="el7" style="display: none;" markdown="1">
 {% highlight bash %}
-yum -y localinstall http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el7/x86_64/katello-repos-latest.rpm
-yum -y localinstall http://yum.theforeman.org/releases/{{ page.foreman_version  }}/el7/x86_64/foreman-release.rpm
-yum -y localinstall http://yum.puppetlabs.com/puppetlabs-release-el-7.noarch.rpm
-yum -y localinstall http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+yum -y localinstall https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el7/x86_64/katello-repos-latest.rpm
+yum -y localinstall https://yum.theforeman.org/releases/{{ page.foreman_version  }}/el7/x86_64/foreman-release.rpm
+yum -y localinstall https://yum.puppetlabs.com/puppetlabs-release-el-7.noarch.rpm
+yum -y localinstall https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 yum -y install foreman-release-scl
 {% endhighlight %}
 </div>

--- a/plugins/katello/3.1/troubleshooting/index.md
+++ b/plugins/katello/3.1/troubleshooting/index.md
@@ -197,10 +197,10 @@ Katello 3.0 generates a client cert at installation time which allows usage of p
 
 Sometimes you want to debug why a synchronization of a repository from Katello is failing and rather than dig through log files and error messages it can often be easier to try to sync the repo with the ''grinder'' tool which is what Katello uses to download repositories.  The tool can be ran from a terminal on your Katello server:
 
-    $ grinder yum --label=sync-test --url=http://fedorapeople.org/groups/katello/releases/yum/1.0/RHEL/6Server/x86_64/
+    $ grinder yum --label=sync-test --url=https://fedorapeople.org/groups/katello/releases/yum/1.0/RHEL/6Server/x86_64/
     grinder.RepoFetch: INFO     fetchYumRepo() repo_label = sync-test, repo_url = 
-    http://fedorapeople.org/groups/katello/releases/yum/1.0/RHEL/6Server/x86_64/, basepath = ./, verify_options = {}
-    grinder.RepoFetch: INFO     sync-test, http://fedorapeople.org/groups/katello/releases/yum/1.0/RHEL/6Server/x86_64/, 
+    https://fedorapeople.org/groups/katello/releases/yum/1.0/RHEL/6Server/x86_64/, basepath = ./, verify_options = {}
+    grinder.RepoFetch: INFO     sync-test, https://fedorapeople.org/groups/katello/releases/yum/1.0/RHEL/6Server/x86_64/, 
     Calling RepoFetch with: cacert=<None>, clicert=<None>, clikey=<None>, proxy_url=<None>, proxy_port=<3128>, proxy_user=<None>, 
     proxy_pass=<NOT_LOGGED>, sslverify=<1>, max_speed=<None>, verify_options=<{}>, filter=<None>
     ....

--- a/plugins/katello/3.1/upgrade/capsule.md
+++ b/plugins/katello/3.1/upgrade/capsule.md
@@ -24,15 +24,15 @@ Update the Foreman and Katello release packages:
   * RHEL6 / CentOS 6:
 
 {% highlight bash %}
-  yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el6/x86_64/katello-repos-latest.rpm
-  yum update -y http://yum.theforeman.org/releases/{{ page.foreman_version }}/el6/x86_64/foreman-release.rpm
+  yum update -y https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el6/x86_64/katello-repos-latest.rpm
+  yum update -y https://yum.theforeman.org/releases/{{ page.foreman_version }}/el6/x86_64/foreman-release.rpm
 {% endhighlight %}
 
   * RHEL7 / CentOS 7:
 
 {% highlight bash %}
-  yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el7/x86_64/katello-repos-latest.rpm
-  yum update -y http://yum.theforeman.org/releases/{{ page.foreman_version }}/el7/x86_64/foreman-release.rpm
+  yum update -y https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el7/x86_64/katello-repos-latest.rpm
+  yum update -y https://yum.theforeman.org/releases/{{ page.foreman_version }}/el7/x86_64/foreman-release.rpm
 {% endhighlight %}
 
 ## Step 3 - Update Packages

--- a/plugins/katello/3.1/upgrade/clients.md
+++ b/plugins/katello/3.1/upgrade/clients.md
@@ -28,34 +28,34 @@ Update the Katello client release packages:
 
 <div id="el5" markdown="1">
 {% highlight bash %}
-yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/RHEL/5Server/x86_64/katello-client-repos-latest.rpm
-yum -y install http://dl.fedoraproject.org/pub/epel/epel-release-latest-5.noarch.rpm
+yum update -y https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/RHEL/5Server/x86_64/katello-client-repos-latest.rpm
+yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-5.noarch.rpm
 {% endhighlight %}
 </div>
 
 <div id="el6" style="display:none;" markdown="1">
 {% highlight bash %}
-yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/RHEL/6Server/x86_64/katello-client-repos-latest.rpm
-yum -y install http://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
+yum update -y https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/RHEL/6Server/x86_64/katello-client-repos-latest.rpm
+yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
 {% endhighlight %}
 </div>
 
 <div id="el7" style="display:none;" markdown="1">
 {% highlight bash %}
-yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/RHEL/7Server/x86_64/katello-client-repos-latest.rpm
-yum -y install http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+yum update -y https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/RHEL/7Server/x86_64/katello-client-repos-latest.rpm
+yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 {% endhighlight %}
 </div>
 
 <div id="fc20" style="display:none;" markdown="1">
 {% highlight bash %}
-yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/RHEL/Fedora/20/x86_64/katello-client-repos-latest.rpm
+yum update -y https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/RHEL/Fedora/20/x86_64/katello-client-repos-latest.rpm
 {% endhighlight %}
 </div>
 
 <div id="fc21" style="display:none;" markdown="1">
 {% highlight bash %}
-yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/RHEL/Fedora/21/x86_64/katello-client-repos-latest.rpm
+yum update -y https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/RHEL/Fedora/21/x86_64/katello-client-repos-latest.rpm
 {% endhighlight %}
 </div>
 

--- a/plugins/katello/3.1/upgrade/index.md
+++ b/plugins/katello/3.1/upgrade/index.md
@@ -57,15 +57,15 @@ Update the Foreman and Katello release packages:
   * RHEL6 / CentOS 6:
 
 {% highlight bash %}
-  yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el6/x86_64/katello-repos-latest.rpm
-  yum update -y http://yum.theforeman.org/releases/{{ page.foreman_version }}/el6/x86_64/foreman-release.rpm
+  yum update -y https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el6/x86_64/katello-repos-latest.rpm
+  yum update -y https://yum.theforeman.org/releases/{{ page.foreman_version }}/el6/x86_64/foreman-release.rpm
 {% endhighlight %}
 
   * RHEL7 / CentOS 7:
 
 {% highlight bash %}
-  yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el7/x86_64/katello-repos-latest.rpm
-  yum update -y http://yum.theforeman.org/releases/{{ page.foreman_version }}/el7/x86_64/foreman-release.rpm
+  yum update -y https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el7/x86_64/katello-repos-latest.rpm
+  yum update -y https://yum.theforeman.org/releases/{{ page.foreman_version }}/el7/x86_64/foreman-release.rpm
 {% endhighlight %}
 
 ## Step 4 - Update Packages

--- a/plugins/katello/3.1/user_guide/content/index.md
+++ b/plugins/katello/3.1/user_guide/content/index.md
@@ -39,7 +39,7 @@ Content > Products > Select desired product > Create Repository (right hand side
 Note the following options:
 
 * Publish via HTTP: allows access to the Repository without any restriction.  Unless you desire to restrict access to your content in this Repository, we recommended to leave this checked.
-* URL: If you are syncing from an external Repository (yum or puppet), this would be filled in. This can be changed, added, or removed later.  For example if you are wanting to create a mirror of EPEL, you would set this to 'http://dl.fedoraproject.org/pub/epel/6/x86_64/'.
+* URL: If you are syncing from an external Repository (yum or puppet), this would be filled in. This can be changed, added, or removed later.  For example if you are wanting to create a mirror of EPEL, you would set this to 'https://dl.fedoraproject.org/pub/epel/6/x86_64/'.
 
 ![Creating a Repository](/plugins/katello/{{ page.version }}/user_guide/content/repo_create.png)
 

--- a/plugins/katello/3.2/cli/index.md
+++ b/plugins/katello/3.2/cli/index.md
@@ -37,9 +37,9 @@ yum-config-manager --enable rhel-6-server-optional-rpms
 
 <div id="el6" markdown="1">
 {% highlight bash %}
-yum -y localinstall http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el6/x86_64/katello-repos-latest.rpm
-yum -y localinstall http://yum.theforeman.org/releases/{{ page.foreman_version }}/el6/x86_64/foreman-release.rpm
-yum -y localinstall http://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
+yum -y localinstall https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el6/x86_64/katello-repos-latest.rpm
+yum -y localinstall https://yum.theforeman.org/releases/{{ page.foreman_version }}/el6/x86_64/foreman-release.rpm
+yum -y localinstall https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
 {% endhighlight %}
 </div>
 
@@ -55,9 +55,9 @@ yum-config-manager --enable rhel-7-server-extras-rpms
 
 <div id="el7" style="display: none;" markdown="1">
 {% highlight bash %}
-yum -y localinstall http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el7/x86_64/katello-repos-latest.rpm
-yum -y localinstall http://yum.theforeman.org/releases/{{ page.foreman_version }}/el7/x86_64/foreman-release.rpm
-yum -y localinstall http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+yum -y localinstall https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el7/x86_64/katello-repos-latest.rpm
+yum -y localinstall https://yum.theforeman.org/releases/{{ page.foreman_version }}/el7/x86_64/foreman-release.rpm
+yum -y localinstall https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 {% endhighlight %}
 </div>
 

--- a/plugins/katello/3.2/installation/clients.md
+++ b/plugins/katello/3.2/installation/clients.md
@@ -26,35 +26,35 @@ Install the appropriate Katello client release packages.  For CentOS 6, you will
 
 <div id="el5" markdown="1">
 {% highlight bash %}
-yum install -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/el5/x86_64/katello-client-repos-latest.rpm
-yum -y install http://dl.fedoraproject.org/pub/epel/epel-release-latest-5.noarch.rpm
+yum install -y https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/el5/x86_64/katello-client-repos-latest.rpm
+yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-5.noarch.rpm
 {% endhighlight %}
 </div>
 
 <div id="el6" style="display:none;" markdown="1">
 {% highlight bash %}
 wget https://copr.fedoraproject.org/coprs/dgoodwin/subscription-manager/repo/epel-6/dgoodwin-subscription-manager-epel-6.repo -O /etc/yum.repos.d/dgoodwin-subscription-manager-epel-6.repo
-yum -y install http://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
-yum install -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/el6/x86_64/katello-client-repos-latest.rpm
+yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
+yum install -y https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/el6/x86_64/katello-client-repos-latest.rpm
 {% endhighlight %}
 </div>
 
 <div id="el7" style="display:none;" markdown="1">
 {% highlight bash %}
-yum -y install http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
-yum install -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/el7/x86_64/katello-client-repos-latest.rpm
+yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+yum install -y https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/el7/x86_64/katello-client-repos-latest.rpm
 {% endhighlight %}
 </div>
 
 <div id="f23" style="display:none;" markdown="1">
 {% highlight bash %}
-yum install -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/f23/x86_64/katello-client-repos-latest.rpm
+yum install -y https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/f23/x86_64/katello-client-repos-latest.rpm
 {% endhighlight %}
 </div>
 
 <div id="f24" style="display:none;" markdown="1">
 {% highlight bash %}
-yum install -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/f24/x86_64/katello-client-repos-latest.rpm
+yum install -y https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/f24/x86_64/katello-client-repos-latest.rpm
 {% endhighlight %}
 </div>
 

--- a/plugins/katello/3.2/installation/index.md
+++ b/plugins/katello/3.2/installation/index.md
@@ -106,11 +106,11 @@ yum-config-manager --enable rhel-6-server-optional-rpms
 <div id="el6" markdown="1">
 {% highlight bash %}
 yum -y update
-yum -y localinstall http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el6/x86_64/katello-repos-latest.rpm
-yum -y localinstall http://fedorapeople.org/groups/katello/releases/yum/foreman/{{ page.foreman_version }}/el6/x86_64/foreman-release.rpm
+yum -y localinstall https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el6/x86_64/katello-repos-latest.rpm
+yum -y localinstall https://fedorapeople.org/groups/katello/releases/yum/foreman/{{ page.foreman_version }}/el6/x86_64/foreman-release.rpm
 yum -y localinstall https://yum.puppetlabs.com/puppetlabs-release-pc1-el-6.noarch.rpm # will install with Puppet 4
-#yum -y localinstall http://yum.puppetlabs.com/puppetlabs-release-el-6.noarch.rpm # use this instead if you prefer Puppet 3
-yum -y localinstall http://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
+#yum -y localinstall https://yum.puppetlabs.com/puppetlabs-release-el-6.noarch.rpm # use this instead if you prefer Puppet 3
+yum -y localinstall https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
 yum -y install foreman-release-scl
 {% endhighlight %}
 </div>
@@ -127,11 +127,11 @@ yum-config-manager --enable rhel-7-server-extras-rpms
 
 <div id="el7" style="display: none;" markdown="1">
 {% highlight bash %}
-yum -y localinstall http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el7/x86_64/katello-repos-latest.rpm
-yum -y localinstall http://yum.theforeman.org/releases/{{ page.foreman_version  }}/el7/x86_64/foreman-release.rpm
+yum -y localinstall https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el7/x86_64/katello-repos-latest.rpm
+yum -y localinstall https://yum.theforeman.org/releases/{{ page.foreman_version  }}/el7/x86_64/foreman-release.rpm
 yum -y localinstall https://yum.puppetlabs.com/puppetlabs-release-pc1-el-7.noarch.rpm # will install with Puppet 4
-#yum -y localinstall http://yum.puppetlabs.com/puppetlabs-release-el-7.noarch.rpm # use this instead if you prefer Puppet 3
-yum -y localinstall http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+#yum -y localinstall https://yum.puppetlabs.com/puppetlabs-release-el-7.noarch.rpm # use this instead if you prefer Puppet 3
+yum -y localinstall https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 yum -y install foreman-release-scl
 {% endhighlight %}
 </div>

--- a/plugins/katello/3.2/troubleshooting/index.md
+++ b/plugins/katello/3.2/troubleshooting/index.md
@@ -197,10 +197,10 @@ Katello 3.0 generates a client cert at installation time which allows usage of p
 
 Sometimes you want to debug why a synchronization of a repository from Katello is failing and rather than dig through log files and error messages it can often be easier to try to sync the repo with the ''grinder'' tool which is what Katello uses to download repositories.  The tool can be ran from a terminal on your Katello server:
 
-    $ grinder yum --label=sync-test --url=http://fedorapeople.org/groups/katello/releases/yum/1.0/RHEL/6Server/x86_64/
+    $ grinder yum --label=sync-test --url=https://fedorapeople.org/groups/katello/releases/yum/1.0/RHEL/6Server/x86_64/
     grinder.RepoFetch: INFO     fetchYumRepo() repo_label = sync-test, repo_url = 
-    http://fedorapeople.org/groups/katello/releases/yum/1.0/RHEL/6Server/x86_64/, basepath = ./, verify_options = {}
-    grinder.RepoFetch: INFO     sync-test, http://fedorapeople.org/groups/katello/releases/yum/1.0/RHEL/6Server/x86_64/, 
+    https://fedorapeople.org/groups/katello/releases/yum/1.0/RHEL/6Server/x86_64/, basepath = ./, verify_options = {}
+    grinder.RepoFetch: INFO     sync-test, https://fedorapeople.org/groups/katello/releases/yum/1.0/RHEL/6Server/x86_64/, 
     Calling RepoFetch with: cacert=<None>, clicert=<None>, clikey=<None>, proxy_url=<None>, proxy_port=<3128>, proxy_user=<None>, 
     proxy_pass=<NOT_LOGGED>, sslverify=<1>, max_speed=<None>, verify_options=<{}>, filter=<None>
     ....

--- a/plugins/katello/3.2/upgrade/capsule.md
+++ b/plugins/katello/3.2/upgrade/capsule.md
@@ -24,15 +24,15 @@ Update the Foreman and Katello release packages:
   * RHEL6 / CentOS 6 **Foreman packages are not available yet**:
 
 {% highlight bash %}
-  yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el6/x86_64/katello-repos-latest.rpm
-  yum update -y http://fedorapeople.org/groups/katello/releases/yum/foreman/{{ page.foreman_version }}/el6/x86_64/foreman-release.rpm
+  yum update -y https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el6/x86_64/katello-repos-latest.rpm
+  yum update -y https://fedorapeople.org/groups/katello/releases/yum/foreman/{{ page.foreman_version }}/el6/x86_64/foreman-release.rpm
 {% endhighlight %}
 
   * RHEL7 / CentOS 7:
 
 {% highlight bash %}
-  yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el7/x86_64/katello-repos-latest.rpm
-  yum update -y http://yum.theforeman.org/releases/{{ page.foreman_version }}/el7/x86_64/foreman-release.rpm
+  yum update -y https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el7/x86_64/katello-repos-latest.rpm
+  yum update -y https://yum.theforeman.org/releases/{{ page.foreman_version }}/el7/x86_64/foreman-release.rpm
 {% endhighlight %}
 
 ## Step 3 - Update Packages

--- a/plugins/katello/3.2/upgrade/clients.md
+++ b/plugins/katello/3.2/upgrade/clients.md
@@ -27,28 +27,28 @@ Update the Katello client release packages:
 
 <div id="el5" markdown="1">
 {% highlight bash %}
-yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/el5/x86_64/katello-client-repos-latest.rpm
-yum -y install http://dl.fedoraproject.org/pub/epel/epel-release-latest-5.noarch.rpm
+yum update -y https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/el5/x86_64/katello-client-repos-latest.rpm
+yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-5.noarch.rpm
 {% endhighlight %}
 </div>
 
 <div id="el6" style="display:none;" markdown="1">
 {% highlight bash %}
-yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/el6/x86_64/katello-client-repos-latest.rpm
-yum -y install http://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
+yum update -y https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/el6/x86_64/katello-client-repos-latest.rpm
+yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
 {% endhighlight %}
 </div>
 
 <div id="el7" style="display:none;" markdown="1">
 {% highlight bash %}
-yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/el7/x86_64/katello-client-repos-latest.rpm
-yum -y install http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+yum update -y https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/el7/x86_64/katello-client-repos-latest.rpm
+yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 {% endhighlight %}
 </div>
 
 <div id="fc23" style="display:none;" markdown="1">
 {% highlight bash %}
-yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/fc23/x86_64/katello-client-repos-latest.rpm
+yum update -y https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/fc23/x86_64/katello-client-repos-latest.rpm
 {% endhighlight %}
 </div>
 

--- a/plugins/katello/3.2/upgrade/index.md
+++ b/plugins/katello/3.2/upgrade/index.md
@@ -41,15 +41,15 @@ Update the Foreman and Katello release packages:
   * RHEL6 / CentOS 6:
 
 {% highlight bash %}
-  yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el6/x86_64/katello-repos-latest.rpm
-  yum update -y http://fedorapeople.org/groups/katello/releases/yum/foreman/{{ page.foreman_version }}/el6/x86_64/foreman-release.rpm
+  yum update -y https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el6/x86_64/katello-repos-latest.rpm
+  yum update -y https://fedorapeople.org/groups/katello/releases/yum/foreman/{{ page.foreman_version }}/el6/x86_64/foreman-release.rpm
 {% endhighlight %}
 
   * RHEL7 / CentOS 7:
 
 {% highlight bash %}
-  yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el7/x86_64/katello-repos-latest.rpm
-  yum update -y http://yum.theforeman.org/releases/{{ page.foreman_version }}/el7/x86_64/foreman-release.rpm
+  yum update -y https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el7/x86_64/katello-repos-latest.rpm
+  yum update -y https://yum.theforeman.org/releases/{{ page.foreman_version }}/el7/x86_64/foreman-release.rpm
 {% endhighlight %}
 
 ## Step 4 - Update Packages

--- a/plugins/katello/3.2/user_guide/content/index.md
+++ b/plugins/katello/3.2/user_guide/content/index.md
@@ -39,7 +39,7 @@ Content > Products > Select desired product > Create Repository (right hand side
 Note the following options:
 
 * Publish via HTTP: allows access to the Repository without any restriction.  Unless you desire to restrict access to your content in this Repository, we recommended to leave this checked.
-* URL: If you are syncing from an external Repository (yum or puppet), this would be filled in. This can be changed, added, or removed later.  For example if you are wanting to create a mirror of EPEL, you would set this to 'http://dl.fedoraproject.org/pub/epel/6/x86_64/'.
+* URL: If you are syncing from an external Repository (yum or puppet), this would be filled in. This can be changed, added, or removed later.  For example if you are wanting to create a mirror of EPEL, you would set this to 'https://dl.fedoraproject.org/pub/epel/6/x86_64/'.
 
 ![Creating a Repository](/plugins/katello/{{ page.version }}/user_guide/content/repo_create.png)
 

--- a/plugins/katello/3.3/cli/index.md
+++ b/plugins/katello/3.3/cli/index.md
@@ -37,9 +37,9 @@ yum-config-manager --enable rhel-6-server-optional-rpms
 
 <div id="el6" markdown="1">
 {% highlight bash %}
-yum -y localinstall http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el6/x86_64/katello-repos-latest.rpm
-yum -y localinstall http://yum.theforeman.org/releases/{{ page.foreman_version }}/el6/x86_64/foreman-release.rpm
-yum -y localinstall http://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
+yum -y localinstall https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el6/x86_64/katello-repos-latest.rpm
+yum -y localinstall https://yum.theforeman.org/releases/{{ page.foreman_version }}/el6/x86_64/foreman-release.rpm
+yum -y localinstall https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
 {% endhighlight %}
 </div>
 
@@ -55,9 +55,9 @@ yum-config-manager --enable rhel-7-server-extras-rpms
 
 <div id="el7" style="display: none;" markdown="1">
 {% highlight bash %}
-yum -y localinstall http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el7/x86_64/katello-repos-latest.rpm
-yum -y localinstall http://yum.theforeman.org/releases/{{ page.foreman_version }}/el7/x86_64/foreman-release.rpm
-yum -y localinstall http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+yum -y localinstall https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el7/x86_64/katello-repos-latest.rpm
+yum -y localinstall https://yum.theforeman.org/releases/{{ page.foreman_version }}/el7/x86_64/foreman-release.rpm
+yum -y localinstall https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 {% endhighlight %}
 </div>
 

--- a/plugins/katello/3.3/installation/clients.md
+++ b/plugins/katello/3.3/installation/clients.md
@@ -26,35 +26,35 @@ Install the appropriate Katello client release packages.  For CentOS 6, you will
 
 <div id="el5" markdown="1">
 {% highlight bash %}
-yum install -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/el5/x86_64/katello-client-repos-latest.rpm
-yum -y install http://dl.fedoraproject.org/pub/epel/epel-release-latest-5.noarch.rpm
+yum install -y https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/el5/x86_64/katello-client-repos-latest.rpm
+yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-5.noarch.rpm
 {% endhighlight %}
 </div>
 
 <div id="el6" style="display:none;" markdown="1">
 {% highlight bash %}
 wget https://copr.fedoraproject.org/coprs/dgoodwin/subscription-manager/repo/epel-6/dgoodwin-subscription-manager-epel-6.repo -O /etc/yum.repos.d/dgoodwin-subscription-manager-epel-6.repo
-yum -y install http://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
-yum install -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/el6/x86_64/katello-client-repos-latest.rpm
+yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
+yum install -y https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/el6/x86_64/katello-client-repos-latest.rpm
 {% endhighlight %}
 </div>
 
 <div id="el7" style="display:none;" markdown="1">
 {% highlight bash %}
-yum install -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/el7/x86_64/katello-client-repos-latest.rpm
-yum -y install http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+yum install -y https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/el7/x86_64/katello-client-repos-latest.rpm
+yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 {% endhighlight %}
 </div>
 
 <div id="f22" style="display:none;" markdown="1">
 {% highlight bash %}
-yum install -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/f22/x86_64/katello-client-repos-latest.rpm
+yum install -y https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/f22/x86_64/katello-client-repos-latest.rpm
 {% endhighlight %}
 </div>
 
 <div id="f23" style="display:none;" markdown="1">
 {% highlight bash %}
-yum install -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/f23/x86_64/katello-client-repos-latest.rpm
+yum install -y https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/f23/x86_64/katello-client-repos-latest.rpm
 {% endhighlight %}
 </div>
 

--- a/plugins/katello/3.3/installation/index.md
+++ b/plugins/katello/3.3/installation/index.md
@@ -101,11 +101,11 @@ yum-config-manager --enable rhel-7-server-extras-rpms
 
 <div id="el7" markdown="1">
 {% highlight bash %}
-yum -y localinstall http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el7/x86_64/katello-repos-latest.rpm
-yum -y localinstall http://yum.theforeman.org/releases/{{ page.foreman_version  }}/el7/x86_64/foreman-release.rpm
+yum -y localinstall https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el7/x86_64/katello-repos-latest.rpm
+yum -y localinstall https://yum.theforeman.org/releases/{{ page.foreman_version  }}/el7/x86_64/foreman-release.rpm
 yum -y localinstall https://yum.puppetlabs.com/puppetlabs-release-pc1-el-7.noarch.rpm # will install with Puppet 4
-#yum -y localinstall http://yum.puppetlabs.com/puppetlabs-release-el-7.noarch.rpm # use this instead if you prefer Puppet 3
-yum -y localinstall http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+#yum -y localinstall https://yum.puppetlabs.com/puppetlabs-release-el-7.noarch.rpm # use this instead if you prefer Puppet 3
+yum -y localinstall https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 yum -y install foreman-release-scl
 {% endhighlight %}
 </div>

--- a/plugins/katello/3.3/troubleshooting/index.md
+++ b/plugins/katello/3.3/troubleshooting/index.md
@@ -197,10 +197,10 @@ Katello 3.0 generates a client cert at installation time which allows usage of p
 
 Sometimes you want to debug why a synchronization of a repository from Katello is failing and rather than dig through log files and error messages it can often be easier to try to sync the repo with the ''grinder'' tool which is what Katello uses to download repositories.  The tool can be ran from a terminal on your Katello server:
 
-    $ grinder yum --label=sync-test --url=http://fedorapeople.org/groups/katello/releases/yum/1.0/RHEL/6Server/x86_64/
+    $ grinder yum --label=sync-test --url=https://fedorapeople.org/groups/katello/releases/yum/1.0/RHEL/6Server/x86_64/
     grinder.RepoFetch: INFO     fetchYumRepo() repo_label = sync-test, repo_url = 
-    http://fedorapeople.org/groups/katello/releases/yum/1.0/RHEL/6Server/x86_64/, basepath = ./, verify_options = {}
-    grinder.RepoFetch: INFO     sync-test, http://fedorapeople.org/groups/katello/releases/yum/1.0/RHEL/6Server/x86_64/, 
+    https://fedorapeople.org/groups/katello/releases/yum/1.0/RHEL/6Server/x86_64/, basepath = ./, verify_options = {}
+    grinder.RepoFetch: INFO     sync-test, https://fedorapeople.org/groups/katello/releases/yum/1.0/RHEL/6Server/x86_64/, 
     Calling RepoFetch with: cacert=<None>, clicert=<None>, clikey=<None>, proxy_url=<None>, proxy_port=<3128>, proxy_user=<None>, 
     proxy_pass=<NOT_LOGGED>, sslverify=<1>, max_speed=<None>, verify_options=<{}>, filter=<None>
     ....

--- a/plugins/katello/3.3/upgrade/clients.md
+++ b/plugins/katello/3.3/upgrade/clients.md
@@ -28,34 +28,34 @@ Update the Katello client release packages:
 
 <div id="el5" markdown="1">
 {% highlight bash %}
-yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/el5/x86_64/katello-client-repos-latest.rpm
-yum -y install http://dl.fedoraproject.org/pub/epel/epel-release-latest-5.noarch.rpm
+yum update -y https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/el5/x86_64/katello-client-repos-latest.rpm
+yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-5.noarch.rpm
 {% endhighlight %}
 </div>
 
 <div id="el6" style="display:none;" markdown="1">
 {% highlight bash %}
-yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/el6/x86_64/katello-client-repos-latest.rpm
-yum -y install http://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
+yum update -y https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/el6/x86_64/katello-client-repos-latest.rpm
+yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
 {% endhighlight %}
 </div>
 
 <div id="el7" style="display:none;" markdown="1">
 {% highlight bash %}
-yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/el7/x86_64/katello-client-repos-latest.rpm
-yum -y install http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+yum update -y https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/el7/x86_64/katello-client-repos-latest.rpm
+yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 {% endhighlight %}
 </div>
 
 <div id="fc24" style="display:none;" markdown="1">
 {% highlight bash %}
-yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/fc24/x86_64/katello-client-repos-latest.rpm
+yum update -y https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/fc24/x86_64/katello-client-repos-latest.rpm
 {% endhighlight %}
 </div>
 
 <div id="fc25" style="display:none;" markdown="1">
 {% highlight bash %}
-yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/fc25/x86_64/katello-client-repos-latest.rpm
+yum update -y https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/fc25/x86_64/katello-client-repos-latest.rpm
 {% endhighlight %}
 </div>
 

--- a/plugins/katello/3.3/upgrade/index.md
+++ b/plugins/katello/3.3/upgrade/index.md
@@ -41,8 +41,8 @@ Update the Foreman and Katello release packages:
   * RHEL7 / CentOS 7:
 
 {% highlight bash %}
-  yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el7/x86_64/katello-repos-latest.rpm
-  yum update -y http://yum.theforeman.org/releases/{{ page.foreman_version }}/el7/x86_64/foreman-release.rpm
+  yum update -y https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el7/x86_64/katello-repos-latest.rpm
+  yum update -y https://yum.theforeman.org/releases/{{ page.foreman_version }}/el7/x86_64/foreman-release.rpm
   yum update -y foreman-release-scl
 {% endhighlight %}
 

--- a/plugins/katello/3.3/upgrade/smart_proxy.md
+++ b/plugins/katello/3.3/upgrade/smart_proxy.md
@@ -24,8 +24,8 @@ Update the Foreman and Katello release packages:
   * RHEL7 / CentOS 7:
 
 {% highlight bash %}
-  yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el7/x86_64/katello-repos-latest.rpm
-  yum update -y http://yum.theforeman.org/releases/{{ page.foreman_version }}/el7/x86_64/foreman-release.rpm
+  yum update -y https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el7/x86_64/katello-repos-latest.rpm
+  yum update -y https://yum.theforeman.org/releases/{{ page.foreman_version }}/el7/x86_64/foreman-release.rpm
 {% endhighlight %}
 
 ## Step 3 - Update Packages

--- a/plugins/katello/3.3/user_guide/content/index.md
+++ b/plugins/katello/3.3/user_guide/content/index.md
@@ -39,7 +39,7 @@ Content > Products > Select desired product > Create Repository (right hand side
 Note the following options:
 
 * Publish via HTTP: allows access to the Repository without any restriction.  Unless you desire to restrict access to your content in this Repository, we recommended to leave this checked.
-* URL: If you are syncing from an external Repository (yum or puppet), this would be filled in. This can be changed, added, or removed later.  For example if you are wanting to create a mirror of EPEL, you would set this to 'http://dl.fedoraproject.org/pub/epel/6/x86_64/'.
+* URL: If you are syncing from an external Repository (yum or puppet), this would be filled in. This can be changed, added, or removed later.  For example if you are wanting to create a mirror of EPEL, you would set this to 'https://dl.fedoraproject.org/pub/epel/6/x86_64/'.
 
 ![Creating a Repository](/plugins/katello/{{ page.version }}/user_guide/content/repo_create.png)
 

--- a/plugins/katello/3.4/cli/index.md
+++ b/plugins/katello/3.4/cli/index.md
@@ -37,9 +37,9 @@ yum-config-manager --enable rhel-6-server-optional-rpms
 
 <div id="el6" markdown="1">
 {% highlight bash %}
-yum -y localinstall http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el6/x86_64/katello-repos-latest.rpm
-yum -y localinstall http://yum.theforeman.org/releases/{{ page.foreman_version }}/el6/x86_64/foreman-release.rpm
-yum -y localinstall http://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
+yum -y localinstall https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el6/x86_64/katello-repos-latest.rpm
+yum -y localinstall https://yum.theforeman.org/releases/{{ page.foreman_version }}/el6/x86_64/foreman-release.rpm
+yum -y localinstall https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
 {% endhighlight %}
 </div>
 
@@ -55,9 +55,9 @@ yum-config-manager --enable rhel-7-server-extras-rpms
 
 <div id="el7" style="display: none;" markdown="1">
 {% highlight bash %}
-yum -y localinstall http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el7/x86_64/katello-repos-latest.rpm
-yum -y localinstall http://yum.theforeman.org/releases/{{ page.foreman_version }}/el7/x86_64/foreman-release.rpm
-yum -y localinstall http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+yum -y localinstall https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el7/x86_64/katello-repos-latest.rpm
+yum -y localinstall https://yum.theforeman.org/releases/{{ page.foreman_version }}/el7/x86_64/foreman-release.rpm
+yum -y localinstall https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 {% endhighlight %}
 </div>
 

--- a/plugins/katello/3.4/installation/clients.md
+++ b/plugins/katello/3.4/installation/clients.md
@@ -26,35 +26,35 @@ Install the appropriate Katello client release packages.  For CentOS 6, you will
 
 <div id="el5" markdown="1">
 {% highlight bash %}
-yum install -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/el5/x86_64/katello-client-repos-latest.rpm
-yum -y install http://dl.fedoraproject.org/pub/epel/epel-release-latest-5.noarch.rpm
+yum install -y https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/el5/x86_64/katello-client-repos-latest.rpm
+yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-5.noarch.rpm
 {% endhighlight %}
 </div>
 
 <div id="el6" style="display:none;" markdown="1">
 {% highlight bash %}
 wget https://copr.fedoraproject.org/coprs/dgoodwin/subscription-manager/repo/epel-6/dgoodwin-subscription-manager-epel-6.repo -O /etc/yum.repos.d/dgoodwin-subscription-manager-epel-6.repo
-yum -y install http://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
-yum install -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/el6/x86_64/katello-client-repos-latest.rpm
+yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
+yum install -y https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/el6/x86_64/katello-client-repos-latest.rpm
 {% endhighlight %}
 </div>
 
 <div id="el7" style="display:none;" markdown="1">
 {% highlight bash %}
-yum install -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/el7/x86_64/katello-client-repos-latest.rpm
-yum -y install http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+yum install -y https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/el7/x86_64/katello-client-repos-latest.rpm
+yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 {% endhighlight %}
 </div>
 
 <div id="f22" style="display:none;" markdown="1">
 {% highlight bash %}
-yum install -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/f22/x86_64/katello-client-repos-latest.rpm
+yum install -y https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/f22/x86_64/katello-client-repos-latest.rpm
 {% endhighlight %}
 </div>
 
 <div id="f23" style="display:none;" markdown="1">
 {% highlight bash %}
-yum install -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/f23/x86_64/katello-client-repos-latest.rpm
+yum install -y https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/f23/x86_64/katello-client-repos-latest.rpm
 {% endhighlight %}
 </div>
 

--- a/plugins/katello/3.4/installation/index.md
+++ b/plugins/katello/3.4/installation/index.md
@@ -100,12 +100,12 @@ yum-config-manager --enable rhel-7-server-extras-rpms
 
 <div id="el7" markdown="1">
 {% highlight bash %}
-yum -y localinstall http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el7/x86_64/katello-repos-latest.rpm
-yum -y localinstall http://yum.theforeman.org/releases/{{ page.foreman_version }}/el7/x86_64/foreman-release.rpm
+yum -y localinstall https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el7/x86_64/katello-repos-latest.rpm
+yum -y localinstall https://yum.theforeman.org/releases/{{ page.foreman_version }}/el7/x86_64/foreman-release.rpm
 yum -y localinstall https://yum.puppetlabs.com/puppetlabs-release-pc1-el-7.noarch.rpm # will install with Puppet 4
-#yum -y localinstall http://yum.puppetlabs.com/puppetlabs-release-el-7.noarch.rpm # use this instead if you prefer Puppet 3
+#yum -y localinstall https://yum.puppetlabs.com/puppetlabs-release-el-7.noarch.rpm # use this instead if you prefer Puppet 3
 
-yum -y localinstall http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+yum -y localinstall https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 yum -y install foreman-release-scl
 {% endhighlight %}
 </div>

--- a/plugins/katello/3.4/troubleshooting/index.md
+++ b/plugins/katello/3.4/troubleshooting/index.md
@@ -197,10 +197,10 @@ Katello 3.0 generates a client cert at installation time which allows usage of p
 
 Sometimes you want to debug why a synchronization of a repository from Katello is failing and rather than dig through log files and error messages it can often be easier to try to sync the repo with the ''grinder'' tool which is what Katello uses to download repositories.  The tool can be ran from a terminal on your Katello server:
 
-    $ grinder yum --label=sync-test --url=http://fedorapeople.org/groups/katello/releases/yum/1.0/RHEL/6Server/x86_64/
+    $ grinder yum --label=sync-test --url=https://fedorapeople.org/groups/katello/releases/yum/1.0/RHEL/6Server/x86_64/
     grinder.RepoFetch: INFO     fetchYumRepo() repo_label = sync-test, repo_url =
-    http://fedorapeople.org/groups/katello/releases/yum/1.0/RHEL/6Server/x86_64/, basepath = ./, verify_options = {}
-    grinder.RepoFetch: INFO     sync-test, http://fedorapeople.org/groups/katello/releases/yum/1.0/RHEL/6Server/x86_64/,
+    https://fedorapeople.org/groups/katello/releases/yum/1.0/RHEL/6Server/x86_64/, basepath = ./, verify_options = {}
+    grinder.RepoFetch: INFO     sync-test, https://fedorapeople.org/groups/katello/releases/yum/1.0/RHEL/6Server/x86_64/,
     Calling RepoFetch with: cacert=<None>, clicert=<None>, clikey=<None>, proxy_url=<None>, proxy_port=<3128>, proxy_user=<None>,
     proxy_pass=<NOT_LOGGED>, sslverify=<1>, max_speed=<None>, verify_options=<{}>, filter=<None>
     ....

--- a/plugins/katello/3.4/upgrade/clients.md
+++ b/plugins/katello/3.4/upgrade/clients.md
@@ -28,34 +28,34 @@ Update the Katello client release packages:
 
 <div id="el5" markdown="1">
 {% highlight bash %}
-yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/el5/x86_64/katello-client-repos-latest.rpm
-yum -y install http://dl.fedoraproject.org/pub/epel/epel-release-latest-5.noarch.rpm
+yum update -y https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/el5/x86_64/katello-client-repos-latest.rpm
+yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-5.noarch.rpm
 {% endhighlight %}
 </div>
 
 <div id="el6" style="display:none;" markdown="1">
 {% highlight bash %}
-yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/el6/x86_64/katello-client-repos-latest.rpm
-yum -y install http://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
+yum update -y https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/el6/x86_64/katello-client-repos-latest.rpm
+yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
 {% endhighlight %}
 </div>
 
 <div id="el7" style="display:none;" markdown="1">
 {% highlight bash %}
-yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/el7/x86_64/katello-client-repos-latest.rpm
-yum -y install http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+yum update -y https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/el7/x86_64/katello-client-repos-latest.rpm
+yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 {% endhighlight %}
 </div>
 
 <div id="fc24" style="display:none;" markdown="1">
 {% highlight bash %}
-yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/fc24/x86_64/katello-client-repos-latest.rpm
+yum update -y https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/fc24/x86_64/katello-client-repos-latest.rpm
 {% endhighlight %}
 </div>
 
 <div id="fc25" style="display:none;" markdown="1">
 {% highlight bash %}
-yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/fc25/x86_64/katello-client-repos-latest.rpm
+yum update -y https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/fc25/x86_64/katello-client-repos-latest.rpm
 {% endhighlight %}
 </div>
 

--- a/plugins/katello/3.4/upgrade/index.md
+++ b/plugins/katello/3.4/upgrade/index.md
@@ -38,8 +38,8 @@ Update the Foreman and Katello release packages:
   * RHEL7 / CentOS 7:
 
 {% highlight bash %}
-  yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el7/x86_64/katello-repos-latest.rpm
-  yum update -y http://yum.theforeman.org/releases/{{ page.foreman_version }}/el7/x86_64/foreman-release.rpm
+  yum update -y https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el7/x86_64/katello-repos-latest.rpm
+  yum update -y https://yum.theforeman.org/releases/{{ page.foreman_version }}/el7/x86_64/foreman-release.rpm
   yum update -y foreman-release-scl
 {% endhighlight %}
 

--- a/plugins/katello/3.4/upgrade/smart_proxy.md
+++ b/plugins/katello/3.4/upgrade/smart_proxy.md
@@ -24,8 +24,8 @@ Update the Foreman and Katello release packages:
   * RHEL7 / CentOS 7:
 
 {% highlight bash %}
-  yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el7/x86_64/katello-repos-latest.rpm
-  yum update -y http://yum.theforeman.org/releases/{{ page.foreman_version }}/el7/x86_64/foreman-release.rpm
+  yum update -y https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el7/x86_64/katello-repos-latest.rpm
+  yum update -y https://yum.theforeman.org/releases/{{ page.foreman_version }}/el7/x86_64/foreman-release.rpm
 {% endhighlight %}
 
 ## Step 3 - Update Packages

--- a/plugins/katello/3.4/user_guide/content/index.md
+++ b/plugins/katello/3.4/user_guide/content/index.md
@@ -39,7 +39,7 @@ Content > Products > Select desired product > Create Repository (right hand side
 Note the following options:
 
 * Publish via HTTP: allows access to the Repository without any restriction.  Unless you desire to restrict access to your content in this Repository, we recommended to leave this checked.
-* URL: If you are syncing from an external Repository (yum or puppet), this would be filled in. This can be changed, added, or removed later.  For example if you are wanting to create a mirror of EPEL, you would set this to 'http://dl.fedoraproject.org/pub/epel/6/x86_64/'.
+* URL: If you are syncing from an external Repository (yum or puppet), this would be filled in. This can be changed, added, or removed later.  For example if you are wanting to create a mirror of EPEL, you would set this to 'https://dl.fedoraproject.org/pub/epel/6/x86_64/'.
 
 ![Creating a Repository](/plugins/katello/{{ page.version }}/user_guide/content/repo_create.png)
 

--- a/plugins/katello/3.5/cli/index.md
+++ b/plugins/katello/3.5/cli/index.md
@@ -37,9 +37,9 @@ yum-config-manager --enable rhel-6-server-optional-rpms
 
 <div id="el6" markdown="1">
 {% highlight bash %}
-yum -y localinstall http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el6/x86_64/katello-repos-latest.rpm
-yum -y localinstall http://yum.theforeman.org/releases/{{ page.foreman_version }}/el6/x86_64/foreman-release.rpm
-yum -y localinstall http://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
+yum -y localinstall https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el6/x86_64/katello-repos-latest.rpm
+yum -y localinstall https://yum.theforeman.org/releases/{{ page.foreman_version }}/el6/x86_64/foreman-release.rpm
+yum -y localinstall https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
 {% endhighlight %}
 </div>
 
@@ -55,9 +55,9 @@ yum-config-manager --enable rhel-7-server-extras-rpms
 
 <div id="el7" style="display: none;" markdown="1">
 {% highlight bash %}
-yum -y localinstall http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el7/x86_64/katello-repos-latest.rpm
-yum -y localinstall http://yum.theforeman.org/releases/{{ page.foreman_version }}/el7/x86_64/foreman-release.rpm
-yum -y localinstall http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+yum -y localinstall https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el7/x86_64/katello-repos-latest.rpm
+yum -y localinstall https://yum.theforeman.org/releases/{{ page.foreman_version }}/el7/x86_64/foreman-release.rpm
+yum -y localinstall https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 {% endhighlight %}
 </div>
 

--- a/plugins/katello/3.5/installation/clients.md
+++ b/plugins/katello/3.5/installation/clients.md
@@ -26,35 +26,35 @@ Install the appropriate Katello client release packages.  For CentOS 6, you will
 
 <div id="el5" markdown="1">
 {% highlight bash %}
-yum install -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/el5/x86_64/katello-client-repos-latest.rpm
-yum -y install http://dl.fedoraproject.org/pub/epel/epel-release-latest-5.noarch.rpm
+yum install -y https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/el5/x86_64/katello-client-repos-latest.rpm
+yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-5.noarch.rpm
 {% endhighlight %}
 </div>
 
 <div id="el6" style="display:none;" markdown="1">
 {% highlight bash %}
 wget https://copr.fedoraproject.org/coprs/dgoodwin/subscription-manager/repo/epel-6/dgoodwin-subscription-manager-epel-6.repo -O /etc/yum.repos.d/dgoodwin-subscription-manager-epel-6.repo
-yum -y install http://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
-yum install -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/el6/x86_64/katello-client-repos-latest.rpm
+yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
+yum install -y https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/el6/x86_64/katello-client-repos-latest.rpm
 {% endhighlight %}
 </div>
 
 <div id="el7" style="display:none;" markdown="1">
 {% highlight bash %}
-yum install -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/el7/x86_64/katello-client-repos-latest.rpm
-yum -y install http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+yum install -y https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/el7/x86_64/katello-client-repos-latest.rpm
+yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 {% endhighlight %}
 </div>
 
 <div id="f22" style="display:none;" markdown="1">
 {% highlight bash %}
-yum install -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/f22/x86_64/katello-client-repos-latest.rpm
+yum install -y https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/f22/x86_64/katello-client-repos-latest.rpm
 {% endhighlight %}
 </div>
 
 <div id="f23" style="display:none;" markdown="1">
 {% highlight bash %}
-yum install -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/f23/x86_64/katello-client-repos-latest.rpm
+yum install -y https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/f23/x86_64/katello-client-repos-latest.rpm
 {% endhighlight %}
 </div>
 

--- a/plugins/katello/3.5/installation/index.md
+++ b/plugins/katello/3.5/installation/index.md
@@ -101,10 +101,10 @@ yum-config-manager --enable rhel-7-server-extras-rpms
 
 <div id="el7" markdown="1">
 {% highlight bash %}
-yum -y localinstall http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el7/x86_64/katello-repos-latest.rpm
-yum -y localinstall http://yum.theforeman.org/releases/{{ page.foreman_version }}/el7/x86_64/foreman-release.rpm
+yum -y localinstall https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el7/x86_64/katello-repos-latest.rpm
+yum -y localinstall https://yum.theforeman.org/releases/{{ page.foreman_version }}/el7/x86_64/foreman-release.rpm
 yum -y localinstall https://yum.puppetlabs.com/puppetlabs-release-pc1-el-7.noarch.rpm
-yum -y localinstall http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+yum -y localinstall https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 yum -y install foreman-release-scl python-django
 {% endhighlight %}
 </div>

--- a/plugins/katello/3.5/troubleshooting/index.md
+++ b/plugins/katello/3.5/troubleshooting/index.md
@@ -197,10 +197,10 @@ Katello 3.0 generates a client cert at installation time which allows usage of p
 
 Sometimes you want to debug why a synchronization of a repository from Katello is failing and rather than dig through log files and error messages it can often be easier to try to sync the repo with the ''grinder'' tool which is what Katello uses to download repositories.  The tool can be ran from a terminal on your Katello server:
 
-    $ grinder yum --label=sync-test --url=http://fedorapeople.org/groups/katello/releases/yum/1.0/RHEL/6Server/x86_64/
+    $ grinder yum --label=sync-test --url=https://fedorapeople.org/groups/katello/releases/yum/1.0/RHEL/6Server/x86_64/
     grinder.RepoFetch: INFO     fetchYumRepo() repo_label = sync-test, repo_url = 
-    http://fedorapeople.org/groups/katello/releases/yum/1.0/RHEL/6Server/x86_64/, basepath = ./, verify_options = {}
-    grinder.RepoFetch: INFO     sync-test, http://fedorapeople.org/groups/katello/releases/yum/1.0/RHEL/6Server/x86_64/, 
+    https://fedorapeople.org/groups/katello/releases/yum/1.0/RHEL/6Server/x86_64/, basepath = ./, verify_options = {}
+    grinder.RepoFetch: INFO     sync-test, https://fedorapeople.org/groups/katello/releases/yum/1.0/RHEL/6Server/x86_64/, 
     Calling RepoFetch with: cacert=<None>, clicert=<None>, clikey=<None>, proxy_url=<None>, proxy_port=<3128>, proxy_user=<None>, 
     proxy_pass=<NOT_LOGGED>, sslverify=<1>, max_speed=<None>, verify_options=<{}>, filter=<None>
     ....

--- a/plugins/katello/3.5/upgrade/clients.md
+++ b/plugins/katello/3.5/upgrade/clients.md
@@ -28,34 +28,34 @@ Update the Katello client release packages:
 
 <div id="el5" markdown="1">
 {% highlight bash %}
-yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/el5/x86_64/katello-client-repos-latest.rpm
-yum -y install http://dl.fedoraproject.org/pub/epel/epel-release-latest-5.noarch.rpm
+yum update -y https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/el5/x86_64/katello-client-repos-latest.rpm
+yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-5.noarch.rpm
 {% endhighlight %}
 </div>
 
 <div id="el6" style="display:none;" markdown="1">
 {% highlight bash %}
-yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/el6/x86_64/katello-client-repos-latest.rpm
-yum -y install http://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
+yum update -y https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/el6/x86_64/katello-client-repos-latest.rpm
+yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
 {% endhighlight %}
 </div>
 
 <div id="el7" style="display:none;" markdown="1">
 {% highlight bash %}
-yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/el7/x86_64/katello-client-repos-latest.rpm
-yum -y install http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+yum update -y https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/el7/x86_64/katello-client-repos-latest.rpm
+yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 {% endhighlight %}
 </div>
 
 <div id="fc24" style="display:none;" markdown="1">
 {% highlight bash %}
-yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/fc24/x86_64/katello-client-repos-latest.rpm
+yum update -y https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/fc24/x86_64/katello-client-repos-latest.rpm
 {% endhighlight %}
 </div>
 
 <div id="fc25" style="display:none;" markdown="1">
 {% highlight bash %}
-yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/fc25/x86_64/katello-client-repos-latest.rpm
+yum update -y https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/fc25/x86_64/katello-client-repos-latest.rpm
 {% endhighlight %}
 </div>
 

--- a/plugins/katello/3.5/upgrade/index.md
+++ b/plugins/katello/3.5/upgrade/index.md
@@ -41,8 +41,8 @@ Update the Foreman and Katello release packages:
   * RHEL7 / CentOS 7:
 
 {% highlight bash %}
-  yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el7/x86_64/katello-repos-latest.rpm
-  yum update -y http://yum.theforeman.org/releases/{{ page.foreman_version }}/el7/x86_64/foreman-release.rpm
+  yum update -y https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el7/x86_64/katello-repos-latest.rpm
+  yum update -y https://yum.theforeman.org/releases/{{ page.foreman_version }}/el7/x86_64/foreman-release.rpm
   yum update -y foreman-release-scl
 {% endhighlight %}
 

--- a/plugins/katello/3.5/upgrade/smart_proxy.md
+++ b/plugins/katello/3.5/upgrade/smart_proxy.md
@@ -24,8 +24,8 @@ Update the Foreman and Katello release packages:
   * RHEL7 / CentOS 7:
 
 {% highlight bash %}
-  yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el7/x86_64/katello-repos-latest.rpm
-  yum update -y http://yum.theforeman.org/releases/{{ page.foreman_version }}/el7/x86_64/foreman-release.rpm
+  yum update -y https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el7/x86_64/katello-repos-latest.rpm
+  yum update -y https://yum.theforeman.org/releases/{{ page.foreman_version }}/el7/x86_64/foreman-release.rpm
 {% endhighlight %}
 
 ## Step 3 - Update Packages

--- a/plugins/katello/3.5/user_guide/content/index.md
+++ b/plugins/katello/3.5/user_guide/content/index.md
@@ -39,7 +39,7 @@ Content > Products > Select desired product > Create Repository (right hand side
 Note the following options:
 
 * Publish via HTTP: allows access to the Repository without any restriction.  Unless you desire to restrict access to your content in this Repository, we recommended to leave this checked.
-* URL: If you are syncing from an external Repository (yum or puppet), this would be filled in. This can be changed, added, or removed later.  For example if you are wanting to create a mirror of EPEL, you would set this to 'http://dl.fedoraproject.org/pub/epel/6/x86_64/'.
+* URL: If you are syncing from an external Repository (yum or puppet), this would be filled in. This can be changed, added, or removed later.  For example if you are wanting to create a mirror of EPEL, you would set this to 'https://dl.fedoraproject.org/pub/epel/6/x86_64/'.
 
 ![Creating a Repository](/plugins/katello/{{ page.version }}/user_guide/content/repo_create.png)
 

--- a/plugins/katello/nightly/cli/index.md
+++ b/plugins/katello/nightly/cli/index.md
@@ -37,9 +37,9 @@ yum-config-manager --enable rhel-6-server-optional-rpms
 
 <div id="el6" markdown="1">
 {% highlight bash %}
-yum -y localinstall http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el6/x86_64/katello-repos-latest.rpm
-yum -y localinstall http://yum.theforeman.org/releases/{{ page.foreman_version }}/el6/x86_64/foreman-release.rpm
-yum -y localinstall http://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
+yum -y localinstall https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el6/x86_64/katello-repos-latest.rpm
+yum -y localinstall https://yum.theforeman.org/releases/{{ page.foreman_version }}/el6/x86_64/foreman-release.rpm
+yum -y localinstall https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
 {% endhighlight %}
 </div>
 
@@ -55,9 +55,9 @@ yum-config-manager --enable rhel-7-server-extras-rpms
 
 <div id="el7" style="display: none;" markdown="1">
 {% highlight bash %}
-yum -y localinstall http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el7/x86_64/katello-repos-latest.rpm
-yum -y localinstall http://yum.theforeman.org/releases/{{ page.foreman_version }}/el7/x86_64/foreman-release.rpm
-yum -y localinstall http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+yum -y localinstall https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el7/x86_64/katello-repos-latest.rpm
+yum -y localinstall https://yum.theforeman.org/releases/{{ page.foreman_version }}/el7/x86_64/foreman-release.rpm
+yum -y localinstall https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 {% endhighlight %}
 </div>
 

--- a/plugins/katello/nightly/installation/clients.md
+++ b/plugins/katello/nightly/installation/clients.md
@@ -26,35 +26,35 @@ Install the appropriate Katello client release packages.  For CentOS 6, you will
 
 <div id="el5" markdown="1">
 {% highlight bash %}
-yum install -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/el5/x86_64/katello-client-repos-latest.rpm
-yum -y install http://dl.fedoraproject.org/pub/epel/epel-release-latest-5.noarch.rpm
+yum install -y https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/el5/x86_64/katello-client-repos-latest.rpm
+yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-5.noarch.rpm
 {% endhighlight %}
 </div>
 
 <div id="el6" style="display:none;" markdown="1">
 {% highlight bash %}
 wget https://copr.fedoraproject.org/coprs/dgoodwin/subscription-manager/repo/epel-6/dgoodwin-subscription-manager-epel-6.repo -O /etc/yum.repos.d/dgoodwin-subscription-manager-epel-6.repo
-yum -y install http://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
-yum install -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/el6/x86_64/katello-client-repos-latest.rpm
+yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
+yum install -y https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/el6/x86_64/katello-client-repos-latest.rpm
 {% endhighlight %}
 </div>
 
 <div id="el7" style="display:none;" markdown="1">
 {% highlight bash %}
-yum install -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/el7/x86_64/katello-client-repos-latest.rpm
-yum -y install http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+yum install -y https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/el7/x86_64/katello-client-repos-latest.rpm
+yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 {% endhighlight %}
 </div>
 
 <div id="f22" style="display:none;" markdown="1">
 {% highlight bash %}
-yum install -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/f22/x86_64/katello-client-repos-latest.rpm
+yum install -y https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/f22/x86_64/katello-client-repos-latest.rpm
 {% endhighlight %}
 </div>
 
 <div id="f23" style="display:none;" markdown="1">
 {% highlight bash %}
-yum install -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/f23/x86_64/katello-client-repos-latest.rpm
+yum install -y https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/f23/x86_64/katello-client-repos-latest.rpm
 {% endhighlight %}
 </div>
 

--- a/plugins/katello/nightly/installation/index.md
+++ b/plugins/katello/nightly/installation/index.md
@@ -101,10 +101,10 @@ yum-config-manager --enable rhel-7-server-extras-rpms
 
 <div id="el7" markdown="1">
 {% highlight bash %}
-yum -y localinstall http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el7/x86_64/katello-repos-latest.rpm
-yum -y localinstall http://yum.theforeman.org/releases/{{ page.foreman_version }}/el7/x86_64/foreman-release.rpm
+yum -y localinstall https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el7/x86_64/katello-repos-latest.rpm
+yum -y localinstall https://yum.theforeman.org/releases/{{ page.foreman_version }}/el7/x86_64/foreman-release.rpm
 yum -y localinstall https://yum.puppetlabs.com/puppetlabs-release-pc1-el-7.noarch.rpm
-yum -y localinstall http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+yum -y localinstall https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 yum -y install foreman-release-scl
 {% endhighlight %}
 </div>

--- a/plugins/katello/nightly/troubleshooting/index.md
+++ b/plugins/katello/nightly/troubleshooting/index.md
@@ -197,10 +197,10 @@ Katello 3.0 generates a client cert at installation time which allows usage of p
 
 Sometimes you want to debug why a synchronization of a repository from Katello is failing and rather than dig through log files and error messages it can often be easier to try to sync the repo with the ''grinder'' tool which is what Katello uses to download repositories.  The tool can be ran from a terminal on your Katello server:
 
-    $ grinder yum --label=sync-test --url=http://fedorapeople.org/groups/katello/releases/yum/1.0/RHEL/6Server/x86_64/
+    $ grinder yum --label=sync-test --url=https://fedorapeople.org/groups/katello/releases/yum/1.0/RHEL/6Server/x86_64/
     grinder.RepoFetch: INFO     fetchYumRepo() repo_label = sync-test, repo_url = 
-    http://fedorapeople.org/groups/katello/releases/yum/1.0/RHEL/6Server/x86_64/, basepath = ./, verify_options = {}
-    grinder.RepoFetch: INFO     sync-test, http://fedorapeople.org/groups/katello/releases/yum/1.0/RHEL/6Server/x86_64/, 
+    https://fedorapeople.org/groups/katello/releases/yum/1.0/RHEL/6Server/x86_64/, basepath = ./, verify_options = {}
+    grinder.RepoFetch: INFO     sync-test, https://fedorapeople.org/groups/katello/releases/yum/1.0/RHEL/6Server/x86_64/, 
     Calling RepoFetch with: cacert=<None>, clicert=<None>, clikey=<None>, proxy_url=<None>, proxy_port=<3128>, proxy_user=<None>, 
     proxy_pass=<NOT_LOGGED>, sslverify=<1>, max_speed=<None>, verify_options=<{}>, filter=<None>
     ....

--- a/plugins/katello/nightly/upgrade/clients.md
+++ b/plugins/katello/nightly/upgrade/clients.md
@@ -28,34 +28,34 @@ Update the Katello client release packages:
 
 <div id="el5" markdown="1">
 {% highlight bash %}
-yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/el5/x86_64/katello-client-repos-latest.rpm
-yum -y install http://dl.fedoraproject.org/pub/epel/epel-release-latest-5.noarch.rpm
+yum update -y https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/el5/x86_64/katello-client-repos-latest.rpm
+yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-5.noarch.rpm
 {% endhighlight %}
 </div>
 
 <div id="el6" style="display:none;" markdown="1">
 {% highlight bash %}
-yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/el6/x86_64/katello-client-repos-latest.rpm
-yum -y install http://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
+yum update -y https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/el6/x86_64/katello-client-repos-latest.rpm
+yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
 {% endhighlight %}
 </div>
 
 <div id="el7" style="display:none;" markdown="1">
 {% highlight bash %}
-yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/el7/x86_64/katello-client-repos-latest.rpm
-yum -y install http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+yum update -y https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/el7/x86_64/katello-client-repos-latest.rpm
+yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 {% endhighlight %}
 </div>
 
 <div id="fc24" style="display:none;" markdown="1">
 {% highlight bash %}
-yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/fc24/x86_64/katello-client-repos-latest.rpm
+yum update -y https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/fc24/x86_64/katello-client-repos-latest.rpm
 {% endhighlight %}
 </div>
 
 <div id="fc25" style="display:none;" markdown="1">
 {% highlight bash %}
-yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/fc25/x86_64/katello-client-repos-latest.rpm
+yum update -y https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/fc25/x86_64/katello-client-repos-latest.rpm
 {% endhighlight %}
 </div>
 

--- a/plugins/katello/nightly/upgrade/index.md
+++ b/plugins/katello/nightly/upgrade/index.md
@@ -39,8 +39,8 @@ Update the Foreman and Katello release packages:
   * RHEL7 / CentOS 7:
 
 {% highlight bash %}
-  yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el7/x86_64/katello-repos-latest.rpm
-  yum update -y http://yum.theforeman.org/releases/{{ page.foreman_version }}/el7/x86_64/foreman-release.rpm
+  yum update -y https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el7/x86_64/katello-repos-latest.rpm
+  yum update -y https://yum.theforeman.org/releases/{{ page.foreman_version }}/el7/x86_64/foreman-release.rpm
   yum update -y foreman-release-scl
 {% endhighlight %}
 

--- a/plugins/katello/nightly/upgrade/smart_proxy.md
+++ b/plugins/katello/nightly/upgrade/smart_proxy.md
@@ -24,8 +24,8 @@ Update the Foreman and Katello release packages:
   * RHEL7 / CentOS 7:
 
 {% highlight bash %}
-  yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el7/x86_64/katello-repos-latest.rpm
-  yum update -y http://yum.theforeman.org/releases/{{ page.foreman_version }}/el7/x86_64/foreman-release.rpm
+  yum update -y https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el7/x86_64/katello-repos-latest.rpm
+  yum update -y https://yum.theforeman.org/releases/{{ page.foreman_version }}/el7/x86_64/foreman-release.rpm
 {% endhighlight %}
 
 ## Step 3 - Update Packages

--- a/plugins/katello/nightly/user_guide/content/index.md
+++ b/plugins/katello/nightly/user_guide/content/index.md
@@ -39,7 +39,7 @@ Content > Products > Select desired product > Create Repository (right hand side
 Note the following options:
 
 * Publish via HTTP: allows access to the Repository without any restriction.  Unless you desire to restrict access to your content in this Repository, we recommended to leave this checked.
-* URL: If you are syncing from an external Repository (yum or puppet), this would be filled in. This can be changed, added, or removed later.  For example if you are wanting to create a mirror of EPEL, you would set this to 'http://dl.fedoraproject.org/pub/epel/6/x86_64/'.
+* URL: If you are syncing from an external Repository (yum or puppet), this would be filled in. This can be changed, added, or removed later.  For example if you are wanting to create a mirror of EPEL, you would set this to 'https://dl.fedoraproject.org/pub/epel/6/x86_64/'.
 
 ![Creating a Repository](/plugins/katello/{{ page.version }}/user_guide/content/repo_create.png)
 


### PR DESCRIPTION
RPMs should really not be downloaded over http, so I changed all the links in the Katello docs to https.

I checked the links, and yum.puppetlabs.com and dl.fedoraproject.org serves the same files on http and https and fedorapeople.org redirects http -> https.

Thanks.