### PR TITLE
Updated 3.4_install_from_source nightly

### DIFF
--- a/_includes/manuals/nightly/3.4_install_from_source.md
+++ b/_includes/manuals/nightly/3.4_install_from_source.md
@@ -63,6 +63,25 @@ to get latest "stable" version do:
 git clone https://github.com/theforeman/foreman.git -b {{page.version}}-stable
 {% endhighlight %}
 
+### Adding a plugin
+To add a plugin, add it to a gemfile inside the bundler.d folder indicating the path to the file. For example, create a file Gemfile.local.rb containing:
+
+{% highlight bash %}
+gem 'foreman-tasks', :path => '/home/tbrisker/gits/foreman-tasks'
+{% endhighlight %}
+
+You can clone the source of the plugin to any place you wish, just be sure to indicate the correct path and run bundle install after updating the file.
+
+You can also use plugins as a gem from rubygems.org or from source in github if you don’t want to modify them:
+
+{% highlight bash %}
+gem 'foreman_ansible' # will install foreman_ansible gem from rubygems.org
+{% endhighlight %}
+
+{% highlight bash %}
+gem 'foreman_discovery', :git => "https://github.com/theforeman/foreman_discovery.git" # will install discovery directly from github
+{% endhighlight %}
+
 ### CLI (Hammer)
 
 To install hammer from git checkouts, you will just need ```rake``` installed on your system.


### PR DESCRIPTION
Added section on how to add plugins to Forman source install to nightly manuals.