### PR TITLE
Update Hammer CLI Katello rubygem

### DIFF
--- a/plugins/katello/3.10/cli/index.md
+++ b/plugins/katello/3.10/cli/index.md
@@ -64,7 +64,7 @@ yum -y localinstall http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.n
 After setting up the appropriate repositories, install Katello:
 
 {% highlight bash %}
-yum -y install rubygem-hammer_cli_katello
+yum -y install tfm-rubygem-hammer_cli_katello
 {% endhighlight %}
 
 ## How do I use Hammer?

--- a/plugins/katello/3.7/cli/index.md
+++ b/plugins/katello/3.7/cli/index.md
@@ -64,7 +64,7 @@ yum -y localinstall http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.n
 After setting up the appropriate repositories, install Katello:
 
 {% highlight bash %}
-yum -y install rubygem-hammer_cli_katello
+yum -y install tfm-rubygem-hammer_cli_katello
 {% endhighlight %}
 
 ## How do I use Hammer?

--- a/plugins/katello/3.8/cli/index.md
+++ b/plugins/katello/3.8/cli/index.md
@@ -64,7 +64,7 @@ yum -y localinstall http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.n
 After setting up the appropriate repositories, install Katello:
 
 {% highlight bash %}
-yum -y install rubygem-hammer_cli_katello
+yum -y install tfm-rubygem-hammer_cli_katello
 {% endhighlight %}
 
 ## How do I use Hammer?

--- a/plugins/katello/3.9/cli/index.md
+++ b/plugins/katello/3.9/cli/index.md
@@ -64,7 +64,7 @@ yum -y localinstall http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.n
 After setting up the appropriate repositories, install Katello:
 
 {% highlight bash %}
-yum -y install rubygem-hammer_cli_katello
+yum -y install tfm-rubygem-hammer_cli_katello
 {% endhighlight %}
 
 ## How do I use Hammer?

--- a/plugins/katello/nightly/cli/index.md
+++ b/plugins/katello/nightly/cli/index.md
@@ -64,7 +64,7 @@ yum -y localinstall https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.
 After setting up the appropriate repositories, install Katello:
 
 {% highlight bash %}
-yum -y install rubygem-hammer_cli_katello
+yum -y install tfm-rubygem-hammer_cli_katello
 {% endhighlight %}
 
 ## How do I use Hammer?


### PR DESCRIPTION
Currently, theforeman.org lists the following directions for installing the hammer rubygem:
```
After setting up the appropriate repositories, install Katello:

yum -y install rubygem-hammer_cli_katello
```

But running the following shows that "tfm" should be a prefix:
```
[vagrant@centos7-devel katello]$ rpm -qa | grep hammer
tfm-rubygem-hammer_cli_katello-0.17-0.201901041743git4cc3b230.1.pre.master.el7.noarch
```