### PR TITLE
Fix not working sudoers example in plugins/foreman_salt

### DIFF
--- a/plugins/foreman_salt/2.0/index.md
+++ b/plugins/foreman_salt/2.0/index.md
@@ -102,7 +102,7 @@ Install the Salt Smart Proxy package for your operating system (see above). The 
 Add this to /etc/sudoers:
 
     Cmnd_Alias SALT = /usr/bin/salt, /usr/bin/salt-key
-    foreman-proxy ALL = NOPASSWD: SALT
+    foreman_proxy ALL = (ALL) NOPASSWD: SALT
     Defaults:foreman-proxy !requiretty
 
 In `/etc/salt/master`, make the following changes:

--- a/plugins/foreman_salt/2.0/index.md
+++ b/plugins/foreman_salt/2.0/index.md
@@ -102,7 +102,7 @@ Install the Salt Smart Proxy package for your operating system (see above). The 
 Add this to /etc/sudoers:
 
     Cmnd_Alias SALT = /usr/bin/salt, /usr/bin/salt-key
-    foreman_proxy ALL = (ALL) NOPASSWD: SALT
+    foreman-proxy ALL = (ALL) NOPASSWD: SALT
     Defaults:foreman-proxy !requiretty
 
 In `/etc/salt/master`, make the following changes:

--- a/plugins/foreman_salt/2.1/index.md
+++ b/plugins/foreman_salt/2.1/index.md
@@ -112,7 +112,7 @@ Install the Salt Smart Proxy package for your operating system (see above). The 
   - Add this to /etc/sudoers:
 
         Cmnd_Alias SALT = /usr/bin/salt, /usr/bin/salt-key
-        foreman_proxy ALL = (ALL) NOPASSWD: SALT
+        foreman-proxy ALL = (ALL) NOPASSWD: SALT
         Defaults:foreman-proxy !requiretty
 
    - For the salt-api, ensure the salt-api package is installed, and a supported server such as python-cherrypy is installed.

--- a/plugins/foreman_salt/2.1/index.md
+++ b/plugins/foreman_salt/2.1/index.md
@@ -112,7 +112,7 @@ Install the Salt Smart Proxy package for your operating system (see above). The 
   - Add this to /etc/sudoers:
 
         Cmnd_Alias SALT = /usr/bin/salt, /usr/bin/salt-key
-        foreman-proxy ALL = NOPASSWD: SALT
+        foreman_proxy ALL = (ALL) NOPASSWD: SALT
         Defaults:foreman-proxy !requiretty
 
    - For the salt-api, ensure the salt-api package is installed, and a supported server such as python-cherrypy is installed.

--- a/plugins/foreman_salt/3.0/index.md
+++ b/plugins/foreman_salt/3.0/index.md
@@ -88,7 +88,7 @@ Install the Salt Smart Proxy package for your operating system (see above). The 
   - Add this to /etc/sudoers:
 
         Cmnd_Alias SALT = /usr/bin/salt, /usr/bin/salt-key
-        foreman-proxy ALL = NOPASSWD: SALT
+        foreman_proxy ALL = (ALL) NOPASSWD: SALT
         Defaults:foreman-proxy !requiretty
 
    - For the salt-api, ensure the salt-api package is installed, and a supported server such as python-cherrypy is installed.

--- a/plugins/foreman_salt/3.0/index.md
+++ b/plugins/foreman_salt/3.0/index.md
@@ -88,7 +88,7 @@ Install the Salt Smart Proxy package for your operating system (see above). The 
   - Add this to /etc/sudoers:
 
         Cmnd_Alias SALT = /usr/bin/salt, /usr/bin/salt-key
-        foreman_proxy ALL = (ALL) NOPASSWD: SALT
+        foreman-proxy ALL = (ALL) NOPASSWD: SALT
         Defaults:foreman-proxy !requiretty
 
    - For the salt-api, ensure the salt-api package is installed, and a supported server such as python-cherrypy is installed.

--- a/plugins/foreman_salt/4.0/index.md
+++ b/plugins/foreman_salt/4.0/index.md
@@ -96,7 +96,7 @@ Install the Salt Smart Proxy package for your operating system (see above). The 
   - Add this to /etc/sudoers:
 
         Cmnd_Alias SALT = /usr/bin/salt, /usr/bin/salt-key
-        foreman_proxy ALL = (ALL) NOPASSWD: SALT
+        foreman-proxy ALL = (ALL) NOPASSWD: SALT
         Defaults:foreman-proxy !requiretty
 
    - For the salt-api, ensure the salt-api package is installed, and a supported server such as python-cherrypy is installed.

--- a/plugins/foreman_salt/4.0/index.md
+++ b/plugins/foreman_salt/4.0/index.md
@@ -96,7 +96,7 @@ Install the Salt Smart Proxy package for your operating system (see above). The 
   - Add this to /etc/sudoers:
 
         Cmnd_Alias SALT = /usr/bin/salt, /usr/bin/salt-key
-        foreman-proxy ALL = NOPASSWD: SALT
+        foreman_proxy ALL = (ALL) NOPASSWD: SALT
         Defaults:foreman-proxy !requiretty
 
    - For the salt-api, ensure the salt-api package is installed, and a supported server such as python-cherrypy is installed.

--- a/plugins/foreman_salt/5.0/index.md
+++ b/plugins/foreman_salt/5.0/index.md
@@ -104,7 +104,7 @@ Install the Salt Smart Proxy package for your operating system (see above). The 
   - Add this to /etc/sudoers:
 
         Cmnd_Alias SALT = /usr/bin/salt, /usr/bin/salt-key
-        foreman_proxy ALL = (ALL) NOPASSWD: SALT
+        foreman-proxy ALL = (ALL) NOPASSWD: SALT
         Defaults:foreman-proxy !requiretty
 
    - For the salt-api, ensure the salt-api package is installed, and a supported server such as python-cherrypy is installed.

--- a/plugins/foreman_salt/5.0/index.md
+++ b/plugins/foreman_salt/5.0/index.md
@@ -104,7 +104,7 @@ Install the Salt Smart Proxy package for your operating system (see above). The 
   - Add this to /etc/sudoers:
 
         Cmnd_Alias SALT = /usr/bin/salt, /usr/bin/salt-key
-        foreman-proxy ALL = NOPASSWD: SALT
+        foreman_proxy ALL = (ALL) NOPASSWD: SALT
         Defaults:foreman-proxy !requiretty
 
    - For the salt-api, ensure the salt-api package is installed, and a supported server such as python-cherrypy is installed.

--- a/plugins/foreman_salt/6.0/index.md
+++ b/plugins/foreman_salt/6.0/index.md
@@ -112,7 +112,7 @@ Install the Salt Smart Proxy package for your operating system (see above). The 
   - Add this to /etc/sudoers:
 
         Cmnd_Alias SALT = /usr/bin/salt, /usr/bin/salt-key
-        foreman_proxy ALL = (ALL) NOPASSWD: SALT
+        foreman-proxy ALL = (ALL) NOPASSWD: SALT
         Defaults:foreman-proxy !requiretty
 
    - For the salt-api, ensure the salt-api package is installed, and a supported server such as python-cherrypy is installed.

--- a/plugins/foreman_salt/6.0/index.md
+++ b/plugins/foreman_salt/6.0/index.md
@@ -112,7 +112,7 @@ Install the Salt Smart Proxy package for your operating system (see above). The 
   - Add this to /etc/sudoers:
 
         Cmnd_Alias SALT = /usr/bin/salt, /usr/bin/salt-key
-        foreman-proxy ALL = NOPASSWD: SALT
+        foreman_proxy ALL = (ALL) NOPASSWD: SALT
         Defaults:foreman-proxy !requiretty
 
    - For the salt-api, ensure the salt-api package is installed, and a supported server such as python-cherrypy is installed.

--- a/plugins/foreman_salt/7.0/index.md
+++ b/plugins/foreman_salt/7.0/index.md
@@ -120,7 +120,7 @@ Install the Salt Smart Proxy package for your operating system (see above). The 
   - Add this to /etc/sudoers:
 
         Cmnd_Alias SALT = /usr/bin/salt, /usr/bin/salt-key
-        foreman_proxy ALL = (ALL) NOPASSWD: SALT
+        foreman-proxy ALL = (ALL) NOPASSWD: SALT
         Defaults:foreman-proxy !requiretty
 
    - For the salt-api, ensure the salt-api package is installed, and a supported server such as python-cherrypy is installed.

--- a/plugins/foreman_salt/7.0/index.md
+++ b/plugins/foreman_salt/7.0/index.md
@@ -120,7 +120,7 @@ Install the Salt Smart Proxy package for your operating system (see above). The 
   - Add this to /etc/sudoers:
 
         Cmnd_Alias SALT = /usr/bin/salt, /usr/bin/salt-key
-        foreman-proxy ALL = NOPASSWD: SALT
+        foreman_proxy ALL = (ALL) NOPASSWD: SALT
         Defaults:foreman-proxy !requiretty
 
    - For the salt-api, ensure the salt-api package is installed, and a supported server such as python-cherrypy is installed.


### PR DESCRIPTION
This will fix commands `salt` and `salt-key` to be run on a Foreman-proxy.

The current example(s) are incorrect and you'll find "HTTP 406 - Not Acceptable" messages in `foreman-proxy/proxy.log`, next to `sudo: foreman-proxy : command not allowed ; TTY=unknown ; PWD=/ ; USER=foreman-proxy ; COMMAND=/usr/bin/salt-key --finger-all --output=json` in `auth.log`.