### PR TITLE
Add a proper redirect on documentation.html

### DIFF
--- a/documentation.html
+++ b/documentation.html
@@ -1,0 +1,8 @@
+---
+layout: default
+redirect: /manuals/latest/quickstart_guide.html
+---
+
+# Documentation
+
+Our documentation has been removed in favor of the menu navigation and the quickstart guide. Please update your bookmarks.


### PR DESCRIPTION
This page used to exist. Just making it a 404 is bad, especially since it's the second hit on Google for 'foreman documentation'. This redirects it to the quickstart guide.