### PR TITLE
Fix Foreman version number for 3.8 proxy

### DIFF
--- a/plugins/katello/3.8/upgrade/smart_proxy.md
+++ b/plugins/katello/3.8/upgrade/smart_proxy.md
@@ -2,7 +2,7 @@
 layout: plugins/katello/documentation
 title: Smart Proxy Upgrade
 version: 3.8
-foreman_version: 1.18
+foreman_version: 1.19
 ---
 
 # Smart Proxy Upgrade


### PR DESCRIPTION
Katello 3.8 doc for proxy upgrade has Foreman version 1.18 specified - this should be Foreman 1.19