### PR TITLE
Update Katello client docs 3.7 through nightly

### DIFF
--- a/plugins/katello/3.7/installation/clients.md
+++ b/plugins/katello/3.7/installation/clients.md
@@ -20,6 +20,7 @@ Install the appropriate Katello client release packages.  For CentOS 6, you will
      <option value="el6">Enterprise Linux 6 (CentOS, etc.)</option>
      <option value="el7">Enterprise Linux 7 (CentOS, etc.)</option>
      <option value="f27">Fedora 27</option>
+     <option value="f28">Fedora 28</option>
      <option value="sles11">Suse Enterprise Linux Server 11</option>
      <option value="sles12">Suse Enterprise Linux Server 12</option>
   </select>
@@ -50,6 +51,12 @@ yum -y install http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch
 <div id="f27" style="display:none;" markdown="1">
 {% highlight bash %}
 yum install -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/f27/x86_64/katello-client-repos-latest.rpm
+{% endhighlight %}
+</div>
+
+<div id="f28" style="display:none;" markdown="1">
+{% highlight bash %}
+yum install -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/f28/x86_64/katello-client-repos-latest.rpm
 {% endhighlight %}
 </div>
 

--- a/plugins/katello/3.7/upgrade/clients.md
+++ b/plugins/katello/3.7/upgrade/clients.md
@@ -21,8 +21,8 @@ Update the Katello client release packages:
      <option value="el5">Enterprise Linux 5 (RHEL, CentOS, etc.)</option>
      <option value="el6">Enterprise Linux 6 (RHEL, CentOS, etc.)</option>
      <option value="el7">Enterprise Linux 7 (RHEL, CentOS, etc.)</option>
-     <option value="fc24">Fedora 24</option>
-     <option value="fc25">Fedora 25</option>
+     <option value="f27">Fedora 27</option>
+     <option value="f28">Fedora 28</option>
   </select>
 </p>
 
@@ -47,15 +47,15 @@ yum -y install http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch
 {% endhighlight %}
 </div>
 
-<div id="fc24" style="display:none;" markdown="1">
+<div id="f27" style="display:none;" markdown="1">
 {% highlight bash %}
-yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/fc24/x86_64/katello-client-repos-latest.rpm
+yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/fc27/x86_64/katello-client-repos-latest.rpm
 {% endhighlight %}
 </div>
 
-<div id="fc25" style="display:none;" markdown="1">
+<div id="f28" style="display:none;" markdown="1">
 {% highlight bash %}
-yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/fc25/x86_64/katello-client-repos-latest.rpm
+yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/fc28/x86_64/katello-client-repos-latest.rpm
 {% endhighlight %}
 </div>
 

--- a/plugins/katello/3.8/installation/clients.md
+++ b/plugins/katello/3.8/installation/clients.md
@@ -20,6 +20,7 @@ Install the appropriate Katello client release packages.  For CentOS 6, you will
      <option value="el6">Enterprise Linux 6 (CentOS, etc.)</option>
      <option value="el7">Enterprise Linux 7 (CentOS, etc.)</option>
      <option value="f27">Fedora 27</option>
+     <option value="f28">Fedora 28</option>
      <option value="sles11">Suse Enterprise Linux Server 11</option>
      <option value="sles12">Suse Enterprise Linux Server 12</option>
   </select>
@@ -50,6 +51,12 @@ yum -y install http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch
 <div id="f27" style="display:none;" markdown="1">
 {% highlight bash %}
 yum install -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/f27/x86_64/katello-client-repos-latest.rpm
+{% endhighlight %}
+</div>
+
+<div id="f28" style="display:none;" markdown="1">
+{% highlight bash %}
+yum install -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/f28/x86_64/katello-client-repos-latest.rpm
 {% endhighlight %}
 </div>
 

--- a/plugins/katello/3.8/upgrade/clients.md
+++ b/plugins/katello/3.8/upgrade/clients.md
@@ -21,8 +21,10 @@ Update the Katello client release packages:
      <option value="el5">Enterprise Linux 5 (RHEL, CentOS, etc.)</option>
      <option value="el6">Enterprise Linux 6 (RHEL, CentOS, etc.)</option>
      <option value="el7">Enterprise Linux 7 (RHEL, CentOS, etc.)</option>
-     <option value="fc24">Fedora 24</option>
-     <option value="fc25">Fedora 25</option>
+     <option value="f27">Fedora 27</option>
+     <option value="f28">Fedora 28</option>
+     <option value="sles11">Suse Enterprise Linux Server 11</option>
+     <option value="sles12">Suse Enterprise Linux Server 12</option>
   </select>
 </p>
 
@@ -47,15 +49,29 @@ yum -y install http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch
 {% endhighlight %}
 </div>
 
-<div id="fc24" style="display:none;" markdown="1">
+<div id="f27" style="display:none;" markdown="1">
 {% highlight bash %}
-yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/fc24/x86_64/katello-client-repos-latest.rpm
+yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/fc27/x86_64/katello-client-repos-latest.rpm
 {% endhighlight %}
 </div>
 
-<div id="fc25" style="display:none;" markdown="1">
+<div id="f28" style="display:none;" markdown="1">
 {% highlight bash %}
-yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/fc25/x86_64/katello-client-repos-latest.rpm
+yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/client/fc28/x86_64/katello-client-repos-latest.rpm
+{% endhighlight %}
+</div>
+
+<div id="sles12" style="display:none;" markdown="1">
+{% highlight bash %}
+rpm -Uvh https://yum.theforeman.org/client/{{ page.foreman_version }}/sles12/x86_64/foreman-client-release.rpm
+{% endhighlight %}
+</div>
+
+<div id="sles11" style="display:none;" markdown="1">
+{% highlight bash %}
+# For python-datetime dependency, ensure that the SDK addon product is enabled see: https://www.suse.com/support/kb/doc/?id=7015337
+zypper modifyrepo -e nu_novell_com:SLES11-Extras
+rpm -Uvh https://yum.theforeman.org/client/{{ page.foreman_version }}/sles11/x86_64/foreman-client-release.rpm
 {% endhighlight %}
 </div>
 

--- a/plugins/katello/3.9/installation/clients.md
+++ b/plugins/katello/3.9/installation/clients.md
@@ -11,7 +11,7 @@ Client machines can be added in one of two ways: manually or via a provisioned h
 
 ## Manual
 
-Install the appropriate Katello client release packages.  For CentOS 6, you will also need to enable the COPR repository for subscription-manager.
+Install the appropriate Katello client release packages.
 
 <p>
   Select your Operating System:
@@ -20,6 +20,7 @@ Install the appropriate Katello client release packages.  For CentOS 6, you will
      <option value="el6">Enterprise Linux 6 (CentOS, etc.)</option>
      <option value="el7">Enterprise Linux 7 (CentOS, etc.)</option>
      <option value="f27">Fedora 27</option>
+     <option value="f28">Fedora 28</option>
      <option value="sles11">Suse Enterprise Linux Server 11</option>
      <option value="sles12">Suse Enterprise Linux Server 12</option>
   </select>
@@ -102,4 +103,4 @@ zypper install katello-host-tools
 
 In order to install the katello-agent package on a host you are provisioning, you will need to make the appropriate client repository available within your Katello. The first step is to either create a new product or add to an existing product, the appropriate client repository from the dropdown in the [manual](/plugins/katello/{{ page.version }}/installation/clients.html#manual) section above. After you create the new repositories, they will need to be synced locally. Next, you will then need to add them to the relevant content view(s) for the hosts you are wanting to provision. At this point, a new version of the content view can be published and promoted to the appropriate environments that you are wanting to provision a host into. At this point, you can go provision a host and the host will install the katello-agent package during setup.
 
-When provisioning new clients that should use Puppet 4, set a parameter called 'enable-puppet4' to 'true', so the templates know which package to install and where to place the configuration.  This parameter can be placed at the host, host group, or another appropriate level of the hierarchy.
+When provisioning new clients that should use Puppet 5, set a parameter called 'enable-puppet5' to 'true', so the templates know which package to install and where to place the configuration.  This parameter can be placed at the host, host group, or another appropriate level of the hierarchy.

--- a/plugins/katello/3.9/upgrade/clients.md
+++ b/plugins/katello/3.9/upgrade/clients.md
@@ -21,8 +21,8 @@ Update the Katello client release packages:
      <option value="el5">Enterprise Linux 5 (RHEL, CentOS, etc.)</option>
      <option value="el6">Enterprise Linux 6 (RHEL, CentOS, etc.)</option>
      <option value="el7">Enterprise Linux 7 (RHEL, CentOS, etc.)</option>
-     <option value="fc27">Fedora 27</option>
-     <option value="fc28">Fedora 28</option>
+     <option value="f27">Fedora 27</option>
+     <option value="f28">Fedora 28</option>
      <option value="sles11">Suse Enterprise Linux Server 11</option>
      <option value="sles12">Suse Enterprise Linux Server 12</option>
   </select>

--- a/plugins/katello/nightly/upgrade/clients.md
+++ b/plugins/katello/nightly/upgrade/clients.md
@@ -21,8 +21,8 @@ Update the Katello client release packages:
      <option value="el5">Enterprise Linux 5 (RHEL, CentOS, etc.)</option>
      <option value="el6">Enterprise Linux 6 (RHEL, CentOS, etc.)</option>
      <option value="el7">Enterprise Linux 7 (RHEL, CentOS, etc.)</option>
-     <option value="fc27">Fedora 27</option>
-     <option value="fc28">Fedora 28</option>
+     <option value="f27">Fedora 27</option>
+     <option value="f28">Fedora 28</option>
      <option value="sles11">Suse Enterprise Linux Server 11</option>
      <option value="sles12">Suse Enterprise Linux Server 12</option>
   </select>

--- a/static/js/osmenu.js
+++ b/static/js/osmenu.js
@@ -12,6 +12,7 @@ $(document).ready(function(){
             'f25': [],
             'f26': [],
             'f27': [],
+            'f28': [],
             'sles11': [],
             'sles12': []
         };


### PR DESCRIPTION
There were a few discrepancies between the Katello client docs across the few latest releases, mainly:

- dropdowns referred to fedora 24+25 where we have 27 & 28 bits
- dropdowns not working due to JS problems
- missing client version for fedora

Went through and made things more consistent & accurate.

Tagging @sjha4 to review 3.8 and @zjhuntin to review 3.9 changes :)