### PR TITLE
Updates to upgrade troubleshooting section

### DIFF
--- a/_includes/manuals/1.21/3.6_upgrade.md
+++ b/_includes/manuals/1.21/3.6_upgrade.md
@@ -184,3 +184,19 @@ And consider removing unused SCL packages:
 
 See
 [Troubleshooting](http://projects.theforeman.org/projects/foreman/wiki/Troubleshooting)
+
+In some cases the Foreman web interface fails to list the host certificates in the "infrastucture"=>"Puppet CA" section. Instead of listing the host certificates it may show the following error:
+
+    Failure: ERF50-5345 [Foreman::WrappedException]: Unable to connect ([ProxyAPI::ProxyException]: ERF12-5356 [ProxyAPI::ProxyException]: Unable to get PuppetCA certificates ([RestClient::NotAcceptable]: 406 Not Acceptable) for proxy ...
+
+This is most likely due to missing sudo permissions for the local user foreman-proxy. Make sure that
+
+    1. The sudo permissions are correct, ie the file /etc/sudoers.d/foreman-proxy contains
+
+       foreman-proxy ALL = (root) NOPASSWD : /opt/puppetlabs/bin/puppetserver ca *
+       Defaults:foreman-proxy !requiretty
+
+    2. The sudo permissions apply for local users, ie /etc/security/access.conf contains
+
+       +:ALL:LOCAL
+

--- a/_includes/manuals/nightly/3.6_upgrade.md
+++ b/_includes/manuals/nightly/3.6_upgrade.md
@@ -184,3 +184,19 @@ And consider removing unused SCL packages:
 
 See
 [Troubleshooting](http://projects.theforeman.org/projects/foreman/wiki/Troubleshooting)
+
+In some cases the Foreman web interface fails to list the host certificates in the "infrastucture"=>"Puppet CA" section. Instead of listing the host certificates it may show the following error:
+
+    Failure: ERF50-5345 [Foreman::WrappedException]: Unable to connect ([ProxyAPI::ProxyException]: ERF12-5356 [ProxyAPI::ProxyException]: Unable to get PuppetCA certificates ([RestClient::NotAcceptable]: 406 Not Acceptable) for proxy ...
+
+This is most likely due to missing sudo permissions for the local user foreman-proxy. Make sure that
+
+    1. The sudo permissions are correct, ie the file /etc/sudoers.d/foreman-proxy contains
+
+       foreman-proxy ALL = (root) NOPASSWD : /opt/puppetlabs/bin/puppetserver ca *
+       Defaults:foreman-proxy !requiretty
+
+    2. The sudo permissions apply for local users, ie /etc/security/access.conf contains
+
+       +:ALL:LOCAL
+


### PR DESCRIPTION
Certificate listing in Foreman web GUI fails if sudo rights of local foreman-proxy user are either incorrect or not read. This documents adds troubleshooting documentation for both.