### PR TITLE
fixed typo of forman-rake to foreman-rake

### DIFF
--- a/_includes/manuals/1.23/3.7_migration.md
+++ b/_includes/manuals/1.23/3.7_migration.md
@@ -127,7 +127,7 @@ production:
 In the next step, call a rake task which will create new database:
 
 ```sh
-forman-rake db:create RAILS_ENV=development
+foreman-rake db:create RAILS_ENV=development
 ```
 
 The new database needs to be set up with all the tables required for Foreman to


### PR DESCRIPTION
manual now has a valid rake command for mysql to postgres migration 