### PR TITLE
Fix 1.17 manual

### DIFF
--- a/_includes/manuals/1.17/4.4.4_prov_ptables.md
+++ b/_includes/manuals/1.17/4.4.4_prov_ptables.md
@@ -132,6 +132,7 @@ part /     --fstype ext3 --size=1024 --grow
 part swap  --recommended
 ```
 * A script to dynamically calculate the desired sizes. E.G.
+
 ```
 #Dynamic - The below code is to manage the swap size
 


### PR DESCRIPTION
The Foreman 1.17 manual is currently broken because of a not starting code-box in 4.4.4, see:
<img width="1160" alt="foreman org missing5" src="https://user-images.githubusercontent.com/34890848/40181853-5c7f8d5e-59ea-11e8-8ea5-c0cad5ff2b3e.png">
This causes paragraphs 4.4.5-5.1 to not be displayed correctly (and also missing in the navigation on the left).
This PR fixes this and lets the manual be displayed correctly again.
<img width="1139" alt="theforeman org missing5 fixed" src="https://user-images.githubusercontent.com/34890848/40182062-d4506060-59ea-11e8-9e81-dabb17bb4cbc.png">

