### PR TITLE
Add tls_disabled_versions to smart proxy section of manual

### DIFF
--- a/_includes/manuals/1.17/4.3.2_smartproxy_settings.md
+++ b/_includes/manuals/1.17/4.3.2_smartproxy_settings.md
@@ -90,6 +90,8 @@ see [**SSL**](manuals/{{page.version}}/index.html#4.3.10SSL) for more informatio
 
 Specific SSL cipher suites can be disabled by using the `:ssl_disabled_ciphers:` option. For more information on which cipher suites are enabled by default and how to correctly disable specific ones, please see [**SSL cipher suites**](manuals/{{page.version}}/index.html#ssl-cipher-suites).
 
+The TLS versions can be disabled if requiring a specific version. So while unsecure SSLv3 and TLS v1.0 are disabled by default, setting the array of `:tls_disabled_versions:` to include `1.1` will disable this version, too.
+
 This is the list of hosts from which the smart proxy will accept connections.  For HTTPS connections, the name must match the common name (CN) within the subject DN and for HTTP connections, it must match the hostname from reverse DNS.
 
 <pre>

--- a/_includes/manuals/1.18/4.3.2_smartproxy_settings.md
+++ b/_includes/manuals/1.18/4.3.2_smartproxy_settings.md
@@ -90,6 +90,8 @@ see [**SSL**](manuals/{{page.version}}/index.html#4.3.10SSL) for more informatio
 
 Specific SSL cipher suites can be disabled by using the `:ssl_disabled_ciphers:` option. For more information on which cipher suites are enabled by default and how to correctly disable specific ones, please see [**SSL cipher suites**](manuals/{{page.version}}/index.html#ssl-cipher-suites).
 
+The TLS versions can be disabled if requiring a specific version. So while unsecure SSLv3 and TLS v1.0 are disabled by default, setting the array of `:tls_disabled_versions:` to include `1.1` will disable this version, too.
+
 This is the list of hosts from which the smart proxy will accept connections.  For HTTPS connections, the name must match the common name (CN) within the subject DN and for HTTP connections, it must match the hostname from reverse DNS.
 
 <pre>

--- a/_includes/manuals/1.19/4.3.2_smartproxy_settings.md
+++ b/_includes/manuals/1.19/4.3.2_smartproxy_settings.md
@@ -92,6 +92,8 @@ see [**SSL**](manuals/{{page.version}}/index.html#4.3.10SSL) for more informatio
 
 Specific SSL cipher suites can be disabled by using the `:ssl_disabled_ciphers:` option. For more information on which cipher suites are enabled by default and how to correctly disable specific ones, please see [**SSL cipher suites**](manuals/{{page.version}}/index.html#ssl-cipher-suites).
 
+The TLS versions can be disabled if requiring a specific version. So while unsecure SSLv3 and TLS v1.0 are disabled by default, setting the array of `:tls_disabled_versions:` to include `1.1` will disable this version, too.
+
 This is the list of hosts from which the smart proxy will accept connections.  For HTTPS connections, the name must match the common name (CN) within the subject DN and for HTTP connections, it must match the hostname from reverse DNS.
 
 <pre>

--- a/_includes/manuals/1.20/4.3.2_smartproxy_settings.md
+++ b/_includes/manuals/1.20/4.3.2_smartproxy_settings.md
@@ -92,6 +92,8 @@ see [**SSL**](manuals/{{page.version}}/index.html#4.3.10SSL) for more informatio
 
 Specific SSL cipher suites can be disabled by using the `:ssl_disabled_ciphers:` option. For more information on which cipher suites are enabled by default and how to correctly disable specific ones, please see [**SSL cipher suites**](manuals/{{page.version}}/index.html#ssl-cipher-suites).
 
+The TLS versions can be disabled if requiring a specific version. So while unsecure SSLv3 and TLS v1.0 are disabled by default, setting the array of `:tls_disabled_versions:` to include `1.1` will disable this version, too.
+
 This is the list of hosts from which the smart proxy will accept connections.  For HTTPS connections, the name must match the common name (CN) within the subject DN and for HTTP connections, it must match the hostname from reverse DNS.
 
 <pre>

--- a/_includes/manuals/1.21/4.3.2_smartproxy_settings.md
+++ b/_includes/manuals/1.21/4.3.2_smartproxy_settings.md
@@ -92,6 +92,8 @@ see [**SSL**](manuals/{{page.version}}/index.html#4.3.10SSL) for more informatio
 
 Specific SSL cipher suites can be disabled by using the `:ssl_disabled_ciphers:` option. For more information on which cipher suites are enabled by default and how to correctly disable specific ones, please see [**SSL cipher suites**](manuals/{{page.version}}/index.html#ssl-cipher-suites).
 
+The TLS versions can be disabled if requiring a specific version. So while unsecure SSLv3 and TLS v1.0 are disabled by default, setting the array of `:tls_disabled_versions:` to include `1.1` will disable this version, too.
+
 This is the list of hosts from which the smart proxy will accept connections.  For HTTPS connections, the name must match the common name (CN) within the subject DN and for HTTP connections, it must match the hostname from reverse DNS.
 
 <pre>

--- a/_includes/manuals/nightly/4.3.2_smartproxy_settings.md
+++ b/_includes/manuals/nightly/4.3.2_smartproxy_settings.md
@@ -92,6 +92,8 @@ see [**SSL**](manuals/{{page.version}}/index.html#4.3.10SSL) for more informatio
 
 Specific SSL cipher suites can be disabled by using the `:ssl_disabled_ciphers:` option. For more information on which cipher suites are enabled by default and how to correctly disable specific ones, please see [**SSL cipher suites**](manuals/{{page.version}}/index.html#ssl-cipher-suites).
 
+The TLS versions can be disabled if requiring a specific version. So while unsecure SSLv3 and TLS v1.0 are disabled by default, setting the array of `:tls_disabled_versions:` to include `1.1` will disable this version, too.
+
 This is the list of hosts from which the smart proxy will accept connections.  For HTTPS connections, the name must match the common name (CN) within the subject DN and for HTTP connections, it must match the hostname from reverse DNS.
 
 <pre>


### PR DESCRIPTION
I found this option missing in the manual when discussing at [community.theforeman.org](https://community.theforeman.org/t/how-to-limit-foreman-smart-proxy-listening-on-port-8443-to-accept-tls1-2-connections-only/13680).

If the text is fine, I will copy it to all manuals from 1.17 onwards when the option was introduced.