### PR TITLE
Style changes to remove the horizontal bar in the contribution page

### DIFF
--- a/contribute.md
+++ b/contribute.md
@@ -18,7 +18,7 @@ not consider [creating an event](https://github.com/theforeman/theforeman.org/bl
 The Foreman is an open-source project that's licensed under the GNU General Public License version 3.<br>
 Contributions of all types are gladly accepted!
 
-### Setting up a development environmnt
+### Setting up a development environment
 These types of tasks generally require a familiarity with Ruby (on Rails) development or RPM/Debian packaging. If you are still new to Rails, community members can help you if you get stuck with something or have any other questions.
 
 You will need to download a copy of the current development code. [The

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1034,6 +1034,7 @@ pre {
   background-color: #2f2f2f;
   line-height: 14px;
   height: auto;
+  max-width: 850px;
 }
 
 pre code {


### PR DESCRIPTION
Created a max-width for the code blocks to clear the horizontal scrolling bar and a typo in the contributing page.