### PR TITLE
Replace survey frontpage banner with link to OpenSourceCamp

### DIFF
--- a/_includes/alerts.html
+++ b/_includes/alerts.html
@@ -1,7 +1,7 @@
 <div class='tease'>
   <p>
-  <a>The 2018 Foreman Community Survey is now live.</a>
+  <a>Join us at OpenSourceCamp (14th June) for talks, coding, and discussions!</a>
     <br/>
-    <a href='https://t.co/g07Trr3NsE'>Tell us how we're doing!</a>
+    <a href='https://opensourcecamp.de/'>Get your ticket here!</a>
   </p>
 </div>


### PR DESCRIPTION
The survey is closed, and we need to start promoting our first conference :)