### PR TITLE
allow easier selection of os-specific sections

### DIFF
--- a/plugins/katello/nightly/installation/clients.md
+++ b/plugins/katello/nightly/installation/clients.md
@@ -77,6 +77,7 @@ Now you are ready to install the client package:
 
 The `katello-host-tools` package reports errata & package profile information, but does not allow you to run remote actions on the clients.
 
+<div class="el5 el6 el7 f27 f28">
 {% highlight bash %}
 yum install katello-host-tools
 {% endhighlight %}
@@ -87,17 +88,22 @@ We generally recommend using Foreman Remote Execution or Ansible for remote acti
 yum install katello-agent
 {% endhighlight %}
 
+<div class="el7 f27 f28">
 Optionally you can also install `katello-host-tools-tracer` and the client will report processes that need restarting after an update back to the Katello server.
 
 {% highlight bash %}
 yum install katello-host-tools-tracer
 {% endhighlight %}
+</div>
+</div>
 
-For Suse Clients, only katello-host-tools is supported:
+<div class="sles11 sles12" style="display:none;" markdown="1">
+For Suse Clients, only `katello-host-tools` is supported:
 
 {% highlight bash %}
 zypper install katello-host-tools
 {% endhighlight %}
+</div>
 
 ## Provisioned
 

--- a/static/js/osmenu.js
+++ b/static/js/osmenu.js
@@ -19,10 +19,12 @@ $(document).ready(function(){
 
         function show(os) {
             $('#' + os).show();
+            $('.' + os).show();
         }
 
         function hide(os) {
             $('#' + os).hide();
+            $('.' + os).hide();
         }
 
         function showOS(operatingSystem) {
@@ -30,10 +32,13 @@ $(document).ready(function(){
 
             for(os in operatingSystems) {
                 if (operatingSystems.hasOwnProperty(os)) {
+                    hide(os);
+                }
+            }
+            for(os in operatingSystems) {
+                if (operatingSystems.hasOwnProperty(os)) {
                     if (os === operatingSystem) {
                         show(os);
-                    } else {
-                        hide(os);
                     }
                 }
             }


### PR DESCRIPTION
* use css classes for selection, allowing multiple sections to be marked
  as "to show" or "to hide"
* the above requires the "show/hide" loop to be split in two:
  first hide everything, then show what the author selected
* use this feature to hide tracer on EL5/6 and yum instructions on SUSE