### PR TITLE
Enable incremental flag for faster builds

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -12,7 +12,7 @@ end
 
 desc 'Start server'
 task :server do
-  sh "jekyll serve --watch"
+  sh "jekyll serve --watch --incremental"
 end
 
 desc 'Starts up browser window (requires running server)'


### PR DESCRIPTION
This little thing has been there since Jekyll 3.0. Given our build time for the whole website on my laptop is 120 sec, the performance gains are quite considerable. It takes around 20s to regenerate a page of the manual, which is much nicer. 