### PR TITLE
Update manual for Smart Proxy puppetca and the new providers

### DIFF
--- a/_includes/manuals/1.19/4.3.7_smartproxy_puppetca.md
+++ b/_includes/manuals/1.19/4.3.7_smartproxy_puppetca.md
@@ -1,23 +1,39 @@
 
 Activate the Puppet CA management module within the Smart Proxy instance.  This is used to manage the autosign configuration and handle listing, signing and revocation of individual certificates.
 
-This should only be enabled in the Smart Proxy that is hosted on the machine responsible for providing certificates to your puppet clients. You would expect to see a directory **/var/lib/puppet/ssl/ca** on such a host.
+Builtin provider is only:
+
+* `puppetca_hostname_whitelisting` - direct management of Puppet's `autosign.conf`
+
+This should only be enabled in the Smart Proxy that is hosted on the machine responsible for providing certificates to your puppet clients. You would expect to see a subdirectory **ca** in your Puppet's ssldir on such a host. You can determine the ssldir with the command `puppet config print ssldir`. On this host enable the feature in `puppetca.yml`:
 
 <pre>
 :enabled: https
 </pre>
 
-If your puppet SSL directory is located elsewhere, you'll need to set 'ssldir' as well.
+If your puppet SSL directory is not located in `/var/lib/puppet/ssl`, you'll need to set **ssldir** as well.
 <pre>
 :ssldir: /etc/puppet/ssl
 </pre>
 
-The 'autosignfile' setting is used to find autosign.conf:
+Also choose the provider to use, default should be `puppetca_hostname_whitelisting`:
+<pre>
+:use_provider: puppetca_hostname_whitelisting
+</pre>
+
+#### puppetca_hostname_whitelisting
+
+The puppetca_hostname_whitelisting provider directly manages Puppet's `autosign.conf` file.
+This will create an autosign entry for a host during deployment and remove it when deployment is finished.
+Furthermore it allows you to manage entries manually using the Foreman WebUI.
+
+The **autosignfile** setting in `puppetca_hostname_whitelisting.yml` is used to find autosign.conf:
 
 <pre>
 :autosignfile: /etc/puppet/autosign.conf
 </pre>
 
+The location of the file can be determined with `puppet config print autosign`.
 The proxy requires write access to the puppet autosign.conf file, which is usually owner and group puppet, and has mode 0644 according to the puppet defaults.
 
 Under a Puppet 4 AIO installation, paths should be set to:

--- a/_includes/manuals/1.20/4.3.7_smartproxy_puppetca.md
+++ b/_includes/manuals/1.20/4.3.7_smartproxy_puppetca.md
@@ -1,23 +1,40 @@
 
 Activate the Puppet CA management module within the Smart Proxy instance.  This is used to manage the autosign configuration and handle listing, signing and revocation of individual certificates.
 
-This should only be enabled in the Smart Proxy that is hosted on the machine responsible for providing certificates to your puppet clients. You would expect to see a directory **/var/lib/puppet/ssl/ca** on such a host.
+Builtin providers are:
+
+* `puppetca_hostname_whitelisting` - direct management of Puppet's `autosign.conf`
+* `puppetca_token_whitelisting` - manage token-based signing of certificate requests
+
+This should only be enabled in the Smart Proxy that is hosted on the machine responsible for providing certificates to your puppet clients. You would expect to see a subdirectory **ca** in your Puppet's ssldir on such a host. You can determine the ssldir with the command `puppet config print ssldir`. On this host enable the feature in `puppetca.yml`:
 
 <pre>
 :enabled: https
 </pre>
 
-If your puppet SSL directory is located elsewhere, you'll need to set 'ssldir' as well.
+If your puppet SSL directory is not located in `/var/lib/puppet/ssl`, you'll need to set **ssldir** as well.
 <pre>
 :ssldir: /etc/puppet/ssl
 </pre>
 
-The 'autosignfile' setting is used to find autosign.conf:
+Also choose the provider to use, default should be `puppetca_hostname_whitelisting`:
+<pre>
+:use_provider: puppetca_hostname_whitelisting
+</pre>
+
+#### puppetca_hostname_whitelisting
+
+The puppetca_hostname_whitelisting provider directly manages Puppet's `autosign.conf` file.
+This will create an autosign entry for a host during deployment and remove it when deployment is finished.
+Furthermore it allows you to manage entries manually using the Foreman WebUI.
+
+The **autosignfile** setting in `puppetca_hostname_whitelisting.yml` is used to find autosign.conf:
 
 <pre>
 :autosignfile: /etc/puppet/autosign.conf
 </pre>
 
+The location of the file can be determined with `puppet config print autosign`.
 The proxy requires write access to the puppet autosign.conf file, which is usually owner and group puppet, and has mode 0644 according to the puppet defaults.
 
 Under a Puppet 4 AIO installation, paths should be set to:
@@ -56,4 +73,35 @@ For older versions of Puppet (2.x) with separate commands:
 <pre>
 foreman-proxy ALL = NOPASSWD: /usr/sbin/puppetca *
 Defaults:foreman-proxy !requiretty
+</pre>
+
+#### puppetca_token_whitelisting
+
+The puppetca_token_whitelisting provider uses a token-based certificate signing managed by the Smart proxy itself and queried by Puppet during Provisioning.
+This provider adds more security and logging to the autosigning process but does not allow for manual creation of autosigning entries.
+
+This provider has the following settings in `puppetca_token_whitelisting.yml`:
+
+<pre>
+:sign_all: false
+:token_ttl: 360
+:tokens_file: /var/lib/foreman-proxy/tokens.yml
+</pre>
+
+By changing **sign_all** to `true` you will disable token verification and sign all certificate requests.
+The setting **token_ttl** defines how long a token after creation is valid in minutes.
+**tokens_file** sets the path to the file used to store tokens during deployment, the foreman-proxy user requires read and write access to this file.
+
+You can also change the certificate used for encrypting the token file by setting **certificate**. By default it uses the certificate of the Smart Proxy defined in `settings.yml` as **ssl_certificate**.
+
+To integrate this in Puppet the script `puppet_sign.rb` provided by the Smart Proxy has to be used for verfication of the tokens during certificate signing.
+If installed via package the script should be already located at `/usr/share/foreman-proxy/extra/puppet_sign.rb`.
+For manual installation the script can be found on [Github](https://github.com/theforeman/smart-proxy/blob/develop/extra/puppet_sign.rb). Using the latest version should be fine, if you encounter problems try the one released with your Smart Proxy version.
+The script has to be executable by the same user running the Puppet master, typically puppet.
+
+After deploying the script the Puppet configuration has to be changed to point the **autosign** setting to the script.
+
+<pre>
+[master]
+autosign = /usr/share/foreman-proxy/extra/puppet_sign.rb
 </pre>

--- a/_includes/manuals/nightly/4.3.7_smartproxy_puppetca.md
+++ b/_includes/manuals/nightly/4.3.7_smartproxy_puppetca.md
@@ -1,23 +1,40 @@
 
 Activate the Puppet CA management module within the Smart Proxy instance.  This is used to manage the autosign configuration and handle listing, signing and revocation of individual certificates.
 
-This should only be enabled in the Smart Proxy that is hosted on the machine responsible for providing certificates to your puppet clients. You would expect to see a directory **/var/lib/puppet/ssl/ca** on such a host.
+Builtin providers are:
+
+* `puppetca_hostname_whitelisting` - direct management of Puppet's `autosign.conf`
+* `puppetca_token_whitelisting` - manage token-based signing of certificate requests
+
+This should only be enabled in the Smart Proxy that is hosted on the machine responsible for providing certificates to your puppet clients. You would expect to see a subdirectory **ca** in your Puppet's ssldir on such a host. You can determine the ssldir with the command `puppet config print ssldir`. On this host enable the feature in `puppetca.yml`:
 
 <pre>
 :enabled: https
 </pre>
 
-If your puppet SSL directory is located elsewhere, you'll need to set 'ssldir' as well.
+If your puppet SSL directory is not located in `/var/lib/puppet/ssl`, you'll need to set **ssldir** as well.
 <pre>
 :ssldir: /etc/puppet/ssl
 </pre>
 
-The 'autosignfile' setting is used to find autosign.conf:
+Also choose the provider to use, default should be `puppetca_hostname_whitelisting`:
+<pre>
+:use_provider: puppetca_hostname_whitelisting
+</pre>
+
+#### puppetca_hostname_whitelisting
+
+The puppetca_hostname_whitelisting provider directly manages Puppet's `autosign.conf` file.
+This will create an autosign entry for a host during deployment and remove it when deployment is finished.
+Furthermore it allows you to manage entries manually using the Foreman WebUI.
+
+The **autosignfile** setting in `puppetca_hostname_whitelisting.yml` is used to find autosign.conf:
 
 <pre>
 :autosignfile: /etc/puppet/autosign.conf
 </pre>
 
+The location of the file can be determined with `puppet config print autosign`.
 The proxy requires write access to the puppet autosign.conf file, which is usually owner and group puppet, and has mode 0644 according to the puppet defaults.
 
 Under a Puppet 4 AIO installation, paths should be set to:
@@ -56,4 +73,35 @@ For older versions of Puppet (2.x) with separate commands:
 <pre>
 foreman-proxy ALL = NOPASSWD: /usr/sbin/puppetca *
 Defaults:foreman-proxy !requiretty
+</pre>
+
+#### puppetca_token_whitelisting
+
+The puppetca_token_whitelisting provider uses a token-based certificate signing managed by the Smart proxy itself and queried by Puppet during Provisioning.
+This provider adds more security and logging to the autosigning process but does not allow for manual creation of autosigning entries.
+
+This provider has the following settings in `puppetca_token_whitelisting.yml`:
+
+<pre>
+:sign_all: false
+:token_ttl: 360
+:tokens_file: /var/lib/foreman-proxy/tokens.yml
+</pre>
+
+By changing **sign_all** to `true` you will disable token verification and sign all certificate requests.
+The setting **token_ttl** defines how long a token after creation is valid in minutes.
+**tokens_file** sets the path to the file used to store tokens during deployment, the foreman-proxy user requires read and write access to this file.
+
+You can also change the certificate used for encrypting the token file by setting **certificate**. By default it uses the certificate of the Smart Proxy defined in `settings.yml` as **ssl_certificate**.
+
+To integrate this in Puppet the script `puppet_sign.rb` provided by the Smart Proxy has to be used for verfication of the tokens during certificate signing.
+If installed via package the script should be already located at `/usr/share/foreman-proxy/extra/puppet_sign.rb`.
+For manual installation the script can be found on [Github](https://github.com/theforeman/smart-proxy/blob/develop/extra/puppet_sign.rb). Using the latest version should be fine, if you encounter problems try the one released with your Smart Proxy version.
+The script has to be executable by the same user running the Puppet master, typically puppet.
+
+After deploying the script the Puppet configuration has to be changed to point the **autosign** setting to the script.
+
+<pre>
+[master]
+autosign = /usr/share/foreman-proxy/extra/puppet_sign.rb
 </pre>


### PR DESCRIPTION
Update of the documentation was requested by @tbrisker in https://github.com/theforeman/smart-proxy/pull/586. @timogoebel can you please review?

Should the changes also be backported to older manuals? If yes, 1.19 included the change to make puppetca plug-able and 1.20 added the token based mechanism, correct?