### PR TITLE
Remove puppet upgrade page

### DIFF
--- a/_includes/plugins/katello/sidebar_3.10.html
+++ b/_includes/plugins/katello/sidebar_3.10.html
@@ -31,9 +31,6 @@
     <li class="item">
       <a href="/plugins/katello/3.10/upgrade/clients.html">2.3 Clients</a>
     </li>
-    <li class="item">
-      <a href="/plugins/katello/3.10/upgrade/puppet.html">2.4 Puppet</a>
-    </li>
   </ul>
 </ul>
 

--- a/_includes/plugins/katello/sidebar_3.7.html
+++ b/_includes/plugins/katello/sidebar_3.7.html
@@ -31,9 +31,6 @@
     <li class="item">
       <a href="/plugins/katello/3.7/upgrade/clients.html">2.3 Clients</a>
     </li>
-    <li class="item">
-      <a href="/plugins/katello/3.7/upgrade/puppet.html">2.4 Puppet</a>
-    </li>
   </ul>
 </ul>
 

--- a/_includes/plugins/katello/sidebar_3.8.html
+++ b/_includes/plugins/katello/sidebar_3.8.html
@@ -31,9 +31,6 @@
     <li class="item">
       <a href="/plugins/katello/3.8/upgrade/clients.html">2.3 Clients</a>
     </li>
-    <li class="item">
-      <a href="/plugins/katello/3.8/upgrade/puppet.html">2.4 Puppet</a>
-    </li>
   </ul>
 </ul>
 

--- a/_includes/plugins/katello/sidebar_3.9.html
+++ b/_includes/plugins/katello/sidebar_3.9.html
@@ -31,9 +31,6 @@
     <li class="item">
       <a href="/plugins/katello/3.9/upgrade/clients.html">2.3 Clients</a>
     </li>
-    <li class="item">
-      <a href="/plugins/katello/3.9/upgrade/puppet.html">2.4 Puppet</a>
-    </li>
   </ul>
 </ul>
 


### PR DESCRIPTION
on recent Katello versions, this page no longer exists and isn't
relevant, so we should remove the link since it 404s