### PR TITLE
Documentation update for puppetdir

### DIFF
--- a/_includes/manuals/1.18/3.5.5_facts_and_the_enc.md
+++ b/_includes/manuals/1.18/3.5.5_facts_and_the_enc.md
@@ -28,7 +28,7 @@ Unless it already exists from setting up reporting, create a new configuration f
 </pre>
 
 Edit the URL field to point to your Foreman instance, and the SSL fields for the hostname of the Puppet master (which may be the same host). Paths to Puppet's SSL certificates will be under /etc/puppetlabs/ssl/ when using Puppet 4 with AIO. More information on SSL certificates is at [Securing communications with SSL](/manuals/{{page.version}}/index.html#5.4SecuringCommunicationswithSSL).
-With Puppet 5 with AIO puppetdir should be /opt/puppetlabs/server/data/puppetserver/
+When using Puppet 5 with AIO, puppetdir should be set to /opt/puppetlabs/server/data/puppetserver/
 
 Add the following lines to the [master] section of puppet.conf:
 

--- a/_includes/manuals/1.18/3.5.5_facts_and_the_enc.md
+++ b/_includes/manuals/1.18/3.5.5_facts_and_the_enc.md
@@ -28,6 +28,7 @@ Unless it already exists from setting up reporting, create a new configuration f
 </pre>
 
 Edit the URL field to point to your Foreman instance, and the SSL fields for the hostname of the Puppet master (which may be the same host). Paths to Puppet's SSL certificates will be under /etc/puppetlabs/ssl/ when using Puppet 4 with AIO. More information on SSL certificates is at [Securing communications with SSL](/manuals/{{page.version}}/index.html#5.4SecuringCommunicationswithSSL).
+With Puppet 5 with AIO puppetdir should be /opt/puppetlabs/server/data/puppetserver/
 
 Add the following lines to the [master] section of puppet.conf:
 

--- a/_includes/manuals/1.18/3.5.5_facts_and_the_enc.md
+++ b/_includes/manuals/1.18/3.5.5_facts_and_the_enc.md
@@ -27,8 +27,7 @@ Unless it already exists from setting up reporting, create a new configuration f
 :threads: null
 </pre>
 
-Edit the URL field to point to your Foreman instance, and the SSL fields for the hostname of the Puppet master (which may be the same host). Paths to Puppet's SSL certificates will be under /etc/puppetlabs/ssl/ when using Puppet 4 with AIO. More information on SSL certificates is at [Securing communications with SSL](/manuals/{{page.version}}/index.html#5.4SecuringCommunicationswithSSL).
-When using Puppet 5 with AIO, puppetdir should be set to /opt/puppetlabs/server/data/puppetserver/
+Edit the URL field to point to your Foreman instance, and the SSL fields for the hostname of the Puppet master (which may be the same host). Paths to Puppet's SSL certificates will be under /etc/puppetlabs/ssl/ and puppetdir will be under /opt/puppetlabs/server/data/puppetserver/ when using Puppet 4 with AIO. More information on SSL certificates is at [Securing communications with SSL](/manuals/{{page.version}}/index.html#5.4SecuringCommunicationswithSSL).
 
 Add the following lines to the [master] section of puppet.conf:
 

--- a/_includes/manuals/1.19/3.5.5_facts_and_the_enc.md
+++ b/_includes/manuals/1.19/3.5.5_facts_and_the_enc.md
@@ -27,7 +27,7 @@ Unless it already exists from setting up reporting, create a new configuration f
 :threads: null
 </pre>
 
-Edit the URL field to point to your Foreman instance, and the SSL fields for the hostname of the Puppet master (which may be the same host). Paths to Puppet's SSL certificates will be under /etc/puppetlabs/ssl/ when using Puppet 4 with AIO. More information on SSL certificates is at [Securing communications with SSL](/manuals/{{page.version}}/index.html#5.4SecuringCommunicationswithSSL).
+Edit the URL field to point to your Foreman instance, and the SSL fields for the hostname of the Puppet master (which may be the same host). Paths to Puppet's SSL certificates will be under /etc/puppetlabs/ssl/ and puppetdir will be under /opt/puppetlabs/server/data/puppetserver/ when using Puppet 4 with AIO. More information on SSL certificates is at [Securing communications with SSL](/manuals/{{page.version}}/index.html#5.4SecuringCommunicationswithSSL).
 
 Add the following lines to the [master] section of puppet.conf:
 

--- a/_includes/manuals/nightly/3.5.5_facts_and_the_enc.md
+++ b/_includes/manuals/nightly/3.5.5_facts_and_the_enc.md
@@ -27,7 +27,7 @@ Unless it already exists from setting up reporting, create a new configuration f
 :threads: null
 </pre>
 
-Edit the URL field to point to your Foreman instance, and the SSL fields for the hostname of the Puppet master (which may be the same host). Paths to Puppet's SSL certificates will be under /etc/puppetlabs/ssl/ when using Puppet 4 with AIO. More information on SSL certificates is at [Securing communications with SSL](/manuals/{{page.version}}/index.html#5.4SecuringCommunicationswithSSL).
+Edit the URL field to point to your Foreman instance, and the SSL fields for the hostname of the Puppet master (which may be the same host). Paths to Puppet's SSL certificates will be under /etc/puppetlabs/ssl/ and puppetdir will be under /opt/puppetlabs/server/data/puppetserver/ when using Puppet 4 with AIO. More information on SSL certificates is at [Securing communications with SSL](/manuals/{{page.version}}/index.html#5.4SecuringCommunicationswithSSL).
 
 Add the following lines to the [master] section of puppet.conf:
 


### PR DESCRIPTION
Hello,

as stated on the forum : https://community.theforeman.org/t/import-add-new-host-to-foreman/10655
He is a small update of the documentation in order to reflect the puppetdir path for puppet 5 AIO

Hugo