### PR TITLE
Replace blurb of foreman-users & foreman-dev with blurb about new forums at https://community.theforeman.org

### DIFF
--- a/_includes/manuals/1.21/7.3_getting_help.md
+++ b/_includes/manuals/1.21/7.3_getting_help.md
@@ -4,10 +4,12 @@ Please check the [Troubleshooting wiki page](http://projects.theforeman.org/proj
 We work on the [irc.freenode.net](http://webchat.freenode.net/) servers. You can get general support in #theforeman, while development chat takes place in #theforeman-dev.
 
 ### Mailing lists
-Mailing lists are available via Google Groups. Much like IRC, we have a general users (support, Q/A, etc) lists and a development list:
 
-* [foreman-users](https://groups.google.com/forum/?fromgroups#!forum/foreman-users)
-* [foreman-dev](https://groups.google.com/forum/?fromgroups#!forum/foreman-dev)
+An online discussion forum is available at https://community.theforeman.org/. Much like IRC, we have discussion areas for general users (support, Q/A, etc) lists, as well as a discussion areas for developers, tutorials and release announcements.
+
+* [General Support](https://community.theforeman.org/c/support)
+* [Development](https://community.theforeman.org/c/support)
+* [Release Announcements](https://community.theforeman.org/c/release-announcements)
 
 ### Gathering information
 In order to troubleshoot and get relevant data use foreman-debug which collects information about your OS, Foreman and related components.

--- a/_includes/manuals/1.21/7.3_getting_help.md
+++ b/_includes/manuals/1.21/7.3_getting_help.md
@@ -1,11 +1,11 @@
-Please check the [Troubleshooting wiki page](http://projects.theforeman.org/projects/1/wiki/Troubleshooting) for solutions to the most common problems.  Otherwise, there are two primary methods of getting support for the Foreman: IRC and mailing lists.
+Please check the [Troubleshooting wiki page](http://projects.theforeman.org/projects/1/wiki/Troubleshooting) for solutions to the most common problems.  Otherwise, there are two primary methods of getting support for the Foreman: IRC and discussion forums.
 
 ### IRC
 We work on the [irc.freenode.net](http://webchat.freenode.net/) servers. You can get general support in #theforeman, while development chat takes place in #theforeman-dev.
 
-### Mailing lists
+### Discussion Forums
 
-An online discussion forum is available at https://community.theforeman.org/. Much like IRC, we have discussion areas for general users (support, Q/A, etc) lists, as well as a discussion areas for developers, tutorials and release announcements.
+An online discussion forum is available at https://community.theforeman.org/. Much like IRC, we have discussion areas for general users (support, Q/A, etc), as well as a discussion areas for developers, tutorials and release announcements.
 
 * [General Support](https://community.theforeman.org/c/support)
 * [Development](https://community.theforeman.org/c/support)

--- a/_includes/manuals/nightly/7.3_getting_help.md
+++ b/_includes/manuals/nightly/7.3_getting_help.md
@@ -4,10 +4,12 @@ Please check the [Troubleshooting wiki page](http://projects.theforeman.org/proj
 We work on the [irc.freenode.net](http://webchat.freenode.net/) servers. You can get general support in #theforeman, while development chat takes place in #theforeman-dev.
 
 ### Mailing lists
-Mailing lists are available via Google Groups. Much like IRC, we have a general users (support, Q/A, etc) lists and a development list:
 
-* [foreman-users](https://groups.google.com/forum/?fromgroups#!forum/foreman-users)
-* [foreman-dev](https://groups.google.com/forum/?fromgroups#!forum/foreman-dev)
+An online discussion forum is available at https://community.theforeman.org/. Much like IRC, we have discussion areas for general users (support, Q/A, etc) lists, as well as a discussion areas for developers, tutorials and release announcements.
+
+* [General Support](https://community.theforeman.org/c/support)
+* [Development](https://community.theforeman.org/c/support)
+* [Release Announcements](https://community.theforeman.org/c/release-announcements)
 
 ### Gathering information
 In order to troubleshoot and get relevant data use foreman-debug which collects information about your OS, Foreman and related components.

--- a/_includes/manuals/nightly/7.3_getting_help.md
+++ b/_includes/manuals/nightly/7.3_getting_help.md
@@ -1,11 +1,11 @@
-Please check the [Troubleshooting wiki page](http://projects.theforeman.org/projects/1/wiki/Troubleshooting) for solutions to the most common problems.  Otherwise, there are two primary methods of getting support for the Foreman: IRC and mailing lists.
+Please check the [Troubleshooting wiki page](http://projects.theforeman.org/projects/1/wiki/Troubleshooting) for solutions to the most common problems.  Otherwise, there are two primary methods of getting support for the Foreman: IRC and discussion forums.
 
 ### IRC
 We work on the [irc.freenode.net](http://webchat.freenode.net/) servers. You can get general support in #theforeman, while development chat takes place in #theforeman-dev.
 
-### Mailing lists
+### Discussion Forums
 
-An online discussion forum is available at https://community.theforeman.org/. Much like IRC, we have discussion areas for general users (support, Q/A, etc) lists, as well as a discussion areas for developers, tutorials and release announcements.
+An online discussion forum is available at https://community.theforeman.org/. Much like IRC, we have discussion areas for general users (support, Q/A, etc), as well as a discussion areas for developers, tutorials and release announcements.
 
 * [General Support](https://community.theforeman.org/c/support)
 * [Development](https://community.theforeman.org/c/support)


### PR DESCRIPTION
Google Groups were replaced with https://community.theforeman.org.

Fixes #1252