### PR TITLE
Make sure Katello 3.11 is the latest

### DIFF
--- a/plugins/katello/3.11/installation/index.md
+++ b/plugins/katello/3.11/installation/index.md
@@ -1,7 +1,7 @@
 ---
 layout: plugins/katello/documentation
 title: Katello Installation
-version: 3.11
+version: '3.11'
 foreman_version: 1.21
 latest: '3.11'
 script: osmenu.js


### PR DESCRIPTION
This gets rid of "These instructions are for installing Katello 3.11, but the latest stable is 3.11. "