### PR TITLE
Add nightly headline feature - type support in Global Parameters

### DIFF
--- a/_includes/manuals/nightly/1.2_release_notes.md
+++ b/_includes/manuals/nightly/1.2_release_notes.md
@@ -4,6 +4,11 @@ This section will be updated prior to the next release.
 
 ### Headline features
 
+#### Array, Boolean and other types support in Parameters
+
+Global parameters now support the same types as smart variables and smart class parameters.
+As a part of this change searching by parameter value is no longer allowed. ([#4127](https://projects.theforeman.org/issues/4127))
+
 ### Features
 
 ### Bug Fixes
@@ -11,5 +16,7 @@ This section will be updated prior to the next release.
 ### Deprecations
 
 ### Upgrade warnings
+
+* With types support in global parameters, searching by parameter value is no longer allowed.
 
 ### Contributors


### PR DESCRIPTION
Added details about ["Type support in Global Parameters"](https://github.com/theforeman/foreman/pull/5241) under headline feature section and about searching changes under upgrade warning.
