### PR TITLE
Update Puppet documentation

### DIFF
--- a/_includes/manuals/nightly/3.1.3_puppet_versions.md
+++ b/_includes/manuals/nightly/3.1.3_puppet_versions.md
@@ -1,84 +1,45 @@
-Foreman integrates with Puppet and Facter in a few places, but generally using a recent, stable version will be fine.  The exact versions of Puppet, Puppet Server and Facter that Foreman is compatible with are listed below.
+Foreman integrates with Puppet and Facter in a few places, but generally using a recent, stable version will be fine.  The exact versions of Puppet, Puppetserver and Facter that Foreman is compatible with are listed below.
 
 <table class="table table-bordered table-condensed">
   <tr>
     <th>Puppet version</th>
-    <th>Foreman installer</th>
-    <th>Smart proxy</th>
-    <th><a href="/manuals/{{page.version}}/index.html#3.5.4PuppetReports">Report/fact processors</a></th>
-    <th><a href="/manuals/{{page.version}}/index.html#3.5.5FactsandtheENC">External node classifier</a></th>
+    <th>Foreman installer (AIO)</th>
+    <th>Foreman installer (non-AIO)</th>
+    <th>Smart Proxy</th>
   </tr>
   <tr>
-    <td>0.x-3.x</td>
+    <td>0.x-4.3</td>
     <td>Not supported</td>
-    <td>Untested</td>
-    <td>Untested</td>
-    <td>Untested <span class='footnote'>*</span></td>
+    <td>Not supported</td>
+    <td>Not supported</td>
   </tr>
   <tr>
-    <td>4.x (AIO)</td>
+    <td>4.4-4.10</td>
+    <td>Not supported</td>
     <td>Not supported</td>
     <td>Deprecated</td>
-    <td>Deprecated</td>
-    <td>Deprecated</td>
-  </tr>
-  <tr>
-    <td>4.x (non-AIO)</td>
-    <td>Untested</td>
-    <td>Not Supported</td>
-    <td>Untested</td>
-    <td>Untested</td>
-  </tr>
-  <tr>
-    <td>5.x (AIO)</td>
-    <td>Supported</td>
-    <td>Supported</td>
-    <td>Supported</td>
-    <td>Supported</td>
-  </tr>
-  <tr>
-    <td>5.x (non-AIO)</td>
-    <td>Untested</td>
-    <td>Not Supported</td>
-    <td>Untested</td>
-    <td>Untested</td>
-  </tr>
-</table>
-
-<span class='footnote'>*</span> Puppet versions < 2.6.5 require `Parametrized_Classes_in_ENC` in Foreman to be disabled.
-
-#### Puppet Server compatibility
-
-Puppet Server is the application for serving Puppet agents used by default in Puppet 4/5 AIO installations.
-
-<table class="table table-bordered table-condensed">
-  <tr>
-    <th>Puppet Server version</th>
-    <th>Foreman installer</th>
-    <th>Notes</th>
-  </tr>
-  <tr>
-    <td>1.x-2.7</td>
-    <td>Untested</td>
-    <td>Version 2.0-2.1 requires server_use_legacy_auth_conf, server_puppetserver_version to be set on the Puppet Server.</td>
-  </tr>
-  <tr>
-    <td>2.8</td>
-    <td>Supported</td>
-    <td></td>
   </tr>
   <tr>
     <td>5.x</td>
     <td>Supported</td>
-    <td></td>
+    <td>Untested</td>
+    <td>Supported</td>
+  </tr>
+  <tr>
+    <td>6.x</td>
+    <td>Supported</td>
+    <td>Untested</td>
+    <td>Supported</td>
   </tr>
 </table>
 
 #### AIO installer compatibility
 
-The Foreman installer supports both AIO and non-AIO configurations when using Puppet 4/5, switching behavior automatically based on the version of Puppet installed (usually during the first run when answers are stored).
+The Foreman installer has code for both AIO and non-AIO configurations, switching behavior automatically based on the version of Puppet installed (usually during the first run when answers are stored). Only AIO installations are tested.
 
-When using an AIO installation of Puppet to run the installer, it will default to configuring the Puppet Server application, and when using a non-AIO version of Puppet, it defaults to a traditional Rack/Passenger configuration.
+#### Puppet Server compatibility
+
+Puppetserver is the application for serving Puppet agents used by default since Puppet 4. Both Fedora and Debian have not packaged Puppetserver for their non-AIO packages. The Puppetlabs packages must be used.
 
 #### Facter compatibility
 

--- a/_includes/manuals/nightly/3.2.3_installation_scenarios.md
+++ b/_includes/manuals/nightly/3.2.3_installation_scenarios.md
@@ -59,7 +59,7 @@ Transfer the following files to the same paths on the new host:
 * /var/lib/puppet/ssl/certs/new-puppetmaster.example.com.pem
 * /var/lib/puppet/ssl/private_keys/new-puppetmaster.example.com.pem
 
-Under a Puppet 4 AIO installation, substitute above paths with `/etc/puppetlabs/puppet/ssl/`.
+Under a Puppet AIO installation, substitute above paths with `/etc/puppetlabs/puppet/ssl/`.
 
 This provides the new host a certificate in the same authority, but doesn't make it a CA itself.  Certificates will continue to be generated on the central Puppet CA host.
 

--- a/_includes/manuals/nightly/3.2.3_installation_scenarios.md
+++ b/_includes/manuals/nightly/3.2.3_installation_scenarios.md
@@ -23,49 +23,36 @@ foreman-rake db:seed
 foreman-rake apipie:cache:index
 {% endhighlight %}
 
-#### Setting up Foreman with external Puppet masters
+#### Setting up Foreman with additional Smart Proxies
 
 Using the scenarios outlined below, a simple scale-out setup can be created as follows:
 
-1. On the Foreman host, run a complete foreman-installer all-in-one installation to provide Foreman, a Puppet master and smart proxy.  This will be the Puppet CA.
+1. On the Foreman host, run a complete foreman-installer all-in-one installation to provide Foreman, a Puppetserver and Smart Proxy. This will be the Puppet CA.
 
-For each Puppet master:
+For each additional Smart Proxy:
 
-1. Generate a new certificate following the steps in the SSL CA section and transfer it to the new Puppet master host
-1. Run the standalone Puppet master installation as detailed below
+1. Bootstrap certificates
+1. Run the standalone installation as detailed below
 
-Each Puppet master will register with Foreman as a smart proxy, while the instance running on the Foreman host itself will act as a central Puppet CA.  These can be selected while adding new hosts or host groups.
+**Note** This relies on the puppet ssl subcommand introduced in Puppet 6. Prior to Puppet 6 there was no separate command and it required manual work.
 
-#### SSL certificate authority setup
+Assuming the Puppetserver with CA is on `foreman.example.com`, the following command can be run:
 
-The scenarios below assume a single Puppet CA (certificate authority) for all hosts, which is also used for Foreman and smart proxy communications, though more complex deployments are possible.  This might be the central Foreman host, or a particular Puppet master.
+```bash
+puppet ssl bootstrap --server foreman.example.com
+```
 
-Other systems require certificates to be generated on the central Puppet CA host, then distributed to them before running foreman-installer (else it may generate a second CA).  To prepare these, on the host acting as Puppet CA, run:
+This will submit a CSR (Certificate Signing Request) to the Puppet CA running on foreman.example.com. There the request can be signed.
 
-    # puppet cert generate new-puppetmaster.example.com
-    Notice: new-puppetmaster.example.com has a waiting certificate request
-    Notice: Signed certificate request for new-puppetmaster.example.com
-    Notice: Removing file Puppet::SSL::CertificateRequest new-puppetmaster.example.com at '/var/lib/puppet/ssl/ca/requests/new-puppetmaster.example.com.pem'
-    Notice: Removing file Puppet::SSL::CertificateRequest new-puppetmaster.example.com at '/var/lib/puppet/ssl/certificate_requests/new-puppetmaster.example.com.pem'
+```bash
+puppetserver ca sign --certname host.example.com
+```
 
-    # ls /var/lib/puppet/ssl/*/new-puppetmaster.example.com.pem
-    /var/lib/puppet/ssl/certs/new-puppetmaster.example.com.pem
-    /var/lib/puppet/ssl/private_keys/new-puppetmaster.example.com.pem
-    /var/lib/puppet/ssl/public_keys/new-puppetmaster.example.com.pem
+CSRs also show up in the Foreman interface and can be signed there as well.
 
-Transfer the following files to the same paths on the new host:
+#### Standalone Puppetserver
 
-* /var/lib/puppet/ssl/certs/ca.pem
-* /var/lib/puppet/ssl/certs/new-puppetmaster.example.com.pem
-* /var/lib/puppet/ssl/private_keys/new-puppetmaster.example.com.pem
-
-Under a Puppet AIO installation, substitute above paths with `/etc/puppetlabs/puppet/ssl/`.
-
-This provides the new host a certificate in the same authority, but doesn't make it a CA itself.  Certificates will continue to be generated on the central Puppet CA host.
-
-#### Standalone Puppet master
-
-A standalone Puppet master can be configured along with a smart proxy installation, enabling the Puppet infrastructure to be scaled out.  A certificate should be generated and copied to the host first to make it part of the same CA, else a new Puppet CA will be generated.
+A standalone Puppetserver can be configured along with a smart proxy installation, enabling the Puppet infrastructure to be scaled out. This assumes the SSL certificates have been bootstrapped.
 
 Command line arguments:
 
@@ -73,8 +60,6 @@ Command line arguments:
 foreman-installer \
   --no-enable-foreman \
   --no-enable-foreman-cli \
-  --no-enable-foreman-plugin-bootdisk \
-  --no-enable-foreman-plugin-setup \
   --enable-puppet \
   --puppet-server-ca=false \
   --puppet-server-foreman-url=https://foreman.example.com \
@@ -91,7 +76,7 @@ Fill in the OAuth consumer key and secret values from your Foreman instance, ret
 
 #### PuppetDB integration
 
-An existing PuppetDB server can be integrated into a Puppet master by adding:
+An existing PuppetDB server can be integrated into a Puppetserver by adding:
 
 {% highlight bash %}
 foreman-installer \
@@ -101,12 +86,11 @@ foreman-installer \
   --puppet-server-storeconfigs-backend=puppetdb
 {% endhighlight %}
 
-Be aware that foreman-installer does not setup the PuppetDB server itself. Starting with 1.13 of foreman-installer, only
-setups using Puppet Labs Puppet 4 AIO packages are supported for PuppetDB integration using these parameters.
+Be aware that foreman-installer does not setup the PuppetDB server itself. Only setups using Puppet's Puppet AIO packages are supported for PuppetDB integration using these parameters.
 
-#### Foreman server without the Puppet master
+#### Foreman server without the Puppetserver
 
-The default "all-in-one" Foreman installation includes a Puppet master, but this can be disabled.  Foreman by default uses Puppet's SSL certificates however, so a certificate must be generated and copied to the host first, or all SSL communications need to be disabled.
+The default "all-in-one" Foreman installation includes a Puppetserver, but this can be disabled. Foreman by default uses Puppet's SSL certificates however, so the certificates must be bootstrapped.
 
 Command line arguments:
 
@@ -129,8 +113,6 @@ Command line arguments for a basic smart proxy installation:
 foreman-installer \
   --no-enable-foreman \
   --no-enable-foreman-cli \
-  --no-enable-foreman-plugin-bootdisk \
-  --no-enable-foreman-plugin-setup \
   --no-enable-puppet \
   --enable-foreman-proxy \
   --foreman-proxy-tftp=false \
@@ -148,8 +130,6 @@ Command line arguments for a smart proxy configured with just BIND, setting DNS 
 foreman-installer \
   --no-enable-foreman \
   --no-enable-foreman-cli \
-  --no-enable-foreman-plugin-bootdisk \
-  --no-enable-foreman-plugin-setup \
   --no-enable-puppet \
   --enable-foreman-proxy \
   --foreman-proxy-tftp=false \

--- a/_includes/manuals/nightly/3.3.1_rpm_packages.md
+++ b/_includes/manuals/nightly/3.3.1_rpm_packages.md
@@ -31,19 +31,16 @@ To enable the optional repository on a RHEL 7 system using subscription-manager,
 
 #### Pre-requisites: Puppet
 
-It's recommended to configure the Puppet Labs repositories to obtain the latest version of Puppet available, instead of the version on EPEL. Either the 3.x open source repository or the Puppet Collection (PC1) repository may be configured:
-
-* [Using Puppet Collections: Yum-based Systems](https://docs.puppet.com/guides/puppetlabs_package_repositories.html#yum-based-systems) (Puppet 4)
-* [Pre-4.0 Open Source Repositories: Yum-based Systems](https://docs.puppet.com/guides/puppetlabs_package_repositories.html#yum-based-systems-repository) (Puppet 3)
+It's recommended to [configure the Puppet repositories](https://puppet.com/docs/puppet/6.7/install_agents.html#task-9788) to obtain the latest version of Puppet available. The version in EPEL is not supported.
 
 #### Available repositories
 
-Four main repos are provided at <http://yum.theforeman.org>:
+Four main repos are provided at <https://yum.theforeman.org>:
 
-* `/releases/latest` or `/releases/VERSION` (e.g. `/releases/{{page.version}}`) carries the stable releases and updates of Foreman and its dependencies.
-* `/rc` carries release candidates only in the few weeks prior to a release.  Ensure after a release is made that you use the main releases repo instead.
-* `/nightly` carries the latest development builds and as such, may be unstable or occasionally broken.
-* `/plugins` or `/plugins/VERSION` (e.g. `/plugins/{{page.version}}`) carries the stable plugin releases.
+* `/client` or `/client/VERSION` (e.g. `/client/{{page.version}}`) carries packages relevant to clients. This is optional and Foreman does not require anything installed on clients.
+* `/rails` or `/rails/VERSION` (e.g. `/rails/{{page.version}}`) carries a Rails SCL. This is a requirement for Foreman.
+* `/releases` or `/releases/VERSION` (e.g. `/releases/{{page.version}}`) carries the all releases and updates of Foreman and its dependencies.
+* `/plugins` or `/plugins/VERSION` (e.g. `/plugins/{{page.version}}`) carries the all plugin releases.
 
 Under each repo are directories for each distribution, then each architecture.
 
@@ -75,6 +72,7 @@ Install foreman and other foreman-* packages to add functionality:
     foreman-vmware        VMware provisioning support
     foreman-cli           Foreman CLI utility
     foreman-console       Console additions
+    foreman-service       A standalone service implementation for use without Passenger
     foreman-selinux       SELinux targeted policy
     foreman-mysql2        MySQL database support
     foreman-postgresql    PostgreSQL database support
@@ -84,7 +82,7 @@ Install foreman and other foreman-* packages to add functionality:
 
 1. Configure by editing `/etc/foreman/settings.yaml` and `/etc/foreman/database.yml`
 1. After changing the database, migrate it: `sudo -u foreman /usr/share/foreman/extras/dbmigrate`
-1. Start the foreman service or set up passenger: `service foreman start`
+1. Start the foreman service or set up passenger: `systemctl start foreman`
 
 #### Upgrade
 

--- a/_includes/manuals/nightly/3.3.1_rpm_packages.md
+++ b/_includes/manuals/nightly/3.3.1_rpm_packages.md
@@ -31,7 +31,7 @@ To enable the optional repository on a RHEL 7 system using subscription-manager,
 
 #### Pre-requisites: Puppet
 
-It's recommended to [configure the Puppet repositories](https://puppet.com/docs/puppet/6.7/install_agents.html#task-9788) to obtain the latest version of Puppet available. The version in EPEL is not supported.
+It's recommended to [configure the Puppet repositories](https://puppet.com/docs/puppet/latest/install_agents.html#task-9788) to obtain the latest version of Puppet available. The version in EPEL is not supported.
 
 #### Available repositories
 

--- a/_includes/manuals/nightly/3.5.4_puppet_reports.md
+++ b/_includes/manuals/nightly/3.5.4_puppet_reports.md
@@ -15,7 +15,7 @@ Without it, no reports will be sent.
 First identify the directory containing report processors, e.g.
 
 * AIO installations: /opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/reports/
-* EL7 or Fedora: /usr/share/ruby/vendor_ruby/puppet/reports/
+* Fedora: /usr/share/ruby/vendor_ruby/puppet/reports/
 * Debian or Ubuntu: /usr/lib/ruby/vendor_ruby/puppet/reports/
 * other OSes, look for tagmail.rb in the Puppet installation (`locate tagmail.rb`)
 
@@ -26,19 +26,19 @@ Create a new configuration file at `/etc/puppetlabs/puppet/foreman.yaml` (Puppet
 ---
 # Update for your Foreman and Puppet master hostname(s)
 :url: "https://foreman.example.com"
-:ssl_ca: "/var/lib/puppet/ssl/certs/ca.pem"
-:ssl_cert: "/var/lib/puppet/ssl/certs/puppet.example.com.pem"
-:ssl_key: "/var/lib/puppet/ssl/private_keys/puppet.example.com.pem"
+:ssl_ca: "/etc/puppetlabs/puppet/ssl/certs/ca.pem"
+:ssl_cert: "/etc/puppetlabs/puppet/ssl/certs/puppet.example.com.pem"
+:ssl_key: "/etc/puppetlabs/puppet/ssl/private_keys/puppet.example.com.pem"
 
 # Advanced settings
-:puppetdir: "/var/lib/puppet"
+:puppetdir: "/opt/puppetlabs/server/data/puppetserver"
 :puppetuser: "puppet"
 :facts: true
 :timeout: 10
 :threads: null
 </pre>
 
-Edit the URL field to point to your Foreman instance, and the SSL fields for the hostname of the Puppet master (which may be the same host). Paths to Puppet's SSL certificates will be under /etc/puppetlabs/ssl/ when using Puppet 4 with AIO.
+Edit the URL field to point to your Foreman instance, and the SSL fields for the hostname of the Puppet master (which may be the same host). Paths to Puppet's SSL certificates will be under /var/lib/puppet/ssl/ when using Puppet with non-AIO.
 
 Lastly add this report processor to your Puppet master configuration.  In your master puppet.conf under the `[main]` section add:
 
@@ -52,7 +52,7 @@ You should start seeing reports coming in under the reports link.
 
 If reports aren't showing up in Foreman when an agent is run, there can be a number of reasons.  First check through the above configuration steps, and then look at these places to narrow down the cause:
 
-1. Puppet master logs may show an issue either loading or executing the report processor.  Check syslog (/var/log/messages or syslog) for `puppet-master` messages, or /var/log/puppetlabs/puppetserver/.
+1. Puppetserver logs may show an issue either loading or executing the report processor.  Check syslog (/var/log/messages or syslog) for `puppetserver` messages, or /var/log/puppetlabs/puppetserver/.
 1. /var/log/foreman/production.log should show a `POST "/api/reports"` request each time a report is received, and will end in `Completed 201 Created` when successful.  Check for errors within the block of log messages.
 1. When viewing reports in Foreman's UI, be aware that the default search is for "eventful" reports.  Clear the search ('x') to see reports with no changes.
 

--- a/_includes/manuals/nightly/3.5.5_facts_and_the_enc.md
+++ b/_includes/manuals/nightly/3.5.5_facts_and_the_enc.md
@@ -67,7 +67,7 @@ should output something like:
 This output should match the information displayed when you click on the YAML button
 on the Host page in Foreman.
 
-For further information see the [Puppet Labs docs on external nodes](https://puppet.com/docs/puppet/6.7/nodes_external.html)
+For further information see the [Puppet Labs docs on external nodes](https://puppet.com/docs/puppet/latest/nodes_external.html)
 
 ##### Debugging the ENC
 

--- a/_includes/manuals/nightly/3.5.5_facts_and_the_enc.md
+++ b/_includes/manuals/nightly/3.5.5_facts_and_the_enc.md
@@ -7,33 +7,33 @@ The external nodes script we supply also deals with uploading facts from hosts t
 
 ##### Puppet master
 
-Download [the ENC script](https://raw.githubusercontent.com/theforeman/puppet-foreman/master/files/external_node_v2.rb) to `/etc/puppetlabs/puppet/node.rb` (Puppet 4 AIO) or `/etc/puppet/node.rb` (non-AIO). The name is arbitrary, but must match configuration below, and ensure it's executable by "puppet" with `chmod +x /etc/puppet/node.rb`.
+Download [the ENC script](https://raw.githubusercontent.com/theforeman/puppet-foreman/master/files/external_node_v2.rb) to `/etc/puppetlabs/puppet/node.rb` (Puppet AIO) or `/etc/puppet/node.rb` (non-AIO). The name is arbitrary, but must match configuration below, and ensure it's executable by "puppet" with `chmod +x /etc/puppet/node.rb`.
 
-Unless it already exists from setting up reporting, create a new configuration file at `/etc/puppetlabs/puppet/foreman.yaml` (Puppet 4 AIO) or `/etc/puppet/foreman.yaml` (non-AIO) containing
+Unless it already exists from setting up reporting, create a new configuration file at `/etc/puppetlabs/puppet/foreman.yaml` (Puppet AIO) or `/etc/puppet/foreman.yaml` (non-AIO) containing
 
 <pre>
 ---
 # Update for your Foreman and Puppet master hostname(s)
 :url: "https://foreman.example.com"
-:ssl_ca: "/var/lib/puppet/ssl/certs/ca.pem"
-:ssl_cert: "/var/lib/puppet/ssl/certs/puppet.example.com.pem"
-:ssl_key: "/var/lib/puppet/ssl/private_keys/puppet.example.com.pem"
+:ssl_ca: "/etc/puppetlabs/puppet/ssl/certs/ca.pem"
+:ssl_cert: "/etc/puppetlabs/puppet/ssl/certs/puppet.example.com.pem"
+:ssl_key: "/etc/puppetlabs/puppet/ssl/private_keys/puppet.example.com.pem"
 
 # Advanced settings
-:puppetdir: "/var/lib/puppet"
+:puppetdir: "/opt/puppetlabs/server/data/puppetserver"
 :puppetuser: "puppet"
 :facts: true
 :timeout: 10
 :threads: null
 </pre>
 
-Edit the URL field to point to your Foreman instance, and the SSL fields for the hostname of the Puppet master (which may be the same host). Paths to Puppet's SSL certificates will be under /etc/puppetlabs/ssl/ and puppetdir will be under /opt/puppetlabs/server/data/puppetserver/ when using Puppet 4 with AIO. More information on SSL certificates is at [Securing communications with SSL](/manuals/{{page.version}}/index.html#5.4SecuringCommunicationswithSSL).
+Edit the URL field to point to your Foreman instance, and the SSL fields for the hostname of the Puppet master (which may be the same host). Paths to Puppet's SSL certificates will be under /var/lib/puppet/ssl/ and puppetdir will be under /var/lib/puppet when using Puppet with non-AIO. More information on SSL certificates is at [Securing communications with SSL](/manuals/{{page.version}}/index.html#5.4SecuringCommunicationswithSSL).
 
 Add the following lines to the [master] section of puppet.conf:
 
 <pre>
 [master]
-  external_nodes = /etc/puppet/node.rb
+  external_nodes = /etc/puppetlabs/puppet/node.rb
   node_terminus  = exec
 </pre>
 
@@ -67,17 +67,17 @@ should output something like:
 This output should match the information displayed when you click on the YAML button
 on the Host page in Foreman.
 
-For further information see the [Puppet Labs docs on external nodes](http://docs.puppetlabs.com/guides/external_nodes.html)
+For further information see the [Puppet Labs docs on external nodes](https://puppet.com/docs/puppet/6.7/nodes_external.html)
 
 ##### Debugging the ENC
 
 1. If Puppet agents receive empty catalogs, check the puppet.conf master configuration has the ENC script configured.  Also check the output of the ENC for the hostname logged by Puppet (which may be different) to see if Foreman is reporting the correct configuration.
-1. If the hostname.yaml facts file is missing, this is typically a Puppet misconfiguration.  Check /etc/puppet/rack/config.ru [has been updated](https://docs.puppetlabs.com/puppet/3/reference/release_notes.html#break-puppet-master-rack-configuration-is-changed) if Puppet has been upgraded.
+1. If the hostname.yaml facts file is missing, this is typically a Puppet misconfiguration.
 1. Failures to upload facts or download the ENC data may be a network issue (check the URL and SSL settings) or an error on the Foreman server.  Check /var/log/foreman/production.log for two requests, `POST "/api/hosts/facts"` and `GET "/node/client.example.com?format=yml"` and for any errors within the block of log messages.
 
 #### Assigning data to hosts through the ENC
 
-Foreman passes all assoicated parameters, classes,and class parameters, to the Host,
+Foreman passes all associated parameters, classes,and class parameters, to the Host,
 including those inherited from host groups, domains, or global settings. See section
 <a href="manuals/{{page.version}}/index.html#4.2ManagingPuppet">Managing Puppet</a> for
 more information on assigning configuration to hosts.
@@ -113,7 +113,7 @@ all of it to Foreman.
 
 Download and configure the node.rb script as above, and then call it like this:
 
-    sudo -u puppet /etc/puppet/node.rb --push-facts
+    sudo -u puppet /etc/puppetlabs/puppet/node.rb --push-facts
 
 The following options are available for node.rb's batch mode:
 
@@ -127,8 +127,8 @@ The following options are available for node.rb's batch mode:
 
 ##### Direct HTTP upload
 
-As of Foreman 1.3, the fact-upload API endpoint accepts data in pure JSON. You can
-push data to Foreman as a hash containing:
+Foreman's fact-upload API endpoint accepts data in pure JSON. You can push data
+to Foreman as a hash containing:
 
     {
       "name": "fqdn-of-host.domain.com",
@@ -141,9 +141,8 @@ push data to Foreman as a hash containing:
       }
     }
 
-The 'certname' is optional but will be used to location the Host in Foreman if
-supplied. The 'facts' hash must be a flat hash, not nested with other arrays or hashes.
-See _link-to-API-when-its-updated-here_ for more details.
+The 'certname' is optional but will be used to locate the Host in Foreman when
+supplied. See [the API documentation](/api/{{page.version}}/apidoc/v2/hosts/facts.html) for more details.
 
 This body can be POSTed to '/api/hosts/facts' using Foreman API v2. See the
 [node.rb template](https://github.com/theforeman/puppet-foreman/blob/master/files/external_node_v2.rb) for an example of constructing and sending data in Ruby.

--- a/_includes/manuals/nightly/4.3.6_smartproxy_puppet.md
+++ b/_includes/manuals/nightly/4.3.6_smartproxy_puppet.md
@@ -1,68 +1,36 @@
+Activate the Puppet management module within the Smart Proxy instance. This module has two functions:
 
-Activate the Puppet management module within the Smart Proxy instance.  This module has two functions:
+* Report the Puppet environments and Puppet classes with their parameters from the Puppetserver. Used when importing classes into Foreman
+* Optionally trigger immediate Puppet runs on clients using one of a number of implementations
 
-* reads the Puppet modules and manifests from the Puppet master, reporting the environments and classes that are declared, used when importing classes into Foreman
-* optionally triggers immediate Puppet runs on clients using one of a number of implementations
-
-It should be activated on Puppet masters that have the environments and modules available to import data from.  To use the Puppet run functionality, it also needs to be capable of executing *puppetrun* or equivalent implementation listed in the section below.  This works independently of the Puppet CA functionality, which may only be one of many Puppet masters in the environment.
+It should be activated on Puppetservers that have the environments and modules available to import data from. This works independently of the Puppet CA functionality. To use the Puppet run functionality, it also needs to configured via an implementation listed in the section below.
 
 To enable this module, make sure these lines are present in `/etc/foreman-proxy/settings.d/puppet.yml`:
 
-<pre>
+```yaml
 :enabled: https
-:puppet_version: 4.5.0
-</pre>
-
-Replace `4.5.0` with the version of Puppet installed on the Puppet master, this will be used to determine which APIs and commands it supports. If Puppet is later upgraded, this version number should also be changed to match.
+```
 
 #### Puppet class/environment imports
 
-<div class="alert alert-info">Parsing manifests is done by Puppet itself, which means the manifests must be valid and pass syntax checks, else they won't show up.  Use <code>puppet parser validate example.pp</code> to validate the content of a manifest.</div>
+<div class="alert alert-info">Parsing manifests is done by Puppet itself, which means the manifests must be valid and pass syntax checks, else they won't show up. Use <code>puppet parser validate example.pp</code> to validate the content of a manifest.</div>
 
-The proxy generates a list of all Puppet classes and their parameters of the Puppet modules inside the environments declared in puppet.conf. These are imported by Foreman to generate the list of classes, smart class parameters and environments that they belong to. The mechanism used depends on the version of Puppet (specified by `:puppet_version`):
+To get a list of environments, classes and their parameters, the proxy queries the Puppetserver on its own API. The URL and settings used for the proxy to Puppetserver API query can be controlled with the following settings in `/etc/foreman-proxy/settings.d/puppet_proxy_puppet_api.yml`:
 
-* On Puppet 4, the smart proxy will use the environments and environment_classes or resource_types API to list classes and parameters. environment_classes API is available and used on Puppet 4.4 or higher, resource_types API is used on 4.0 to 4.3.
-* On Puppet 3.2 to 3.8 with directory environments (`environmentpath`), the smart proxy will use the environments Puppet Master API to list modulepaths and will load the Puppet library to parse manifests to compile a list of classes and parameters.
-* Else on Puppet 2 or 3, the smart proxy will parse puppet.conf and load the Puppet library to parse manifests from environment modulepaths to compile a list of classes and parameters.
-
-The sections below describe the configuration options for the different methods.
-
-##### Puppet 4 configuration options (puppet_proxy_puppet_api.yml)
-
-To get a list of environments, classes and their parameters, the proxy queries the Puppet master on its own API. The URL and settings used for the proxy to Puppet master API query can be controlled with the following settings in `/etc/foreman-proxy/settings.d/puppet_proxy_puppet_api.yml`:
-
-<pre>
+```yaml
 # URL of the puppet master itself for API requests
 #:puppet_url: https://puppet.example.com:8140
 #
 # SSL certificates used to access the puppet API
-#:puppet_ssl_ca: /var/lib/puppet/ssl/certs/ca.pem
-#:puppet_ssl_cert: /var/lib/puppet/ssl/certs/puppet.example.com.pem
-#:puppet_ssl_key: /var/lib/puppet/ssl/private_keys/puppet.example.com.pem
+#:puppet_ssl_ca: /etc/puppetlabs/puppet/ssl/certs/ca.pem
+#:puppet_ssl_cert: /etc/puppetlabs/puppet/ssl/certs/puppet.example.com.pem
+#:puppet_ssl_key: /etc/puppetlabs/puppet/ssl/private_keys/puppet.example.com.pem
 #
 # Smart Proxy api timeout when Puppet's environment classes api is used and classes cache is disabled
 #:api_timeout: 30
-</pre>
+```
 
-This method is compatible with both Puppet Server and Puppet masters running under Rack/Passenger, but the Puppet master has to permit these API queries.
-
-The default (older) [auth.conf style](https://docs.puppet.com/puppet/latest/reference/config_file_auth.html) of configuring the Puppet master is controlled by either /etc/puppetlabs/puppet/auth.conf (AIO) or /etc/puppet/auth.conf, and requires these rules:
-
-<pre>
-path /puppet/v3/environments
-method find
-allow *
-
-path /puppet/v3/environment_classes
-method find
-allow *
-
-path /puppet/v3/resource_type
-method search
-allow *
-</pre>
-
-The [HOCON-formatted auth.conf style](https://docs.puppet.com/puppetserver/latest/config_file_auth.html) is at /etc/puppetlabs/puppetserver/conf.d/auth.conf and requires these rules:
+The Puppetserver has to permit these API queries. The [HOCON-formatted auth.conf style](https://docs.puppet.com/puppetserver/latest/config_file_auth.html) is at /etc/puppetlabs/puppetserver/conf.d/auth.conf and requires these rules:
 
 <pre>
 {
@@ -85,66 +53,19 @@ The [HOCON-formatted auth.conf style](https://docs.puppet.com/puppetserver/lates
     sort-order: 500
     name: "puppetlabs environment classes"
 },
-{
-    match-request: {
-        path: "/puppet/v3/resource_type"
-        type: path
-        method: [get, post]
-    }
-    allow: "*"
-    sort-order: 500
-    name: "puppetlabs resource type"
-},
-</pre>
-
-##### Puppet 2 or 3 configuration options (puppet_proxy_legacy.yml)
-
-There are two ways to declare environments within Puppet.  Config environments are environments explicitly declared in puppet.conf, either with a single "modulepath" setting (which creates a single "production" environment or may be a wildcard), or with `[development]` section headers.  The proxy will parse puppet.conf in the same manner as Puppet to try and determine the known environments.
-
-More information on configuring them is available in the [Puppet environment docs](https://docs.puppetlabs.com/guides/environment.html).  Since Puppet 3.5, these are deprecated in favor of directory environments.
-
-Directory environments are enabled by adding "environmentpath" to puppet.conf.  When the proxy finds this setting, it uses this mode too.  The `:use_environment_api` proxy setting can be used to force this mode on or off, but when unset, it follows the presence of environmentpath (the default).  More information on configuring directory environments is available [in the Puppet docs](http://docs.puppetlabs.com/puppet/latest/reference/environments.html).
-
-To get a list of environments and module paths when using directory environments, the proxy queries the Puppet master on its own API. The path to puppet.conf plus the URL and settings used for the proxy to Puppet master API query can be controlled with the following settings in `/etc/foreman-proxy/settings.d/puppet_proxy_legacy.yml`:
-
-<pre>
-#:puppet_conf: /etc/puppet/puppet.conf
-#
-# URL of the puppet master itself for API requests
-#:puppet_url: https://puppet.example.com:8140
-#
-# SSL certificates used to access the puppet master API
-#:puppet_ssl_ca: /var/lib/puppet/ssl/certs/ca.pem
-#:puppet_ssl_cert: /var/lib/puppet/ssl/certs/puppet.example.com.pem
-#:puppet_ssl_key: /var/lib/puppet/ssl/private_keys/puppet.example.com.pem
-</pre>
-
-The Puppet master has to permit this API query.  Older installations of Puppet that have been upgraded may need a new entry in auth.conf prior to the last 'deny' entry:
-
-<pre>
-path /v2.0/environments
-method find
-allow *
-</pre>
-
-When scanning Puppet manifests, a cache is kept in memory to speed up subsequent import calls. It can be enabled/disabled with the following setting:
-
-<pre>
-# Cache options
-:use_cache: true
 </pre>
 
 #### Puppet run providers
 
+<div class="alert alert-info">Puppetrun functionality used to be part of Puppet 2. In Puppet 3 it was renamed to puppet kick and later deprecated. Puppet 4 dropped it entirely. Foreman Proxy still calls it puppetrun but has different implementations. Note that Foreman Remote Execution can also trigger Puppet runs from the UI.</div>
+
 For the optional Puppet run functionality, one of a number of implementations can be chosen in `/etc/foreman-proxy/settings.d/puppet.yml`.
 
-<pre>
-:use_provider: puppet_proxy_puppetrun
-</pre>
-
+```yaml
+:use_provider: puppet_proxy_customrun
+```
 Available providers are:
 
-* `puppet_proxy_puppetrun` - for puppetrun/kick, deprecated in Puppet 3, not available in Puppet 4, see section below
 * `puppet_proxy_mcollective` - uses `mco puppet`, see section below
 * `puppet_proxy_ssh` - run puppet over SSH
 * `puppet_proxy_salt` - uses `salt puppet.run`
@@ -152,58 +73,35 @@ Available providers are:
 
 Once a provider is configured, in Foreman itself, enable "puppetrun" under *Administer > Settings > Puppet* to activate the "Run Puppet" button on individual host pages.
 
-##### puppetrun (deprecated)
-
-`puppet kick` (or puppetrun in 2.x) can be used to trigger an immediate Puppet run on a client by connecting to the agent daemon on the client over HTTPS.  This functionality is not available in Puppet 4 and was deprecated in Puppet 3, therefore isn't recommended for new deployments - consider alternatives, e.g. SSH or MCollective.
-
-More information can be found in the [puppet kick](https://docs.puppetlabs.com/references/stable/man/kick.html) documentation, specifically the [Usage Notes](https://docs.puppetlabs.com/references/stable/man/kick.html#USAGE-NOTES) which describe the configuration of the agents to listen and authorize connections.
-
-Its configuration options are in `/etc/foreman-proxy/settings.d/puppet_proxy_puppetrun.yml`:
-
-<pre>
-# User for execution of puppetrun commands
-#:user: peadmin
-</pre>
-
-The `:user` setting controls which user to sudo to, which on some installations (notably PE) may be different. When unset, it will sudo to root.
-
-sudo access for the proxy is required to run the client - in your sudoers file ensure you have the following lines (use /opt/puppet/bin/puppet for Puppet Enterprise):
-
-<pre>
-Defaults:foreman-proxy !requiretty
-foreman-proxy ALL = NOPASSWD: /usr/bin/puppet kick *
-</pre>
-
-If you are using Puppet 2.x, the proxy will use the older `puppetrun` command instead.  The sudoers entry should be:
-
-<pre>
-Defaults:foreman-proxy !requiretty
-foreman-proxy ALL = NOPASSWD: /usr/sbin/puppetrun
-</pre>
-
 ##### MCollective
 
 The proxy can trigger Puppet runs using the MCollective "puppet" agent.  To enable this, add this line to `/etc/foreman-proxy/settings.d/puppet.yml`:
 
-    :use_provider: puppet_proxy_mcollective
+```yaml
+:use_provider: puppet_proxy_mcollective
+```
 
-The user that the smart proxy sudos to can be set, notably for PE, by editing `/etc/foreman-proxy/settings.d/puppet_proxy_mcollective.yml`:
+The user that the Smart Proxy sudos to can be set, notably for PE, by editing `/etc/foreman-proxy/settings.d/puppet_proxy_mcollective.yml`:
 
-    # If you want to override the puppet_user above just for mco commands
-    :user: peadmin
+```yaml
+# If you want to override the puppet_user above just for mco commands
+:user: peadmin
+```
 
 If `:user` is not specified, it will sudo to root.
 
 And add a sudoers rule for the user:
 
-    Defaults:foreman-proxy !requiretty
-    foreman-proxy ALL = NOPASSWD: /usr/bin/mco puppet runonce *
+```
+Defaults:foreman-proxy !requiretty
+foreman-proxy ALL = NOPASSWD: /usr/bin/mco puppet runonce *
+```
 
 ##### SSH
 
-The puppet_proxy_ssh provider uses SSH to connect to the client using SSH keys and run the Puppet agent command directly.  It is controlled by the following settings in `/etc/foreman-proxy/settings.d/puppet_proxy_ssh.yml`:
+The puppet_proxy_ssh provider uses SSH to connect to the client using SSH keys and run the Puppet agent command directly. It is controlled by the following settings in `/etc/foreman-proxy/settings.d/puppet_proxy_ssh.yml`:
 
-<pre>
+```yaml
 # the command which will be sent to the host
 :command: /usr/bin/puppet agent --onetime --no-usecacheonfailure
 #
@@ -211,42 +109,27 @@ The puppet_proxy_ssh provider uses SSH to connect to the client using SSH keys a
 :use_sudo: false
 #
 # With which user should the proxy connect
-#:user: root
-#:keyfile: /etc/foreman-proxy/id_rsa
-#
+:user: root
+:keyfile: /etc/foreman-proxy/id_rsa
+
 # wait for the command to finish (and capture exit code), or detach process and return 0
 #:wait: false
-</pre>
+```
 
 The `wait` setting controls whether to block on completion of the Puppet command, so the result of the Puppet run can be returned to Foreman, else it's usually asynchronous.  When true, increase `proxy_request_timeout` under *Administer > Settings* in Foreman itself to ensure it waits longer for a response, as the Puppet run may take some time to complete.
 
-Here is a howto on enabling the SSH feature.
+In `puppet.yml` the provider must be set:
 
-On the foreman-proxy server, enable the SSH provider and uncomment the user and SSH key settings:
-<pre>
-sed -i 's!^#\?\(:use_provider:\).*$!\1 puppet_proxy_ssh!' \
-  /etc/foreman-proxy/settings.d/puppet.yml
-sed -i 's!^#\?\(:user:\).*$!\1 root!' \
-  /etc/foreman-proxy/settings.d/puppet_proxy_ssh.yml
-sed -i 's!^#\?\(:keyfile:\).*$!\1 /etc/foreman-proxy/id_rsa!' \
-  /etc/foreman-proxy/settings.d/puppet_proxy_ssh.yml
-</pre>
-
-The puppet.yml configuration file should now contain:
-
-    :use_provider: puppet_proxy_ssh
-
-And puppet_proxy_ssh.yml should now contain:
-
-    :user: root
-    :keyfile: /etc/foreman-proxy/id_rsa
+```yaml
+:use_provider: puppet_proxy_ssh
+```
 
 The new SSH key needs to be generated by running:
-<pre>
+```
 ssh-keygen -t rsa -N '' -f /etc/foreman-proxy/id_rsa
 chgrp foreman-proxy /etc/foreman-proxy/id_rsa
 chmod 640 /etc/foreman-proxy/id_rsa
-</pre>
+```
 
 Then, foreman-proxy should be restarted. If using systemd, run:
 <pre>systemctl restart foreman-proxy</pre>
@@ -259,7 +142,7 @@ Check defined home directory by running
 ls -d ~foreman-proxy
 </pre>
 
-It should return `/usr/share/foreman-proxy`. Now we will create a .ssh subdirectory and set the proper permissions:
+It should return `/usr/share/foreman-proxy`. If no `.ssh` directory exists, one should be created. If it already exists or is a symlink to `/var/lib/foreman-proxy/ssh` (as `smart_proxy_remote_execution_ssh` sets up), it can be used. To create create a .ssh subdirectory with the proper permissions:
 <pre>
 mkdir /usr/share/foreman-proxy/.ssh
 chown foreman-proxy:foreman-proxy /usr/share/foreman-proxy/.ssh

--- a/_includes/manuals/nightly/4.3.7_smartproxy_puppetca.md
+++ b/_includes/manuals/nightly/4.3.7_smartproxy_puppetca.md
@@ -6,87 +6,56 @@ Builtin providers are:
 * `puppetca_hostname_whitelisting` - direct management of Puppet's `autosign.conf`
 * `puppetca_token_whitelisting` - manage token-based signing of certificate requests
 
-This should only be enabled in the Smart Proxy that is hosted on the machine responsible for providing certificates to your puppet clients. You would expect to see a subdirectory **ca** in your Puppet's ssldir on such a host. You can determine the ssldir with the command `puppet config print ssldir`. On this host enable the feature in `puppetca.yml`:
+This should only be enabled in the Smart Proxy that is hosted on the machine responsible for providing certificates to your puppet clients. On this host enable the feature in `puppetca.yml`:
 
-<pre>
+```yaml
 :enabled: https
-</pre>
-
-If your puppet SSL directory is not located in `/var/lib/puppet/ssl`, you'll need to set **ssldir** as well.
-<pre>
-:ssldir: /etc/puppet/ssl
-</pre>
+```
 
 Also choose the provider to use, default should be `puppetca_hostname_whitelisting`:
-<pre>
+```yaml
 :use_provider: puppetca_hostname_whitelisting
-</pre>
+```
+
+Lastly the Puppet version needs to be specified. Since version 6 the `puppetca_http_api` implementation is used while on earlier versions the `puppetca_puppet_cert` implementation is used.
+```yaml
+:puppet_version: '6.8.0'
+```
 
 #### puppetca_hostname_whitelisting
 
-The puppetca_hostname_whitelisting provider directly manages Puppet's `autosign.conf` file.
+The `puppetca_hostname_whitelisting` provider directly manages Puppet's `autosign.conf` file.
 This will create an autosign entry for a host during deployment and remove it when deployment is finished.
 Furthermore it allows you to manage entries manually using the Foreman WebUI.
 
 The **autosignfile** setting in `puppetca_hostname_whitelisting.yml` is used to find autosign.conf:
 
-<pre>
-:autosignfile: /etc/puppet/autosign.conf
-</pre>
+```yaml
+:autosignfile: /etc/puppetlabs/puppet/autosign.conf
+```
 
 The location of the file can be determined with `puppet config print autosign`.
-The proxy requires write access to the puppet autosign.conf file, which is usually owner and group puppet, and has mode 0644 according to the puppet defaults.
 
-Under a Puppet 4 AIO installation, paths should be set to:
-
-<pre>
-:ssldir: /etc/puppetlabs/puppet/ssl
-:autosignfile: /etc/puppetlabs/puppet/autosign.conf
-</pre>
-
-Ensure the foreman-proxy user is added to the puppet group ( e.g. `gpasswd -a foreman-proxy puppet` or `usermod -aG puppet foreman-proxy`)
+The proxy requires write access to the puppet autosign.conf file, which is usually owner and group puppet, and has mode 0644 according to the puppet defaults. Ensure the foreman-proxy user is added to the puppet group ( e.g. `gpasswd -a foreman-proxy puppet` or `usermod -aG puppet foreman-proxy`)
 
 puppet.conf:
-<pre>
+```ini
 [master]
 autosign = $confdir/autosign.conf {owner = service, group = service, mode = 664 }
-</pre>
-
-sudo access for the proxy is required - in your sudoers file ensure you allow the "puppet cert" command with NOPASSWD and without requiretty.
-
-Under a Puppet 4 AIO installation, configuration should be:
-
-<pre>
-foreman-proxy ALL = NOPASSWD: /opt/puppetlabs/bin/puppet cert *
-Defaults:foreman-proxy !requiretty
-</pre>
-
-Under a non-AIO Puppet installation:
-
-<pre>
-foreman-proxy ALL = NOPASSWD: /usr/bin/puppet cert *
-Defaults:foreman-proxy !requiretty
-</pre>
-
-For older versions of Puppet (2.x) with separate commands:
-
-<pre>
-foreman-proxy ALL = NOPASSWD: /usr/sbin/puppetca *
-Defaults:foreman-proxy !requiretty
-</pre>
+```
 
 #### puppetca_token_whitelisting
 
-The puppetca_token_whitelisting provider uses a token-based certificate signing managed by the Smart proxy itself and queried by Puppet during Provisioning.
+The `puppetca_token_whitelisting` provider uses a token-based certificate signing managed by the Smart Proxy itself and queried by Puppet during Provisioning.
 This provider adds more security and logging to the autosigning process but does not allow for manual creation of autosigning entries.
 
 This provider has the following settings in `puppetca_token_whitelisting.yml`:
 
-<pre>
+```yaml
 :sign_all: false
 :token_ttl: 360
 :tokens_file: /var/lib/foreman-proxy/tokens.yml
-</pre>
+```
 
 By changing **sign_all** to `true` you will disable token verification and sign all certificate requests.
 The setting **token_ttl** defines how long a token after creation is valid in minutes.
@@ -101,7 +70,52 @@ The script has to be executable by the same user running the Puppet master, typi
 
 After deploying the script the Puppet configuration has to be changed to point the **autosign** setting to the script.
 
-<pre>
+```ini
 [master]
 autosign = /usr/libexec/foreman-proxy/puppet_sign.rb
-</pre>
+```
+
+#### puppetca_puppet_cert
+
+**Note** this is used in Puppet 5 and earlier as determined by the `puppet_version` setting in `puppetca.yml`.
+
+This implementation is used for managing certificates. It uses the `puppet cert` command and typically requires sudo access for the proxy.
+
+```yaml
+:ssldir: /etc/puppetlabs/puppet/ssl
+#:puppetca_use_sudo: false
+#:sudo_command: /usr/bin/sudo
+```
+
+The `ssldir` setting is required and can be determined with `puppet config print ssldir`. Puppet AIO defaults to using `/etc/puppetlabs/puppet/ssl`.
+
+By default sudo is used but can be disabled with `puppetca_use_sudo` setting. The sudo command is dermined via the `PATH` variable or can be explicitly set with the `sudo_command` setting.
+
+For sudo to work correctly, it must be configured to allow `puppet cert` with NOPASSWD and without requiretty. Under a Puppet AIO installation, configuration should be:
+
+```
+foreman-proxy ALL = NOPASSWD: /opt/puppetlabs/bin/puppet cert *
+Defaults:foreman-proxy !requiretty
+```
+
+Under a non-AIO Puppet installation:
+
+```
+foreman-proxy ALL = NOPASSWD: /usr/bin/puppet cert *
+Defaults:foreman-proxy !requiretty
+```
+
+#### puppetca_http_api
+
+**Note** this is used in Puppet 6 and newer as determined by the `puppet_version` setting in `puppetca.yml`.
+
+As the name implies, Puppetserver's HTTP API is used to manage certificates. In its configuration file `puppetca_http_api.yml` the connection details are configured:
+
+```yaml
+:puppet_url: https://puppet.example.com:8140
+:puppet_ssl_ca: /etc/puppetlabs/ssl/certs/ca.pem
+:puppet_ssl_cert: /etc/puppetlabs/ssl/certs/puppet.example.com.pem
+:puppet_ssl_key: /etc/puppetlabs/ssl/private_keys/puppet.example.com.pem
+```
+
+The Puppet server does not need to be on the same host, but only the `puppetca_token_whitelisting` provider supports this. Note the Puppetserver also needs to allow access to the Smart Proxy.

--- a/_includes/manuals/nightly/5.4.2_comms_proxy.md
+++ b/_includes/manuals/nightly/5.4.2_comms_proxy.md
@@ -14,12 +14,12 @@ In a simple setup, a single Puppet Certificate Authority (CA) can be used for au
 # if enabled, all communication would be verified via SSL
 # NOTE that both certificates need to be signed by the same CA in order for this to work
 # see http://theforeman.org/projects/smart-proxy/wiki/SSL for more information
-:ssl_certificate: /var/lib/puppet/ssl/certs/FQDN.pem
-:ssl_ca_file: /var/lib/puppet/ssl/certs/ca.pem
-:ssl_private_key: /var/lib/puppet/ssl/private_keys/FQDN.pem
+:ssl_certificate: /etc/puppetlabs/puppet/ssl/certs/FQDN.pem
+:ssl_ca_file: /etc/puppetlabs/puppet/ssl/certs/ca.pem
+:ssl_private_key: /etc/puppetlabs/puppet/ssl/private_keys/FQDN.pem
 </pre>
 
-In this example, the proxy is sharing Puppet's certificates, but it could equally use its own. Under a Puppet 4 AIO installation, substitute above paths with `/etc/puppetlabs/puppet/ssl/`.
+In this example, the proxy is sharing Puppet's certificates, but it could equally use its own.
 
 In addition it contains a list of hosts that connections will be accepted from, which should be the host(s) running Foreman:
 

--- a/_includes/manuals/nightly/5.5.1_backup.md
+++ b/_includes/manuals/nightly/5.5.1_backup.md
@@ -32,13 +32,13 @@ For all other distribution do similar command:
 On the puppet master node, issue the following command to backup Puppet
 certificates on Red Hat compatible systems
 
-    tar --selinux -czvf var_lib_puppet_dir.tar.gz /var/lib/puppet/ssl
+    tar --selinux -czvf var_lib_puppet_dir.tar.gz /etc/puppetlabs/puppet/ssl
 
 For all other distribution do similar command:
 
-    tar -czvf var_lib_puppet_dir.tar.gz /var/lib/puppet/ssl
+    tar -czvf var_lib_puppet_dir.tar.gz /etc/puppetlabs/puppet/ssl
 
-Under a Puppet 4 AIO installation, back up `/etc/puppetlabs/puppet/ssl` instead.
+Under a Puppet non-AIO installation, back up `/var/lib/puppet/ssl` instead.
 
 #### DHCP, DNS and TFTP services
 


### PR DESCRIPTION
This is incomplete since at least the Puppet CA part needs to document the HTTP API-based implementation that's used since Puppet 6.