### PR TITLE
task tmp:sessions:clear does not exist

### DIFF
--- a/_includes/manuals/1.20/3.6_upgrade.md
+++ b/_includes/manuals/1.20/3.6_upgrade.md
@@ -134,7 +134,7 @@ migration script again, it should produce no errors or output:
 You should clear the cache and the existing sessions:
 
     foreman-rake tmp:cache:clear
-    foreman-rake tmp:sessions:clear
+    foreman-rake db:sessions:clear
 
 ##### Step 3 (B) - OpenStack and Rackspace compute resource users
 

--- a/_includes/manuals/nightly/3.6_upgrade.md
+++ b/_includes/manuals/nightly/3.6_upgrade.md
@@ -134,7 +134,7 @@ migration script again, it should produce no errors or output:
 You should clear the cache and the existing sessions:
 
     foreman-rake tmp:cache:clear
-    foreman-rake tmp:sessions:clear
+    foreman-rake db:sessions:clear
 
 ##### Step 3 (B) - OpenStack and Rackspace compute resource users
 


### PR DESCRIPTION
This would fail with the following message:
```
rake aborted!
Don't know how to build task 'tmp:sessions:clear' (see --tasks)
/opt/rh/rh-ruby25/root/usr/share/gems/gems/rake-12.3.0/exe/rake:27:in `<top (required)>'
(See full trace by running task with --trace)
```
