### PR TITLE
Fix link to 1.20 repositories

### DIFF
--- a/plugins/katello/3.9/annotations/index.md
+++ b/plugins/katello/3.9/annotations/index.md
@@ -1,8 +1,8 @@
 ---
 layout: plugins/katello/documentation
 title: Annotated Requests
-version: 3.9
-foreman_version: 1.20
+version: '3.9'
+foreman_version: '1.20'
 script: osmenu.js
 ---
 # Repository Sync (default settings)

--- a/plugins/katello/3.9/cli/index.md
+++ b/plugins/katello/3.9/cli/index.md
@@ -1,8 +1,8 @@
 ---
 layout: plugins/katello/documentation
 title: CLI
-version: 3.9
-foreman_version: 1.20
+version: '3.9'
+foreman_version: '1.20'
 script: osmenu.js
 ---
 

--- a/plugins/katello/3.9/installation/index.md
+++ b/plugins/katello/3.9/installation/index.md
@@ -1,9 +1,9 @@
 ---
 layout: plugins/katello/documentation
 title: Katello Installation
-version: 3.9
-foreman_version: 1.20
-latest: 3.8
+version: '3.9'
+foreman_version: '1.20'
+latest: '3.8'
 script: osmenu.js
 ---
 

--- a/plugins/katello/3.9/upgrade/index.md
+++ b/plugins/katello/3.9/upgrade/index.md
@@ -1,8 +1,8 @@
 ---
 layout: plugins/katello/documentation
 title: Katello Upgrade
-version: 3.9
-foreman_version: 1.20
+version: '3.9'
+foreman_version: '1.20'
 ---
 
 # Katello Upgrade

--- a/plugins/katello/3.9/upgrade/smart_proxy.md
+++ b/plugins/katello/3.9/upgrade/smart_proxy.md
@@ -1,8 +1,8 @@
 ---
 layout: plugins/katello/documentation
 title: Smart Proxy Upgrade
-version: 3.9
-foreman_version: 1.20
+version: '3.9'
+foreman_version: '1.20'
 ---
 
 # Smart Proxy Upgrade


### PR DESCRIPTION
Using `foreman_version: 1.20` without quotes caused the version to be converted
to `1.2`, as it was treated as number, instead of a string, leading to
instructing folks to install

    yum -y localinstall http://yum.theforeman.org/releases/1.2/el7/x86_64/foreman-release.rpm