### PR TITLE
change "Product Content" to "Repository Sets"

### DIFF
--- a/plugins/katello/3.5/user_guide/activation_keys/index.md
+++ b/plugins/katello/3.5/user_guide/activation_keys/index.md
@@ -94,10 +94,9 @@ To change repository enablement settings using a key:
 
 - navigate to: Content > Activation Keys
 - select the desired key from the list
-- click **Product Content**
-- click the edit icon for the repository content set that you would like to modify
-- select the desired value (e.g. 'Override to Yes', 'Override to No', 'Defaults to Yes', 'Defaults to No')
-- click **Save**
+- click **Repository Sets**
+- check the boxes for the repositories that you would like to modify
+- click **Select Action** and choose the desired value (e.g. 'Override to Enabled', 'Override to Disabled', 'Reset to Default')
 
 View current settings:
 ![Activation key product content](/plugins/katello/{{ page.version }}/user_guide/activation_keys/activation_key_product_content.png)


### PR DESCRIPTION
In 3.5 the "Product Content" tab appears to have been renamed to "Repository Sets".  The edit button has also been removed, so add a description for the new checkbox/bulk edit system.

The `activation_key_product_content.png` and `activation_key_product_content_change.png` pictures immediately following are also outdated now.  Is there a set way yall want those generated?