### PR TITLE
Add warning that mysql should be version 5.7

### DIFF
--- a/_includes/manuals/1.20/1.2_release_notes.md
+++ b/_includes/manuals/1.20/1.2_release_notes.md
@@ -501,6 +501,7 @@ them can be set directly in `settings.yaml` or via the installer.
 * Access to `@host.params['param_name']` in templates, which has been deprecated several versions ago, has been removed. Templates can access host parameters using the `host_param('param_name')` macro instead.
 * Operating System `pxe_files`, `pxe_prefix`, `kernel`, `initrd`, `bootfile`, `boot_files_uri`  methods now expect a Medium Provider as their first argument. Please update any templates accordingly. See the [redmine issue](https://projects.theforeman.org/issues/19389) and [associated changes](https://github.com/theforeman/foreman/commit/ef1bbc264acfe0864bd24e7ce54e6b37dcda37ad) for further details.
 * The audit history doesn't display correctly if locations or organizations have been disabled in your settings.yaml. These options are now deprecated, see [the redmine issue](https://projects.theforeman.org/issues/24800) for more details.
+* For installations with MySQL as a backend it must be version 5.7 to support index prefixes larger than 767 bytes. Older versions result in the db migration "Add type to token" failing and leaving the system unusable. Failed upgrades can be recovered by upgrading mysql to 5.7 then re-running the migration scripts.
 
 ### Contributors
 


### PR DESCRIPTION
Add warning for mysql version as discussed in https://community.theforeman.org/t/update-1-20-from-1-19-mysql-5-7-dependancy-warning/12570/3.