### PR TITLE
Quickstart is still on 1.19

### DIFF
--- a/_layouts/quickstart.html
+++ b/_layouts/quickstart.html
@@ -1,6 +1,6 @@
 ---
 pagename: Quickstart
-latestversion: "1.19"
+latestversion: "1.20"
 ---
 {% include header.html %}
 <div id="wrap">


### PR DESCRIPTION
Warning:
This quickstart guide is for Foreman 1.20, but 1.19 is the current stable version.

https://theforeman.org/manuals/1.20/quickstart_guide.html