### PR TITLE
Add 1.18 into doc menu

### DIFF
--- a/_includes/latest_news.html
+++ b/_includes/latest_news.html
@@ -1,2 +1,3 @@
+<p>Foreman 1.18.0-RC1 has been released! <a href="manuals/1.18/quickstart_guide.html"> Follow the quick start to install it.</a> and follow the <a href="manuals/1.18/quickstart_guide.html">quick start guide</a> to install it.</p>
 <p>Foreman 1.17.1 is now available with several bugfixes. <a href="manuals/1.17/quickstart_guide.html"> Follow the quick start to install it.</a></p>
 <p>A new bug fix release for Foreman 1.16 is now available. This release contains fixes for 2 security bugs and other minor patches. See the <a href="manuals/1.16/index.html#Releasenotesfor1.16.1">Foreman 1.16.1 release notes for more details.</a>.</p>

--- a/_includes/version.html
+++ b/_includes/version.html
@@ -1,8 +1,8 @@
 <div class="version-marker">
   <p>
     Latest versions:
-      <a href="{{ site.baseurl }}documentation.html#1.17">1.17.1</a>
+      <a href="{{ site.baseurl }}documentation.html#1.18">1.18.0-RC1</a>
 			/
-      <a href="{{ site.baseurl }}documentation.html#1.16">1.16.1</a>
+      <a href="{{ site.baseurl }}documentation.html#1.17">1.17.1</a>
   </p>
 </div>

--- a/documentation.md
+++ b/documentation.md
@@ -9,6 +9,7 @@ version: '1.17'
 <div class='dropdown'>
 	<a id='version' class='dropdown-toggle' data-toggle='dropdown'>Version {{page.version}} <span class="caret"></span></a>
 	<ul class="dropdown-menu" role="menu" aria-labelledby="version">
+    <li><a tabindex="-1">1.18</a></li>
     <li><a tabindex="-1">1.17</a></li>
     <li><a tabindex="-1">1.16</a></li>
 		<li><a tabindex="-1">1.15</a></li>


### PR DESCRIPTION
Adds 1.18 into the versions menu thus making the RC1 publicly visible. Should be merged after #1106 and #1100 

