### PR TITLE
ignore .jekyll-metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ _site
 .ruby-gemset
 .bundle
 Gemfile.lock
+.jekyll-metadata


### PR DESCRIPTION
As per https://jekyllrb.com/docs/structure/:

"This helps Jekyll keep track of which files have not been modified
since the site was last built, and which files will need to be
regenerated on the next build. This file will not be included in the
generated site. It’s probably a good idea to add this to your
.gitignore file."