### PR TITLE
Fix 4.4.4 layout

### DIFF
--- a/_includes/manuals/1.18/4.4.4_prov_ptables.md
+++ b/_includes/manuals/1.18/4.4.4_prov_ptables.md
@@ -34,7 +34,7 @@ fi
 cat <<EOF > /tmp/diskpart.cfg
 zerombr yes
 clearpart --all --initlabel
-part swap --size "$vir_mem" 
+part swap --size "$vir_mem"
 part /boot --fstype ext3 --size 100 --asprimary
 part / --fstype ext3 --size 1024 --grow
 EOF
@@ -120,7 +120,7 @@ cat <<EOF > /tmp/diskpart.cfg
 EOF
 sed '/<\/ntp-client>/ r /tmp/diskpart.cfg' /tmp/profile/autoinst.xml > /tmp/profile/modified.xml
 ```
-##### Configuration 
+##### Configuration
 
 A partition table entry represents either
 * An explicit layout for the partitions of your hard drive(s). E.G.
@@ -132,6 +132,7 @@ part /     --fstype ext3 --size=1024 --grow
 part swap  --recommended
 ```
 * A script to dynamically calculate the desired sizes. E.G.
+
 ```
 #Dynamic - The below code is to manage the swap size
 
@@ -158,12 +159,12 @@ part / --fstype ext3 --size 8192 --maxsize 12288 --grow
 part /tmp2 --size 250 --fstype ext3 --grow
 EOF
 ```
-The inclusion of the keyword string `#Dynamic` at the start of a line lets Foreman know that this is not an explicit 
-disk layout and must treated as a shell script, executed prior to the install process and that the explicit partition 
+The inclusion of the keyword string `#Dynamic` at the start of a line lets Foreman know that this is not an explicit
+disk layout and must treated as a shell script, executed prior to the install process and that the explicit partition
 table will be found at `/tmp/diskpart.cfg` during the build process.
 
-The dynamic partitioning style is currently only available for the Red Hat family of operating systems, 
+The dynamic partitioning style is currently only available for the Red Hat family of operating systems,
 all others must provide an explicit list of partitions and sizes.
 
-You may also associate one or more operating systems with this partition table or alternatively set this up later on 
+You may also associate one or more operating systems with this partition table or alternatively set this up later on
 the  Operating systems page.


### PR DESCRIPTION
![screenshot from 2018-06-20 10-20-41](https://user-images.githubusercontent.com/598891/41646507-4ba80958-7474-11e8-83d5-2fda148750c8.png)

Currently our 1.18 manual layout is broken after point 4.4.4. You may also check it yourself athttps://theforeman.org/manuals/1.18/#4.4.4PartitionTables - this PR fixes it