### PR TITLE
Fix incorrectly documented configuration option

### DIFF
--- a/_includes/manuals/1.21/3.5.2_configuration_options.md
+++ b/_includes/manuals/1.21/3.5.2_configuration_options.md
@@ -106,7 +106,7 @@ Default: false
 Same as above, but this setting allows REMOTE_USER authentication for API calls as well.
 Default: false
 
-##### authorize_login_delegation_auth_source_autocreate
+##### authorize_login_delegation_auth_source_user_autocreate
 
 If you have authorize_login_delegation set, new users can be autocreated through your external authentication mechanism by changing this to the name of the Auth Source you want to use to auto create users.
 Default: ''

--- a/_includes/manuals/1.22/3.5.2_configuration_options.md
+++ b/_includes/manuals/1.22/3.5.2_configuration_options.md
@@ -106,7 +106,7 @@ Default: false
 Same as above, but this setting allows REMOTE_USER authentication for API calls as well.
 Default: false
 
-##### authorize_login_delegation_auth_source_autocreate
+##### authorize_login_delegation_auth_source_user_autocreate
 
 If you have authorize_login_delegation set, new users can be autocreated through your external authentication mechanism by changing this to the name of the Auth Source you want to use to auto create users.
 Default: ''

--- a/_includes/manuals/1.23/3.5.2_configuration_options.md
+++ b/_includes/manuals/1.23/3.5.2_configuration_options.md
@@ -106,7 +106,7 @@ Default: false
 Same as above, but this setting allows REMOTE_USER authentication for API calls as well.
 Default: false
 
-##### authorize_login_delegation_auth_source_autocreate
+##### authorize_login_delegation_auth_source_user_autocreate
 
 If you have authorize_login_delegation set, new users can be autocreated through your external authentication mechanism by changing this to the name of the Auth Source you want to use to auto create users.
 Default: ''

--- a/_includes/manuals/nightly/3.5.2_configuration_options.md
+++ b/_includes/manuals/nightly/3.5.2_configuration_options.md
@@ -106,7 +106,7 @@ Default: false
 Same as above, but this setting allows REMOTE_USER authentication for API calls as well.
 Default: false
 
-##### authorize_login_delegation_auth_source_autocreate
+##### authorize_login_delegation_auth_source_user_autocreate
 
 If you have authorize_login_delegation set, new users can be autocreated through your external authentication mechanism by changing this to the name of the Auth Source you want to use to auto create users.
 Default: ''

--- a/_posts/2018-06-22-using-saml-for-single-sign---on-to-foreman-through-keycloak.md
+++ b/_posts/2018-06-22-using-saml-for-single-sign---on-to-foreman-through-keycloak.md
@@ -76,7 +76,7 @@ external provider. This requires the following settings:
 1.  Enable external user authentication by setting `authorize_login_delegation` to `true`.
 
 2.  Enable auto-creation of users from external authentication providers:
-    `authorize_login_delegation_auth_source_autocreate` to `External`.
+    `authorize_login_delegation_auth_source_user_autocreate` to `External`.
 
 3.  Set `login_delegation_logout_url` to
     `https://foreman.example.com/saml2/logout?ReturnTo=https://foreman.example.com/users/extlogout`


### PR DESCRIPTION
The correct name is `authorize_login_delegation_auth_source_user_autocreate`, compare https://github.com/theforeman/foreman/blob/f2ee562ece5d5084f39160524ac57b23b7bde251/app/models/setting/auth.rb#L23