### PR TITLE
Update manual for Smart Proxy puppetca with path of puppet_sign.rb

### DIFF
--- a/_includes/manuals/1.20/4.3.7_smartproxy_puppetca.md
+++ b/_includes/manuals/1.20/4.3.7_smartproxy_puppetca.md
@@ -95,7 +95,7 @@ The setting **token_ttl** defines how long a token after creation is valid in mi
 You can also change the certificate used for encrypting the token file by setting **certificate**. By default it uses the certificate of the Smart Proxy defined in `settings.yml` as **ssl_certificate**.
 
 To integrate this in Puppet the script `puppet_sign.rb` provided by the Smart Proxy has to be used for verfication of the tokens during certificate signing.
-If installed via package the script should be already located at `/usr/share/foreman-proxy/extra/puppet_sign.rb`.
+If installed via package the script should be already located at `/usr/libexec/foreman-proxy/puppet_sign.rb`.
 For manual installation the script can be found on [Github](https://github.com/theforeman/smart-proxy/blob/develop/extra/puppet_sign.rb). Using the latest version should be fine, if you encounter problems try the one released with your Smart Proxy version.
 The script has to be executable by the same user running the Puppet master, typically puppet.
 
@@ -103,5 +103,5 @@ After deploying the script the Puppet configuration has to be changed to point t
 
 <pre>
 [master]
-autosign = /usr/share/foreman-proxy/extra/puppet_sign.rb
+autosign = /usr/libexec/foreman-proxy/puppet_sign.rb
 </pre>

--- a/_includes/manuals/nightly/4.3.7_smartproxy_puppetca.md
+++ b/_includes/manuals/nightly/4.3.7_smartproxy_puppetca.md
@@ -95,7 +95,7 @@ The setting **token_ttl** defines how long a token after creation is valid in mi
 You can also change the certificate used for encrypting the token file by setting **certificate**. By default it uses the certificate of the Smart Proxy defined in `settings.yml` as **ssl_certificate**.
 
 To integrate this in Puppet the script `puppet_sign.rb` provided by the Smart Proxy has to be used for verfication of the tokens during certificate signing.
-If installed via package the script should be already located at `/usr/share/foreman-proxy/extra/puppet_sign.rb`.
+If installed via package the script should be already located at `/usr/libexec/foreman-proxy/puppet_sign.rb`.
 For manual installation the script can be found on [Github](https://github.com/theforeman/smart-proxy/blob/develop/extra/puppet_sign.rb). Using the latest version should be fine, if you encounter problems try the one released with your Smart Proxy version.
 The script has to be executable by the same user running the Puppet master, typically puppet.
 
@@ -103,5 +103,5 @@ After deploying the script the Puppet configuration has to be changed to point t
 
 <pre>
 [master]
-autosign = /usr/share/foreman-proxy/extra/puppet_sign.rb
+autosign = /usr/libexec/foreman-proxy/puppet_sign.rb
 </pre>


### PR DESCRIPTION
Changed the path according to @ekohl's suggestion in #1272 