### PR TITLE
Fix display of foreman-installer instructions for Ubuntu 18.04

### DIFF
--- a/_includes/manuals/1.19/2.1_quickstart_installation.md
+++ b/_includes/manuals/1.19/2.1_quickstart_installation.md
@@ -169,7 +169,7 @@ sudo apt-get update && sudo apt-get -y install foreman-installer
 
 The installation run is non-interactive, but the configuration can be customized by supplying any of the options listed in `foreman-installer --help`, or by running `foreman-installer -i` for interactive mode.  More examples are given in the [Installation Options](/manuals/{{page.version}}/index.html#3.2.2InstallerOptions) section.  Adding `-v` will disable the progress bar and display all changes.  To run the installer, execute:
 
-<div class="quickstart_os quickstart_os_none quickstart_os_el7 quickstart_os_rhel7 quickstart_os_debian9 quickstart_os_ubuntu18604 quickstart_os_ubuntu1604">
+<div class="quickstart_os quickstart_os_none quickstart_os_el7 quickstart_os_rhel7 quickstart_os_debian9 quickstart_os_ubuntu1804 quickstart_os_ubuntu1604">
 {% highlight bash %}
 sudo foreman-installer
 {% endhighlight %}

--- a/_includes/manuals/1.20/2.1_quickstart_installation.md
+++ b/_includes/manuals/1.20/2.1_quickstart_installation.md
@@ -169,7 +169,7 @@ sudo apt-get update && sudo apt-get -y install foreman-installer
 
 The installation run is non-interactive, but the configuration can be customized by supplying any of the options listed in `foreman-installer --help`, or by running `foreman-installer -i` for interactive mode.  More examples are given in the [Installation Options](/manuals/{{page.version}}/index.html#3.2.2InstallerOptions) section.  Adding `-v` will disable the progress bar and display all changes.  To run the installer, execute:
 
-<div class="quickstart_os quickstart_os_none quickstart_os_el7 quickstart_os_rhel7 quickstart_os_debian9 quickstart_os_ubuntu18604 quickstart_os_ubuntu1604">
+<div class="quickstart_os quickstart_os_none quickstart_os_el7 quickstart_os_rhel7 quickstart_os_debian9 quickstart_os_ubuntu1804 quickstart_os_ubuntu1604">
 {% highlight bash %}
 sudo foreman-installer
 {% endhighlight %}

--- a/_includes/manuals/1.21/2.1_quickstart_installation.md
+++ b/_includes/manuals/1.21/2.1_quickstart_installation.md
@@ -169,7 +169,7 @@ sudo apt-get update && sudo apt-get -y install foreman-installer
 
 The installation run is non-interactive, but the configuration can be customized by supplying any of the options listed in `foreman-installer --help`, or by running `foreman-installer -i` for interactive mode.  More examples are given in the [Installation Options](/manuals/{{page.version}}/index.html#3.2.2InstallerOptions) section.  Adding `-v` will disable the progress bar and display all changes.  To run the installer, execute:
 
-<div class="quickstart_os quickstart_os_none quickstart_os_el7 quickstart_os_rhel7 quickstart_os_debian9 quickstart_os_ubuntu18604 quickstart_os_ubuntu1604">
+<div class="quickstart_os quickstart_os_none quickstart_os_el7 quickstart_os_rhel7 quickstart_os_debian9 quickstart_os_ubuntu1804 quickstart_os_ubuntu1604">
 {% highlight bash %}
 sudo foreman-installer
 {% endhighlight %}

--- a/_includes/manuals/nightly/2.1_quickstart_installation.md
+++ b/_includes/manuals/nightly/2.1_quickstart_installation.md
@@ -169,7 +169,7 @@ sudo apt-get update && sudo apt-get -y install foreman-installer
 
 The installation run is non-interactive, but the configuration can be customized by supplying any of the options listed in `foreman-installer --help`, or by running `foreman-installer -i` for interactive mode.  More examples are given in the [Installation Options](/manuals/{{page.version}}/index.html#3.2.2InstallerOptions) section.  Adding `-v` will disable the progress bar and display all changes.  To run the installer, execute:
 
-<div class="quickstart_os quickstart_os_none quickstart_os_el7 quickstart_os_rhel7 quickstart_os_debian9 quickstart_os_ubuntu18604 quickstart_os_ubuntu1604">
+<div class="quickstart_os quickstart_os_none quickstart_os_el7 quickstart_os_rhel7 quickstart_os_debian9 quickstart_os_ubuntu1804 quickstart_os_ubuntu1604">
 {% highlight bash %}
 sudo foreman-installer
 {% endhighlight %}


### PR DESCRIPTION
When selecting 'Ubuntu 18.04 (Bionic)' from the operating system specific installation instructions dropdown the command to execute the installer (`sudo foreman-installer`) disappears.
This looks to be due to a typo in the naming of the relevant CSS class. This fix works when testing with browser developer tools.