### PR TITLE
Updating and clearifying outofsync interval settings

### DIFF
--- a/_includes/manuals/1.18/3.5.2_configuration_options.md
+++ b/_includes/manuals/1.18/3.5.2_configuration_options.md
@@ -416,8 +416,8 @@ Default: foreman_organization
 
 ##### outofsync_interval
 
-Duration in minutes after the Puppet interval for servers to be classed as out of sync.  This is added to the puppet_interval setting and used in pages such as the host list and dashboard.
-Default: 5
+Duration in minutes after which servers classed as out of sync, if the report origin has not been identified.
+Default: 30
 
 ##### Parametrized_Classes_in_ENC
 
@@ -431,8 +431,8 @@ Default: 60
 
 ##### puppet_interval
 
-This is the number of minutes between each run of puppet.
-Default: 30
+This overrides _outofsync_interval_ duration in minutes after which servers reporting via Puppet are classed as out of sync.
+Default: 35
 
 ##### puppet_server
 

--- a/_includes/manuals/1.18/4.10.2_substatuses.md
+++ b/_includes/manuals/1.18/4.10.2_substatuses.md
@@ -32,7 +32,7 @@ below.
         <tr>
           <td><strong><em>Out&nbsp;of&nbsp;sync</em></strong></td>
           <td>Warning</td>
-          <td>Configuration report was not received even though it was expected based on <em>puppet_interval</em> and <em>outofsync_interval</em> settings.</td>
+          <td>A configuration report was not received within the expected interval, based on the <em>outofsync_interval</em><sup>1</sup></td>
         </tr>
         <tr>
           <td><strong><em>No&nbsp;reports</em></strong></td>
@@ -56,3 +56,5 @@ below.
         </tr>
     </tbody>
 </table>
+
+<sup>1</sup> Reports are identified by an origin and can have different intervals based upon it. For example, reports by Puppet will have 'Puppet' as it's origin and will have it's interval set by <em>puppet_interval</em>.

--- a/_includes/manuals/1.19/3.5.2_configuration_options.md
+++ b/_includes/manuals/1.19/3.5.2_configuration_options.md
@@ -411,8 +411,8 @@ Default: foreman_organization
 
 ##### outofsync_interval
 
-Duration in minutes after the Puppet interval for servers to be classed as out of sync.  This is added to the puppet_interval setting and used in pages such as the host list and dashboard.
-Default: 5
+Duration in minutes after which servers classed as out of sync, if the report origin has not been identified.
+Default: 30
 
 ##### Parametrized_Classes_in_ENC
 
@@ -426,8 +426,8 @@ Default: 60
 
 ##### puppet_interval
 
-This is the number of minutes between each run of puppet.
-Default: 30
+This overrides _outofsync_interval_ duration in minutes after which servers reporting via Puppet are classed as out of sync.
+Default: 35
 
 ##### puppet_server
 

--- a/_includes/manuals/1.19/4.10.2_substatuses.md
+++ b/_includes/manuals/1.19/4.10.2_substatuses.md
@@ -32,7 +32,7 @@ below.
         <tr>
           <td><strong><em>Out&nbsp;of&nbsp;sync</em></strong></td>
           <td>Warning</td>
-          <td>Configuration report was not received even though it was expected based on <em>puppet_interval</em> and <em>outofsync_interval</em> settings.</td>
+          <td>A configuration report was not received within the expected interval, based on the <em>outofsync_interval</em><sup>1</sup></td>
         </tr>
         <tr>
           <td><strong><em>No&nbsp;reports</em></strong></td>
@@ -56,3 +56,5 @@ below.
         </tr>
     </tbody>
 </table>
+
+<sup>1</sup> Reports are identified by an origin and can have different intervals based upon it. For example, reports by Puppet will have 'Puppet' as it's origin and will have it's interval set by <em>puppet_interval</em>.

--- a/_includes/manuals/nightly/3.5.2_configuration_options.md
+++ b/_includes/manuals/nightly/3.5.2_configuration_options.md
@@ -411,8 +411,8 @@ Default: foreman_organization
 
 ##### outofsync_interval
 
-Duration in minutes after the Puppet interval for servers to be classed as out of sync.  This is added to the puppet_interval setting and used in pages such as the host list and dashboard.
-Default: 5
+Duration in minutes after which servers classed as out of sync, if the report origin has not been identified.
+Default: 30
 
 ##### Parametrized_Classes_in_ENC
 
@@ -426,8 +426,8 @@ Default: 60
 
 ##### puppet_interval
 
-This is the number of minutes between each run of puppet.
-Default: 30
+This overrides _outofsync_interval_ duration in minutes after which servers reporting via Puppet are classed as out of sync.
+Default: 35
 
 ##### puppet_server
 

--- a/_includes/manuals/nightly/4.10.2_substatuses.md
+++ b/_includes/manuals/nightly/4.10.2_substatuses.md
@@ -32,7 +32,7 @@ below.
         <tr>
           <td><strong><em>Out&nbsp;of&nbsp;sync</em></strong></td>
           <td>Warning</td>
-          <td>Configuration report was not received even though it was expected based on <em>puppet_interval</em> and <em>outofsync_interval</em> settings.</td>
+          <td>A configuration report was not received within the expected interval, based on the <em>outofsync_interval</em><sup>1</sup></td>
         </tr>
         <tr>
           <td><strong><em>No&nbsp;reports</em></strong></td>
@@ -56,3 +56,5 @@ below.
         </tr>
     </tbody>
 </table>
+
+<sup>1</sup> Reports are identified by an origin and can have different intervals based upon it. For example, reports by Puppet will have 'Puppet' as it's origin and will have it's interval set by <em>puppet_interval</em>.


### PR DESCRIPTION
This updates the documentation about the out of sync intervals in 1.18, 1.19 and nightly to how they are now used.