### PR TITLE
fix placement of latest news in the footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -6,7 +6,7 @@
       </div>
     </div>
     <div class='row'>
-      <div class="latest-news col-md-offset-3 col-md-6">
+      <div class="latest-news col-md-offset-2 col-md-8">
         {% include latest_news.html %}
       </div>
     </div>


### PR DESCRIPTION
before:
![screenshot from 2019-01-29 13-33-34](https://user-images.githubusercontent.com/94284/51908611-99ab0a00-23ca-11e9-91c9-06ef308443a9.png)

after:
![screenshot from 2019-01-29 13-33-11](https://user-images.githubusercontent.com/94284/51908625-a0d21800-23ca-11e9-8172-bec6c93b0c4c.png)
