### PR TITLE
s/python-django/python2-django

### DIFF
--- a/plugins/katello/3.9/installation/index.md
+++ b/plugins/katello/3.9/installation/index.md
@@ -105,7 +105,7 @@ yum -y localinstall http://fedorapeople.org/groups/katello/releases/yum/{{ page.
 yum -y localinstall http://yum.theforeman.org/releases/{{ page.foreman_version }}/el7/x86_64/foreman-release.rpm
 yum -y localinstall https://yum.puppetlabs.com/puppetlabs-release-pc1-el-7.noarch.rpm
 yum -y localinstall http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
-yum -y install foreman-release-scl python-django
+yum -y install foreman-release-scl python2-django
 {% endhighlight %}
 </div>
 


### PR DESCRIPTION
When installing `python-django`, I'm getting

    Package python-django-1.6.11.6-1.el7.noarch is obsoleted by
    python2-django-1.11.13-1.el7.noarch