### PR TITLE
Adding Discovery 10 and 11 docs

### DIFF
--- a/plugins/foreman_discovery/10.0/index.md
+++ b/plugins/foreman_discovery/10.0/index.md
@@ -1,16 +1,16 @@
 ---
 layout: plugin
 pluginname: foreman_discovery
-title: Foreman Discovery 9.1 Manual
-version: 9.1
+title: Foreman Discovery 10.0 Manual
+version: 10.0
 # versions for matrix and snippets
 # (use short version for imgver e.g. 3.0)
-pluginver: 9.1.1
+pluginver: 10.0.0
 proxyver: 1.0.4
 imgver: 3.4
 cliver: 1.0.0
 # uncomment to show warning box for an old release
-warning: old
+#warning: old
 # uncomment to show development version warning
 #warning: unreleased
 ---
@@ -135,6 +135,13 @@ plugin:
   </tr>
   <tr>
     <td>= 1.15</td>
+    <td>9.1.0</td>
+    <td>1.0.4</td>
+    <td>3.3-3.4</td>
+    <td>1.0.0</td>
+  </tr>
+  <tr>
+    <td>= 1.16</td>
     <td>{{page.pluginver}}</td>
     <td>{{page.proxyver}}</td>
     <td>{{page.imgver}}</td>
@@ -143,6 +150,33 @@ plugin:
 </table>
 
 ### 1.1.1 Foreman Discovery plugin
+
+**10.0**: Release notes
+
+Upgrade to Rails 5 is major change in this release. Starting from this version,
+we are improving user interface of Discovery pages to match core standards and
+Patternfly style. Missing PXE loader option was added to API V2 endpoint.
+
+    Fixes #20881 - Clean legacy api from discovery
+    Fixes #21244 - Rails 5 upgrade test failures
+    Fixes #20337 - Add pxe loader into discovery v2 API
+    Fixes #21153 - Passing conditions to destroy_all is deprecated
+    Fixes #21123 - Changed populate_fields_from_facts signature
+    Fixes #20215 - Fix the accordian for Expand All button
+     Refs #20564 - Ignore locking in migration
+     Refs #20971 - correct typo in before_action
+    Fixes #20971 - replace *_filter with *_action
+    Fixes #20970 - Allow discovery via fact import in Rails 5
+    Fixes #20564 - ignore locking in migration
+    Fixes #20162 - Fix the modal for provisioning on index page.
+    Fixes #20497 - host provisioning build mode enabled
+    Fixes #20290 - kexec now produces valid JSON output
+    Fixes #20387 - Clean redundant code for auto complete search
+    Fixes #20269 - Use the inline messaging warning
+    Fixes #20294 - taxonomy via fact fixed, scripts
+    Fixes #20247 - Add welcome page to foreman discovery
+    Fixes #20188 - Change color of 'delete' button to grey
+    Fixes #20170 - Fix the UI for delete modal
 
 **9.1**: Release notes
 

--- a/plugins/foreman_discovery/11.0/index.md
+++ b/plugins/foreman_discovery/11.0/index.md
@@ -1199,6 +1199,14 @@ networking, if the deployment does not provide DHCP services, otherwise
 Anaconda will fail to install the system after kernel reload. Also check if
 netmask, gateway and primary DNS server is present on the associated Subnet.
 
+Some graphic drivers renders console unusable after kexec. From image version
+3.4.4 all KMS drivers were removed and kernel uses the default VGA 80x25 mode.
+Frozen console or graphic artifacts can be solved by choosing a different
+driver when using virtualization or selecting older hardware emulation version
+(VMWare version 4 or 5). When reporting graphic driver issues, attach "lsmod"
+output from discovered nodes and try to blacklist "kms" drivers as a
+workaround.
+
 ### 5.3.1 Unattended and semi-automatic mode
 
 All interactive screens can be fully automated via kernel command line that can

--- a/plugins/foreman_discovery/11.0/index.md
+++ b/plugins/foreman_discovery/11.0/index.md
@@ -1,18 +1,18 @@
 ---
 layout: plugin
 pluginname: foreman_discovery
-title: Foreman Discovery 9.1 Manual
-version: 9.1
+title: Foreman Discovery 11.0 Manual
+version: 11.0
 # versions for matrix and snippets
 # (use short version for imgver e.g. 3.0)
-pluginver: 9.1.1
+pluginver: 11.0.0
 proxyver: 1.0.4
 imgver: 3.4
 cliver: 1.0.0
 # uncomment to show warning box for an old release
-warning: old
+#warning: old
 # uncomment to show development version warning
-#warning: unreleased
+warning: unreleased
 ---
 
 # 1. {{ page.title }}
@@ -135,6 +135,20 @@ plugin:
   </tr>
   <tr>
     <td>= 1.15</td>
+    <td>9.1.0</td>
+    <td>1.0.4</td>
+    <td>3.3-3.4</td>
+    <td>1.0.0</td>
+  </tr>
+  <tr>
+    <td>= 1.16</td>
+    <td>10.0.0</td>
+    <td>1.0.4</td>
+    <td>3.4</td>
+    <td>1.0.0</td>
+  </tr>
+  <tr>
+    <td>= 1.17</td>
     <td>{{page.pluginver}}</td>
     <td>{{page.proxyver}}</td>
     <td>{{page.imgver}}</td>
@@ -143,6 +157,57 @@ plugin:
 </table>
 
 ### 1.1.1 Foreman Discovery plugin
+
+**11.0**: Release notes
+
+Main theme of this release was catching up with core in this cycle with biggest
+items Rails 5 upgrade, migration to FactoryBot and improved fact importer. Some
+changes in UI and integration testing are also part of this release, more to
+come.
+
+Complete list of changes:
+
+    Fixes #22297 - Fixed the pagination
+    Fixes #22145 - Set engine_name properly
+     Refs #22083 - Remove config/as_deprecation_whitelist.yaml
+    Fixes #21934 - Allow searching discovered host by taxonomy id
+    Fixes #21959 - Removed positional args from tests
+    Fixes #21819 - Add Rails 5 style migrations
+    Fixes #21908 - Safemode doesn’t allow to access ‘resbody’ on rescue
+    Fixes #21890 - Fact importer transaction check suppress in tests
+    Fixes #19440 - Integration test provisioning discovered hosts
+    Fixes #21527 - Start using factory bot
+    Fixes #20381 - Improved error message during kexec
+    Fixes #21087 - Correct Api doc for discovery rules
+    Fixes #21407 - Fix broken foreign keys
+    Fixes #21417 - Host update propagates facets
+
+**10.0**: Release notes
+
+Upgrade to Rails 5 is major change in this release. Starting from this version,
+we are improving user interface of Discovery pages to match core standards and
+Patternfly style. Missing PXE loader option was added to API V2 endpoint.
+
+    Fixes #20881 - Clean legacy api from discovery
+    Fixes #21244 - Rails 5 upgrade test failures
+    Fixes #20337 - Add pxe loader into discovery v2 API
+    Fixes #21153 - Passing conditions to destroy_all is deprecated
+    Fixes #21123 - Changed populate_fields_from_facts signature
+    Fixes #20215 - Fix the accordian for Expand All button
+     Refs #20564 - Ignore locking in migration
+     Refs #20971 - correct typo in before_action
+    Fixes #20971 - replace *_filter with *_action
+    Fixes #20970 - Allow discovery via fact import in Rails 5
+    Fixes #20564 - ignore locking in migration
+    Fixes #20162 - Fix the modal for provisioning on index page.
+    Fixes #20497 - host provisioning build mode enabled
+    Fixes #20290 - kexec now produces valid JSON output
+    Fixes #20387 - Clean redundant code for auto complete search
+    Fixes #20269 - Use the inline messaging warning
+    Fixes #20294 - taxonomy via fact fixed, scripts
+    Fixes #20247 - Add welcome page to foreman discovery
+    Fixes #20188 - Change color of 'delete' button to grey
+    Fixes #20170 - Fix the UI for delete modal
 
 **9.1**: Release notes
 

--- a/plugins/foreman_discovery/index.md
+++ b/plugins/foreman_discovery/index.md
@@ -1,7 +1,7 @@
 ---
 layout: plugin_index
 title: Foreman discovery documentation
-versions: [9.1, 8.0, 7.0, 6.0, 5.0, 4.1, 4.0, 3.0, 2.0]
+versions: [11.0, 10.0, 9.1, 8.0, 7.0, 6.0, 5.0, 4.1, 4.0, 3.0, 2.0]
 ---
 
 # Foreman discovery manuals


### PR DESCRIPTION
Looks like I forgot to add 10.0 when I released it.

This patch also adds 11.0 docs, there is unreleased warning box for now.

Also adds a paragraph about KMS driver issue in separate commit