### PR TITLE
Don't rely on display:none

### DIFF
--- a/plugins/katello/3.10/installation/clients.md
+++ b/plugins/katello/3.10/installation/clients.md
@@ -27,14 +27,14 @@ Install the appropriate Katello client release packages.
   </select>
 </p>
 
-<div id="el5" style="display:none;" markdown="1">
+<div id="el5" markdown="1">
 {% highlight bash %}
 yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-5.noarch.rpm
 yum install -y https://yum.theforeman.org/client/{{ page.foreman_version }}/el5/x86_64/foreman-client-release.rpm
 {% endhighlight %}
 </div>
 
-<div id="el6" style="display:none;" markdown="1">
+<div id="el6" markdown="1">
 {% highlight bash %}
 yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
 yum install -y https://yum.theforeman.org/client/{{ page.foreman_version }}/el6/x86_64/foreman-client-release.rpm
@@ -48,25 +48,25 @@ yum install -y https://yum.theforeman.org/client/{{ page.foreman_version }}/el7/
 {% endhighlight %}
 </div>
 
-<div id="f27" style="display:none;" markdown="1">
+<div id="f27" markdown="1">
 {% highlight bash %}
 yum install -y https://yum.theforeman.org/client/{{ page.foreman_version }}/fc27/x86_64/foreman-client-release.rpm
 {% endhighlight %}
 </div>
 
-<div id="f28" style="display:none;" markdown="1">
+<div id="f28" markdown="1">
 {% highlight bash %}
 yum install -y https://yum.theforeman.org/client/{{ page.foreman_version }}/fc28/x86_64/foreman-client-release.rpm
 {% endhighlight %}
 </div>
 
-<div id="sles12" style="display:none;" markdown="1">
+<div id="sles12" markdown="1">
 {% highlight bash %}
 rpm -Uvh https://yum.theforeman.org/client/{{ page.foreman_version }}/sles12/x86_64/foreman-client-release.rpm
 {% endhighlight %}
 </div>
 
-<div id="sles11" style="display:none;" markdown="1">
+<div id="sles11" markdown="1">
 {% highlight bash %}
 # For python-datetime dependency, ensure that the SDK addon product is enabled see: https://www.suse.com/support/kb/doc/?id=7015337
 zypper modifyrepo -e nu_novell_com:SLES11-Extras
@@ -88,6 +88,7 @@ We generally recommend using Foreman Remote Execution or Ansible for remote acti
 {% highlight bash %}
 yum install katello-agent
 {% endhighlight %}
+</div>
 
 <div class="el7 f27 f28">
 Optionally you can also install `katello-host-tools-tracer` and the client will report processes that need restarting after an update back to the Katello server.
@@ -96,9 +97,8 @@ Optionally you can also install `katello-host-tools-tracer` and the client will 
 yum install katello-host-tools-tracer
 {% endhighlight %}
 </div>
-</div>
 
-<div class="sles11 sles12" style="display:none;" markdown="1">
+<div class="sles11 sles12" markdown="1">
 For Suse Clients, only `katello-host-tools` is supported:
 
 {% highlight bash %}

--- a/plugins/katello/3.10/upgrade/clients.md
+++ b/plugins/katello/3.10/upgrade/clients.md
@@ -35,37 +35,37 @@ yum update -y https://yum.theforeman.org/client/{{ page.foreman_version }}/el5/x
 {% endhighlight %}
 </div>
 
-<div id="el6" style="display:none;" markdown="1">
+<div id="el6" markdown="1">
 {% highlight bash %}
 yum update -y https://yum.theforeman.org/client/{{ page.foreman_version }}/el6/x86_64/foreman-client-release.rpm
 {% endhighlight %}
 </div>
 
-<div id="el7" style="display:none;" markdown="1">
+<div id="el7" markdown="1">
 {% highlight bash %}
 yum update -y https://yum.theforeman.org/client/{{ page.foreman_version }}/el7/x86_64/foreman-client-release.rpm
 {% endhighlight %}
 </div>
 
-<div id="f27" style="display:none;" markdown="1">
+<div id="f27" markdown="1">
 {% highlight bash %}
 yum update -y https://yum.theforeman.org/client/{{ page.foreman_version }}/fc27/x86_64/foreman-client-release.rpm
 {% endhighlight %}
 </div>
 
-<div id="f28" style="display:none;" markdown="1">
+<div id="f28" markdown="1">
 {% highlight bash %}
 yum update -y https://yum.theforeman.org/client/{{ page.foreman_version }}/fc28/x86_64/foreman-client-release.rpm
 {% endhighlight %}
 </div>
 
-<div id="sles12" style="display:none;" markdown="1">
+<div id="sles12" markdown="1">
 {% highlight bash %}
 rpm -Uvh https://yum.theforeman.org/client/{{ page.foreman_version }}/sles12/x86_64/foreman-client-release.rpm
 {% endhighlight %}
 </div>
 
-<div id="sles11" style="display:none;" markdown="1">
+<div id="sles11" markdown="1">
 {% highlight bash %}
 # For python-datetime dependency, ensure that the SDK addon product is enabled see: https://www.suse.com/support/kb/doc/?id=7015337
 zypper modifyrepo -e nu_novell_com:SLES11-Extras

--- a/plugins/katello/3.11/installation/clients.md
+++ b/plugins/katello/3.11/installation/clients.md
@@ -34,39 +34,39 @@ yum install -y https://yum.theforeman.org/client/{{ page.foreman_version }}/el5/
 {% endhighlight %}
 </div>
 
-<div id="el6" style="display:none;" markdown="1">
+<div id="el6" markdown="1">
 {% highlight bash %}
 yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
 yum install -y https://yum.theforeman.org/client/{{ page.foreman_version }}/el6/x86_64/foreman-client-release.rpm
 {% endhighlight %}
 </div>
 
-<div id="el7" style="display:none;" markdown="1">
+<div id="el7" markdown="1">
 {% highlight bash %}
 yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 yum install -y https://yum.theforeman.org/client/{{ page.foreman_version }}/el7/x86_64/foreman-client-release.rpm
 {% endhighlight %}
 </div>
 
-<div id="f27" style="display:none;" markdown="1">
+<div id="f27" markdown="1">
 {% highlight bash %}
 yum install -y https://yum.theforeman.org/client/{{ page.foreman_version }}/fc27/x86_64/foreman-client-release.rpm
 {% endhighlight %}
 </div>
 
-<div id="f28" style="display:none;" markdown="1">
+<div id="f28" markdown="1">
 {% highlight bash %}
 yum install -y https://yum.theforeman.org/client/{{ page.foreman_version }}/fc28/x86_64/foreman-client-release.rpm
 {% endhighlight %}
 </div>
 
-<div id="sles12" style="display:none;" markdown="1">
+<div id="sles12" markdown="1">
 {% highlight bash %}
 rpm -Uvh https://yum.theforeman.org/client/{{ page.foreman_version }}/sles12/x86_64/foreman-client-release.rpm
 {% endhighlight %}
 </div>
 
-<div id="sles11" style="display:none;" markdown="1">
+<div id="sles11" markdown="1">
 {% highlight bash %}
 # For python-datetime dependency, ensure that the SDK addon product is enabled see: https://www.suse.com/support/kb/doc/?id=7015337
 zypper modifyrepo -e nu_novell_com:SLES11-Extras

--- a/plugins/katello/3.11/upgrade/clients.md
+++ b/plugins/katello/3.11/upgrade/clients.md
@@ -35,37 +35,37 @@ yum update -y https://yum.theforeman.org/client/{{ page.foreman_version }}/el5/x
 {% endhighlight %}
 </div>
 
-<div id="el6" style="display:none;" markdown="1">
+<div id="el6" markdown="1">
 {% highlight bash %}
 yum update -y https://yum.theforeman.org/client/{{ page.foreman_version }}/el6/x86_64/foreman-client-release.rpm
 {% endhighlight %}
 </div>
 
-<div id="el7" style="display:none;" markdown="1">
+<div id="el7" markdown="1">
 {% highlight bash %}
 yum update -y https://yum.theforeman.org/client/{{ page.foreman_version }}/el7/x86_64/foreman-client-release.rpm
 {% endhighlight %}
 </div>
 
-<div id="f27" style="display:none;" markdown="1">
+<div id="f27" markdown="1">
 {% highlight bash %}
 yum update -y https://yum.theforeman.org/client/{{ page.foreman_version }}/fc27/x86_64/foreman-client-release.rpm
 {% endhighlight %}
 </div>
 
-<div id="f28" style="display:none;" markdown="1">
+<div id="f28" markdown="1">
 {% highlight bash %}
 yum update -y https://yum.theforeman.org/client/{{ page.foreman_version }}/fc28/x86_64/foreman-client-release.rpm
 {% endhighlight %}
 </div>
 
-<div id="sles12" style="display:none;" markdown="1">
+<div id="sles12" markdown="1">
 {% highlight bash %}
 rpm -Uvh https://yum.theforeman.org/client/{{ page.foreman_version }}/sles12/x86_64/foreman-client-release.rpm
 {% endhighlight %}
 </div>
 
-<div id="sles11" style="display:none;" markdown="1">
+<div id="sles11" markdown="1">
 {% highlight bash %}
 # For python-datetime dependency, ensure that the SDK addon product is enabled see: https://www.suse.com/support/kb/doc/?id=7015337
 zypper modifyrepo -e nu_novell_com:SLES11-Extras

--- a/plugins/katello/3.9/installation/clients.md
+++ b/plugins/katello/3.9/installation/clients.md
@@ -27,14 +27,14 @@ Install the appropriate Katello client release packages.
   </select>
 </p>
 
-<div id="el5" style="display:none;" markdown="1">
+<div id="el5" markdown="1">
 {% highlight bash %}
 yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-5.noarch.rpm
 yum install -y https://yum.theforeman.org/client/{{ page.foreman_version }}/el5/x86_64/foreman-client-release.rpm
 {% endhighlight %}
 </div>
 
-<div id="el6" style="display:none;" markdown="1">
+<div id="el6" markdown="1">
 {% highlight bash %}
 yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
 yum install -y https://yum.theforeman.org/client/{{ page.foreman_version }}/el6/x86_64/foreman-client-release.rpm
@@ -48,25 +48,25 @@ yum install -y https://yum.theforeman.org/client/{{ page.foreman_version }}/el7/
 {% endhighlight %}
 </div>
 
-<div id="f27" style="display:none;" markdown="1">
+<div id="f27" markdown="1">
 {% highlight bash %}
 yum install -y https://yum.theforeman.org/client/{{ page.foreman_version }}/fc27/x86_64/foreman-client-release.rpm
 {% endhighlight %}
 </div>
 
-<div id="f28" style="display:none;" markdown="1">
+<div id="f28" markdown="1">
 {% highlight bash %}
 yum install -y https://yum.theforeman.org/client/{{ page.foreman_version }}/fc28/x86_64/foreman-client-release.rpm
 {% endhighlight %}
 </div>
 
-<div id="sles12" style="display:none;" markdown="1">
+<div id="sles12" markdown="1">
 {% highlight bash %}
 rpm -Uvh https://yum.theforeman.org/client/{{ page.foreman_version }}/sles12/x86_64/foreman-client-release.rpm
 {% endhighlight %}
 </div>
 
-<div id="sles11" style="display:none;" markdown="1">
+<div id="sles11" markdown="1">
 {% highlight bash %}
 # For python-datetime dependency, ensure that the SDK addon product is enabled see: https://www.suse.com/support/kb/doc/?id=7015337
 zypper modifyrepo -e nu_novell_com:SLES11-Extras
@@ -88,6 +88,7 @@ We generally recommend using Foreman Remote Execution or Ansible for remote acti
 {% highlight bash %}
 yum install katello-agent
 {% endhighlight %}
+</div>
 
 <div class="el7 f27 f28">
 Optionally you can also install `katello-host-tools-tracer` and the client will report processes that need restarting after an update back to the Katello server.
@@ -96,9 +97,8 @@ Optionally you can also install `katello-host-tools-tracer` and the client will 
 yum install katello-host-tools-tracer
 {% endhighlight %}
 </div>
-</div>
 
-<div class="sles11 sles12" style="display:none;" markdown="1">
+<div class="sles11 sles12" markdown="1">
 For Suse Clients, only `katello-host-tools` is supported:
 
 {% highlight bash %}

--- a/plugins/katello/3.9/upgrade/clients.md
+++ b/plugins/katello/3.9/upgrade/clients.md
@@ -35,37 +35,37 @@ yum update -y https://yum.theforeman.org/client/{{ page.foreman_version }}/el5/x
 {% endhighlight %}
 </div>
 
-<div id="el6" style="display:none;" markdown="1">
+<div id="el6" markdown="1">
 {% highlight bash %}
 yum update -y https://yum.theforeman.org/client/{{ page.foreman_version }}/el6/x86_64/foreman-client-release.rpm
 {% endhighlight %}
 </div>
 
-<div id="el7" style="display:none;" markdown="1">
+<div id="el7" markdown="1">
 {% highlight bash %}
 yum update -y https://yum.theforeman.org/client/{{ page.foreman_version }}/el7/x86_64/foreman-client-release.rpm
 {% endhighlight %}
 </div>
 
-<div id="f27" style="display:none;" markdown="1">
+<div id="f27" markdown="1">
 {% highlight bash %}
 yum update -y https://yum.theforeman.org/client/{{ page.foreman_version }}/fc27/x86_64/foreman-client-release.rpm
 {% endhighlight %}
 </div>
 
-<div id="f28" style="display:none;" markdown="1">
+<div id="f28" markdown="1">
 {% highlight bash %}
 yum update -y https://yum.theforeman.org/client/{{ page.foreman_version }}/fc28/x86_64/foreman-client-release.rpm
 {% endhighlight %}
 </div>
 
-<div id="sles12" style="display:none;" markdown="1">
+<div id="sles12" markdown="1">
 {% highlight bash %}
 rpm -Uvh https://yum.theforeman.org/client/{{ page.foreman_version }}/sles12/x86_64/foreman-client-release.rpm
 {% endhighlight %}
 </div>
 
-<div id="sles11" style="display:none;" markdown="1">
+<div id="sles11" markdown="1">
 {% highlight bash %}
 # For python-datetime dependency, ensure that the SDK addon product is enabled see: https://www.suse.com/support/kb/doc/?id=7015337
 zypper modifyrepo -e nu_novell_com:SLES11-Extras

--- a/plugins/katello/nightly/installation/clients.md
+++ b/plugins/katello/nightly/installation/clients.md
@@ -27,14 +27,14 @@ Install the appropriate Katello client release packages.
   </select>
 </p>
 
-<div id="el5" style="display:none;" markdown="1">
+<div id="el5" markdown="1">
 {% highlight bash %}
 yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-5.noarch.rpm
 yum install -y https://yum.theforeman.org/client/{{ page.foreman_version }}/el5/x86_64/foreman-client-release.rpm
 {% endhighlight %}
 </div>
 
-<div id="el6" style="display:none;" markdown="1">
+<div id="el6" markdown="1">
 {% highlight bash %}
 yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
 yum install -y https://yum.theforeman.org/client/{{ page.foreman_version }}/el6/x86_64/foreman-client-release.rpm
@@ -48,25 +48,25 @@ yum install -y https://yum.theforeman.org/client/{{ page.foreman_version }}/el7/
 {% endhighlight %}
 </div>
 
-<div id="f27" style="display:none;" markdown="1">
+<div id="f27" markdown="1">
 {% highlight bash %}
 yum install -y https://yum.theforeman.org/client/{{ page.foreman_version }}/fc27/x86_64/foreman-client-release.rpm
 {% endhighlight %}
 </div>
 
-<div id="f28" style="display:none;" markdown="1">
+<div id="f28" markdown="1">
 {% highlight bash %}
 yum install -y https://yum.theforeman.org/client/{{ page.foreman_version }}/fc28/x86_64/foreman-client-release.rpm
 {% endhighlight %}
 </div>
 
-<div id="sles12" style="display:none;" markdown="1">
+<div id="sles12" markdown="1">
 {% highlight bash %}
 rpm -Uvh https://yum.theforeman.org/client/{{ page.foreman_version }}/sles12/x86_64/foreman-client-release.rpm
 {% endhighlight %}
 </div>
 
-<div id="sles11" style="display:none;" markdown="1">
+<div id="sles11" markdown="1">
 {% highlight bash %}
 # For python-datetime dependency, ensure that the SDK addon product is enabled see: https://www.suse.com/support/kb/doc/?id=7015337
 zypper modifyrepo -e nu_novell_com:SLES11-Extras
@@ -88,6 +88,7 @@ We generally recommend using Foreman Remote Execution or Ansible for remote acti
 {% highlight bash %}
 yum install katello-agent
 {% endhighlight %}
+</div>
 
 <div class="el7 f27 f28">
 Optionally you can also install `katello-host-tools-tracer` and the client will report processes that need restarting after an update back to the Katello server.
@@ -96,9 +97,8 @@ Optionally you can also install `katello-host-tools-tracer` and the client will 
 yum install katello-host-tools-tracer
 {% endhighlight %}
 </div>
-</div>
 
-<div class="sles11 sles12" style="display:none;" markdown="1">
+<div class="sles11 sles12" markdown="1">
 For Suse Clients, only `katello-host-tools` is supported:
 
 {% highlight bash %}

--- a/plugins/katello/nightly/upgrade/clients.md
+++ b/plugins/katello/nightly/upgrade/clients.md
@@ -35,37 +35,37 @@ yum update -y https://yum.theforeman.org/client/{{ page.foreman_version }}/el5/x
 {% endhighlight %}
 </div>
 
-<div id="el6" style="display:none;" markdown="1">
+<div id="el6" markdown="1">
 {% highlight bash %}
 yum update -y https://yum.theforeman.org/client/{{ page.foreman_version }}/el6/x86_64/foreman-client-release.rpm
 {% endhighlight %}
 </div>
 
-<div id="el7" style="display:none;" markdown="1">
+<div id="el7" markdown="1">
 {% highlight bash %}
 yum update -y https://yum.theforeman.org/client/{{ page.foreman_version }}/el7/x86_64/foreman-client-release.rpm
 {% endhighlight %}
 </div>
 
-<div id="f27" style="display:none;" markdown="1">
+<div id="f27" markdown="1">
 {% highlight bash %}
 yum update -y https://yum.theforeman.org/client/{{ page.foreman_version }}/fc27/x86_64/foreman-client-release.rpm
 {% endhighlight %}
 </div>
 
-<div id="f28" style="display:none;" markdown="1">
+<div id="f28" markdown="1">
 {% highlight bash %}
 yum update -y https://yum.theforeman.org/client/{{ page.foreman_version }}/fc28/x86_64/foreman-client-release.rpm
 {% endhighlight %}
 </div>
 
-<div id="sles12" style="display:none;" markdown="1">
+<div id="sles12" markdown="1">
 {% highlight bash %}
 rpm -Uvh https://yum.theforeman.org/client/{{ page.foreman_version }}/sles12/x86_64/foreman-client-release.rpm
 {% endhighlight %}
 </div>
 
-<div id="sles11" style="display:none;" markdown="1">
+<div id="sles11" markdown="1">
 {% highlight bash %}
 # For python-datetime dependency, ensure that the SDK addon product is enabled see: https://www.suse.com/support/kb/doc/?id=7015337
 zypper modifyrepo -e nu_novell_com:SLES11-Extras

--- a/static/js/osmenu.js
+++ b/static/js/osmenu.js
@@ -1,57 +1,59 @@
 $(document).ready(function(){
+    var operatingSystems = {
+        'rhel5': [],
+        'rhel6': ['el6'],
+        'rhel7': ['el7'],
+        'el5': [],
+        'el6': [],
+        'el7': [],
+        'f22': [],
+        'f23': [],
+        'f25': [],
+        'f26': [],
+        'f27': [],
+        'f28': [],
+        'sles11': [],
+        'sles12': []
+    };
+
+    function show(os) {
+        $('#' + os).show();
+        $('.' + os).show();
+    }
+
+    function hide(os) {
+        $('#' + os).hide();
+        $('.' + os).hide();
+    }
+
+    function showOS(operatingSystem) {
+        var os, oses, i = 0;
+
+        for(os in operatingSystems) {
+            if (operatingSystems.hasOwnProperty(os)) {
+                hide(os);
+            }
+        }
+        for(os in operatingSystems) {
+            if (operatingSystems.hasOwnProperty(os)) {
+                if (os === operatingSystem) {
+                    show(os);
+                }
+            }
+        }
+
+        oses = operatingSystems[operatingSystem];
+
+        for(i; i < oses.length; i += 1) {
+            show(oses[i]);
+        }
+
+        return true;
+    }
+
     $('#operatingSystems').change(function() {
-        var operatingSystems = {
-            'rhel5': [],
-            'rhel6': ['el6'],
-            'rhel7': ['el7'],
-            'el5': [],
-            'el6': [],
-            'el7': [],
-            'f22': [],
-            'f23': [],
-            'f25': [],
-            'f26': [],
-            'f27': [],
-            'f28': [],
-            'sles11': [],
-            'sles12': []
-        };
-
-        function show(os) {
-            $('#' + os).show();
-            $('.' + os).show();
-        }
-
-        function hide(os) {
-            $('#' + os).hide();
-            $('.' + os).hide();
-        }
-
-        function showOS(operatingSystem) {
-            var os, oses, i = 0;
-
-            for(os in operatingSystems) {
-                if (operatingSystems.hasOwnProperty(os)) {
-                    hide(os);
-                }
-            }
-            for(os in operatingSystems) {
-                if (operatingSystems.hasOwnProperty(os)) {
-                    if (os === operatingSystem) {
-                        show(os);
-                    }
-                }
-            }
-
-            oses = operatingSystems[operatingSystem];
-
-            for(i; i < oses.length; i += 1) {
-                show(oses[i]);
-            }
-
-            return true;
-        }
-
         showOS($(this).val());
     });
+
+    showOS($('#operatingSystems').val());
 });


### PR DESCRIPTION
We were missing a `display:none` on the block showing the katello-host-tools-tracer div which did not guarantee that it would be hidden by osmenu.js unless an OS which should hide that data was selected by default.

I've changed osmenu.js so it will trigger not just on OS dropdown change, but when the page has loaded so display:none is no longer needed at all