### PR TITLE
Remove `password_hash` setting from the manual

### DIFF
--- a/_includes/manuals/1.10/3.5.2_configuration_options.md
+++ b/_includes/manuals/1.10/3.5.2_configuration_options.md
@@ -347,11 +347,6 @@ Default: 5
 In Puppet 2.6.5+, the ENC may send a hash of the class's attributes and values. Before then, the ENC used to send just an array of class names. Set this to _true_ if you are using any version of Puppet equal to or higher than 2.6.5.
 Default: true
 
-##### password_hash
-
-Changes the algorithm and format used to hash root passwords entered when creating new hosts or host groups.  This needs to be set to the lowest common denominator of operating systems that are provisioned from Foreman, but try to set it to the highest level (i.e. SHA-512) that all OSes support.  After changing the value, root passwords will need to be re-entered on existing hosts or host groups in order to re-hash them under the new algorithm.
-Default: MD5
-
 ##### proxy_request_timeout
 
 Timeout in seconds used when making REST requests to a Smart Proxy, e.g. when importing Puppet classes or creating DHCP records.  May be set to a larger value when certain operations take a long time.

--- a/_includes/manuals/1.11/3.5.2_configuration_options.md
+++ b/_includes/manuals/1.11/3.5.2_configuration_options.md
@@ -352,11 +352,6 @@ Default: 5
 In Puppet 2.6.5+, the ENC may send a hash of the class's attributes and values. Before then, the ENC used to send just an array of class names. Set this to _true_ if you are using any version of Puppet equal to or higher than 2.6.5.
 Default: true
 
-##### password_hash
-
-Changes the algorithm and format used to hash root passwords entered when creating new hosts or host groups.  This needs to be set to the lowest common denominator of operating systems that are provisioned from Foreman, but try to set it to the highest level (i.e. SHA-512) that all OSes support.  After changing the value, root passwords will need to be re-entered on existing hosts or host groups in order to re-hash them under the new algorithm.
-Default: MD5
-
 ##### proxy_request_timeout
 
 Timeout in seconds used when making REST requests to a Smart Proxy, e.g. when importing Puppet classes or creating DHCP records.  May be set to a larger value when certain operations take a long time.

--- a/_includes/manuals/1.12/3.5.2_configuration_options.md
+++ b/_includes/manuals/1.12/3.5.2_configuration_options.md
@@ -352,11 +352,6 @@ Default: 5
 In Puppet 2.6.5+, the ENC may send a hash of the class's attributes and values. Before then, the ENC used to send just an array of class names. Set this to _true_ if you are using any version of Puppet equal to or higher than 2.6.5.
 Default: true
 
-##### password_hash
-
-Changes the algorithm and format used to hash root passwords entered when creating new hosts or host groups.  This needs to be set to the lowest common denominator of operating systems that are provisioned from Foreman, but try to set it to the highest level (i.e. SHA-512) that all OSes support.  After changing the value, root passwords will need to be re-entered on existing hosts or host groups in order to re-hash them under the new algorithm.
-Default: MD5
-
 ##### proxy_request_timeout
 
 Timeout in seconds used when making REST requests to a Smart Proxy, e.g. when importing Puppet classes or creating DHCP records.  May be set to a larger value when certain operations take a long time.

--- a/_includes/manuals/1.13/3.5.2_configuration_options.md
+++ b/_includes/manuals/1.13/3.5.2_configuration_options.md
@@ -362,11 +362,6 @@ Default: 5
 In Puppet 2.6.5+, the ENC may send a hash of the class's attributes and values. Before then, the ENC used to send just an array of class names. Set this to _true_ if you are using any version of Puppet equal to or higher than 2.6.5.
 Default: true
 
-##### password_hash
-
-Changes the algorithm and format used to hash root passwords entered when creating new hosts or host groups.  This needs to be set to the lowest common denominator of operating systems that are provisioned from Foreman, but try to set it to the highest level (i.e. SHA-512) that all OSes support.  After changing the value, root passwords will need to be re-entered on existing hosts or host groups in order to re-hash them under the new algorithm.
-Default: MD5
-
 ##### proxy_request_timeout
 
 Timeout in seconds used when making REST requests to a Smart Proxy, e.g. when importing Puppet classes or creating DHCP records.  May be set to a larger value when certain operations take a long time.

--- a/_includes/manuals/1.14/3.5.2_configuration_options.md
+++ b/_includes/manuals/1.14/3.5.2_configuration_options.md
@@ -385,11 +385,6 @@ Default: 5
 In Puppet 2.6.5+, the ENC may send a hash of the class's attributes and values. Before then, the ENC used to send just an array of class names. Set this to _true_ if you are using any version of Puppet equal to or higher than 2.6.5.
 Default: true
 
-##### password_hash
-
-Changes the algorithm and format used to hash root passwords entered when creating new hosts or host groups.  This needs to be set to the lowest common denominator of operating systems that are provisioned from Foreman, but try to set it to the highest level (i.e. SHA-512) that all OSes support.  After changing the value, root passwords will need to be re-entered on existing hosts or host groups in order to re-hash them under the new algorithm.
-Default: MD5
-
 ##### proxy_request_timeout
 
 Timeout in seconds used when making REST requests to a Smart Proxy, e.g. when importing Puppet classes or creating DHCP records.  May be set to a larger value when certain operations take a long time.

--- a/_includes/manuals/1.15/3.5.2_configuration_options.md
+++ b/_includes/manuals/1.15/3.5.2_configuration_options.md
@@ -416,11 +416,6 @@ Default: 5
 In Puppet 2.6.5+, the ENC may send a hash of the class's attributes and values. Before then, the ENC used to send just an array of class names. Set this to _true_ if you are using any version of Puppet equal to or higher than 2.6.5.
 Default: true
 
-##### password_hash
-
-Changes the algorithm and format used to hash root passwords entered when creating new hosts or host groups.  This needs to be set to the lowest common denominator of operating systems that are provisioned from Foreman, but try to set it to the highest level (i.e. SHA-512) that all OSes support.  After changing the value, root passwords will need to be re-entered on existing hosts or host groups in order to re-hash them under the new algorithm.
-Default: MD5
-
 ##### proxy_request_timeout
 
 Timeout in seconds used when making REST requests to a Smart Proxy, e.g. when importing Puppet classes or creating DHCP records.  May be set to a larger value when certain operations take a long time.

--- a/_includes/manuals/1.16/3.5.2_configuration_options.md
+++ b/_includes/manuals/1.16/3.5.2_configuration_options.md
@@ -424,11 +424,6 @@ Default: 5
 In Puppet 2.6.5+, the ENC may send a hash of the class's attributes and values. Before then, the ENC used to send just an array of class names. Set this to _true_ if you are using any version of Puppet equal to or higher than 2.6.5.
 Default: true
 
-##### password_hash
-
-Changes the algorithm and format used to hash root passwords entered when creating new hosts or host groups.  This needs to be set to the lowest common denominator of operating systems that are provisioned from Foreman, but try to set it to the highest level (i.e. SHA-512) that all OSes support.  After changing the value, root passwords will need to be re-entered on existing hosts or host groups in order to re-hash them under the new algorithm.
-Default: MD5
-
 ##### proxy_request_timeout
 
 Timeout in seconds used when making REST requests to a Smart Proxy, e.g. when importing Puppet classes or creating DHCP records.  May be set to a larger value when certain operations take a long time.

--- a/_includes/manuals/1.17/3.5.2_configuration_options.md
+++ b/_includes/manuals/1.17/3.5.2_configuration_options.md
@@ -424,11 +424,6 @@ Default: 5
 In Puppet 2.6.5+, the ENC may send a hash of the class's attributes and values. Before then, the ENC used to send just an array of class names. Set this to _true_ if you are using any version of Puppet equal to or higher than 2.6.5.
 Default: true
 
-##### password_hash
-
-Changes the algorithm and format used to hash root passwords entered when creating new hosts or host groups.  This needs to be set to the lowest common denominator of operating systems that are provisioned from Foreman, but try to set it to the highest level (i.e. SHA-512) that all OSes support.  After changing the value, root passwords will need to be re-entered on existing hosts or host groups in order to re-hash them under the new algorithm.
-Default: MD5
-
 ##### proxy_request_timeout
 
 Timeout in seconds used when making REST requests to a Smart Proxy, e.g. when importing Puppet classes or creating DHCP records.  May be set to a larger value when certain operations take a long time.

--- a/_includes/manuals/1.18/3.5.2_configuration_options.md
+++ b/_includes/manuals/1.18/3.5.2_configuration_options.md
@@ -424,11 +424,6 @@ Default: 5
 In Puppet 2.6.5+, the ENC may send a hash of the class's attributes and values. Before then, the ENC used to send just an array of class names. Set this to _true_ if you are using any version of Puppet equal to or higher than 2.6.5.
 Default: true
 
-##### password_hash
-
-Changes the algorithm and format used to hash root passwords entered when creating new hosts or host groups.  This needs to be set to the lowest common denominator of operating systems that are provisioned from Foreman, but try to set it to the highest level (i.e. SHA-512) that all OSes support.  After changing the value, root passwords will need to be re-entered on existing hosts or host groups in order to re-hash them under the new algorithm.
-Default: MD5
-
 ##### proxy_request_timeout
 
 Timeout in seconds used when making REST requests to a Smart Proxy, e.g. when importing Puppet classes or creating DHCP records.  May be set to a larger value when certain operations take a long time.

--- a/_includes/manuals/1.19/3.5.2_configuration_options.md
+++ b/_includes/manuals/1.19/3.5.2_configuration_options.md
@@ -424,11 +424,6 @@ Default: 5
 In Puppet 2.6.5+, the ENC may send a hash of the class's attributes and values. Before then, the ENC used to send just an array of class names. Set this to _true_ if you are using any version of Puppet equal to or higher than 2.6.5.
 Default: true
 
-##### password_hash
-
-Changes the algorithm and format used to hash root passwords entered when creating new hosts or host groups.  This needs to be set to the lowest common denominator of operating systems that are provisioned from Foreman, but try to set it to the highest level (i.e. SHA-512) that all OSes support.  After changing the value, root passwords will need to be re-entered on existing hosts or host groups in order to re-hash them under the new algorithm.
-Default: MD5
-
 ##### proxy_request_timeout
 
 Timeout in seconds used when making REST requests to a Smart Proxy, e.g. when importing Puppet classes or creating DHCP records.  May be set to a larger value when certain operations take a long time.

--- a/_includes/manuals/1.7/3.5.2_configuration_options.md
+++ b/_includes/manuals/1.7/3.5.2_configuration_options.md
@@ -84,7 +84,7 @@ production:
     user_name: foreman@example.net
     password: foreman
 </pre>
-    
+
 ###### No Authentication
 Example for an SMTP service provider with no authentication. Note the colon before none.
 
@@ -274,11 +274,6 @@ Default: foreman_organization
 
 In Puppet 2.6.5+, the ENC may send a hash of the class's attributes and values. Before then, the ENC used to send just an array of class names. Set this to _true_ if you are using any version of Puppet equal to or higher than 2.6.5.
 Default: true
-
-##### password_hash
-
-Changes the algorithm and format used to hash root passwords entered when creating new hosts or host groups.  This needs to be set to the lowest common denominator of operating systems that are provisioned from Foreman, but try to set it to the highest level (i.e. SHA-512) that all OSes support.  After changing the value, root passwords will need to be re-entered on existing hosts or host groups in order to re-hash them under the new algorithm.
-Default: MD5
 
 ##### proxy_request_timeout
 

--- a/_includes/manuals/1.8/3.5.2_configuration_options.md
+++ b/_includes/manuals/1.8/3.5.2_configuration_options.md
@@ -84,7 +84,7 @@ production:
     user_name: foreman@example.net
     password: foreman
 </pre>
-    
+
 ###### No Authentication
 Example for an SMTP service provider with no authentication. Note the colon before none.
 
@@ -279,11 +279,6 @@ Default: foreman_organization
 
 In Puppet 2.6.5+, the ENC may send a hash of the class's attributes and values. Before then, the ENC used to send just an array of class names. Set this to _true_ if you are using any version of Puppet equal to or higher than 2.6.5.
 Default: true
-
-##### password_hash
-
-Changes the algorithm and format used to hash root passwords entered when creating new hosts or host groups.  This needs to be set to the lowest common denominator of operating systems that are provisioned from Foreman, but try to set it to the highest level (i.e. SHA-512) that all OSes support.  After changing the value, root passwords will need to be re-entered on existing hosts or host groups in order to re-hash them under the new algorithm.
-Default: MD5
 
 ##### proxy_request_timeout
 

--- a/_includes/manuals/1.9/3.5.2_configuration_options.md
+++ b/_includes/manuals/1.9/3.5.2_configuration_options.md
@@ -122,7 +122,7 @@ production:
     user_name: foreman@example.net
     password: foreman
 </pre>
-    
+
 ###### No Authentication
 Example for an SMTP service provider with no authentication. Note the colon before none.
 
@@ -328,11 +328,6 @@ Default: 5
 
 In Puppet 2.6.5+, the ENC may send a hash of the class's attributes and values. Before then, the ENC used to send just an array of class names. Set this to _true_ if you are using any version of Puppet equal to or higher than 2.6.5.
 Default: true
-
-##### password_hash
-
-Changes the algorithm and format used to hash root passwords entered when creating new hosts or host groups.  This needs to be set to the lowest common denominator of operating systems that are provisioned from Foreman, but try to set it to the highest level (i.e. SHA-512) that all OSes support.  After changing the value, root passwords will need to be re-entered on existing hosts or host groups in order to re-hash them under the new algorithm.
-Default: MD5
 
 ##### proxy_request_timeout
 

--- a/_includes/manuals/nightly/3.5.2_configuration_options.md
+++ b/_includes/manuals/nightly/3.5.2_configuration_options.md
@@ -424,11 +424,6 @@ Default: 5
 In Puppet 2.6.5+, the ENC may send a hash of the class's attributes and values. Before then, the ENC used to send just an array of class names. Set this to _true_ if you are using any version of Puppet equal to or higher than 2.6.5.
 Default: true
 
-##### password_hash
-
-Changes the algorithm and format used to hash root passwords entered when creating new hosts or host groups.  This needs to be set to the lowest common denominator of operating systems that are provisioned from Foreman, but try to set it to the highest level (i.e. SHA-512) that all OSes support.  After changing the value, root passwords will need to be re-entered on existing hosts or host groups in order to re-hash them under the new algorithm.
-Default: MD5
-
 ##### proxy_request_timeout
 
 Timeout in seconds used when making REST requests to a Smart Proxy, e.g. when importing Puppet classes or creating DHCP records.  May be set to a larger value when certain operations take a long time.


### PR DESCRIPTION
This setting has never actually been implemented. See
https://github.com/theforeman/foreman/pull/1736 for details.