### PR TITLE
Removed TEMPLATE_CONTEXT from logs

### DIFF
--- a/_includes/manuals/nightly/7.2_debugging.md
+++ b/_includes/manuals/nightly/7.2_debugging.md
@@ -111,11 +111,6 @@ Here is the list of most important structured fields which can help with debuggi
     <td>Template name (blob logger)</td>
   </tr>
   <tr>
-    <td>TEMPLATE_CONTEXT</td>
-    <td>["ndc"]["template_context"]</td>
-    <td>Context of template renderer - Ruby class name (blob logger)</td>
-  </tr>
-  <tr>
     <td>TEMPLATE_DIGEST</td>
     <td>["ndc"]["template_digest"]</td>
     <td>Digest (SHA256) of rendered template contents (blob logger)</td>


### PR DESCRIPTION
This is for https://github.com/theforeman/foreman/pull/5683