### PR TITLE
Refs #26327 - add deprecation of :confirm to manual

### DIFF
--- a/_includes/manuals/nightly/1.2_release_notes.md
+++ b/_includes/manuals/nightly/1.2_release_notes.md
@@ -14,6 +14,7 @@ As a part of this change searching by parameter value is no longer allowed. ([#4
 ### Bug Fixes
 
 ### Deprecations
+* Passing `:confirm` option to `link_to` helper is deprecated and will be removed in 1.24. Please pass it as `data: { confirm: "confirmation text" }` instead. Plugin maintainers should update any usage of the `link_to` helper in their code accordingly.
 
 ### Upgrade warnings
 


### PR DESCRIPTION
This is the corollary for https://github.com/theforeman/foreman/pull/6563