### PR TITLE
Update Katello latest version to 3.10 for installation docs

### DIFF
--- a/plugins/katello/2.4/installation/2.0-transition.md
+++ b/plugins/katello/2.4/installation/2.0-transition.md
@@ -2,7 +2,7 @@
 layout: plugins/katello/documentation
 version: 2.4
 title: "Transitioning from 1.4 to 2.0"
-latest: 3.4
+latest: '3.10'
 ---
 
 # Transitioning from Katello 1.4 to 2.0

--- a/plugins/katello/2.4/installation/index.md
+++ b/plugins/katello/2.4/installation/index.md
@@ -4,7 +4,7 @@ title: Katello Installation
 version: 2.4
 foreman_version: "1.10"
 script: osmenu.js
-latest: 3.4
+latest: '3.10'
 ---
 
 # Katello {{ page.version }} Installation

--- a/plugins/katello/3.0/installation/index.md
+++ b/plugins/katello/3.0/installation/index.md
@@ -3,7 +3,7 @@ layout: plugins/katello/documentation
 title: Katello Installation
 version: 3.0
 foreman_version: 1.11
-latest: 3.4
+latest: '3.10'
 script: osmenu.js
 ---
 

--- a/plugins/katello/3.1/installation/index.md
+++ b/plugins/katello/3.1/installation/index.md
@@ -3,7 +3,7 @@ layout: plugins/katello/documentation
 title: Katello Installation
 version: 3.1
 foreman_version: 1.12
-latest: 3.4
+latest: '3.10'
 script: osmenu.js
 ---
 

--- a/plugins/katello/3.2/installation/index.md
+++ b/plugins/katello/3.2/installation/index.md
@@ -3,7 +3,7 @@ layout: plugins/katello/documentation
 title: Katello Installation
 version: 3.2
 foreman_version: 1.13
-latest: 3.4
+latest: '3.10'
 script: osmenu.js
 ---
 

--- a/plugins/katello/3.3/installation/index.md
+++ b/plugins/katello/3.3/installation/index.md
@@ -3,7 +3,7 @@ layout: plugins/katello/documentation
 title: Katello Installation
 version: 3.3
 foreman_version: 1.14
-latest: 3.4
+latest: '3.10'
 script: osmenu.js
 ---
 

--- a/plugins/katello/3.4/installation/index.md
+++ b/plugins/katello/3.4/installation/index.md
@@ -3,7 +3,7 @@ layout: plugins/katello/documentation
 title: Katello Installation
 version: 3.4
 foreman_version: 1.15
-latest: 3.4
+latest: '3.10'
 script: osmenu.js
 ---
 

--- a/plugins/katello/3.5/installation/index.md
+++ b/plugins/katello/3.5/installation/index.md
@@ -3,7 +3,7 @@ layout: plugins/katello/documentation
 title: Katello Installation
 version: 3.5
 foreman_version: 1.16
-latest: 3.5
+latest: '3.10'
 script: osmenu.js
 ---
 

--- a/plugins/katello/3.6/installation/index.md
+++ b/plugins/katello/3.6/installation/index.md
@@ -3,7 +3,7 @@ layout: plugins/katello/documentation
 title: Katello Installation
 version: 3.6
 foreman_version: 1.17
-latest: 3.6
+latest: '3.10'
 script: osmenu.js
 ---
 

--- a/plugins/katello/3.7/installation/index.md
+++ b/plugins/katello/3.7/installation/index.md
@@ -3,7 +3,7 @@ layout: plugins/katello/documentation
 title: Katello Installation
 version: 3.7
 foreman_version: 1.18
-latest: 3.7
+latest: '3.10'
 script: osmenu.js
 ---
 

--- a/plugins/katello/3.8/installation/index.md
+++ b/plugins/katello/3.8/installation/index.md
@@ -3,7 +3,7 @@ layout: plugins/katello/documentation
 title: Katello Installation
 version: 3.8
 foreman_version: 1.19
-latest: 3.8
+latest: '3.10'
 script: osmenu.js
 ---
 

--- a/plugins/katello/3.9/installation/index.md
+++ b/plugins/katello/3.9/installation/index.md
@@ -3,7 +3,7 @@ layout: plugins/katello/documentation
 title: Katello Installation
 version: '3.9'
 foreman_version: '1.20'
-latest: '3.9'
+latest: '3.10'
 script: osmenu.js
 ---
 

--- a/plugins/katello/nightly/installation/index.md
+++ b/plugins/katello/nightly/installation/index.md
@@ -3,7 +3,7 @@ layout: plugins/katello/documentation
 title: Katello Installation
 version: nightly
 foreman_version: nightly
-latest: 3.4
+latest: nightly
 script: osmenu.js
 ---
 
@@ -11,7 +11,7 @@ script: osmenu.js
 
 {% if page.version == 'nightly' %}
   <div class="alert alert-danger">
-    These are the instructions for installing the unstable nightly release of katello!
+    These are the instructions for installing the unstable nightly release of Katello!
   </div>
 {% elsif page.version != page.latest %}
   <div class="alert alert-danger">


### PR DESCRIPTION
Looks like this hasn't been touched in quite a while .. I'll add a note in tool_belt doc branching steps soon.