### PR TITLE
Add upgrade warning for puppet matcher inheritance setting

### DIFF
--- a/_includes/manuals/nightly/1.2_release_notes.md
+++ b/_includes/manuals/nightly/1.2_release_notes.md
@@ -28,4 +28,6 @@ This section will be updated prior to the next release.
   * Rake tasks `puppet:import:puppet_classes` and `puppet:import:environments_only` have been removed. These actions should be done by using the matching UI or API actions.
   * The `foreman-config` script has been removed. Use `foreman-rake config` instead.
 
+* The `Host group matchers inheritance` puppet setting has been renamed to `Matchers inheritance`. This setting will now manage puppet smart class parameter's matchers inheritance for hostgroups (as in the past) and taxonomies (organizations and locations). With this change it will be possible to inherit (and possibly merge if value's type permit it) values from parent taxonomies as it was already the case for hostgroups.
+
 ### Contributors

--- a/_includes/manuals/nightly/3.5.2_configuration_options.md
+++ b/_includes/manuals/nightly/3.5.2_configuration_options.md
@@ -229,9 +229,9 @@ See also: unattended_url
 Default PXELinux/PXEGrub/PXEGrub2 template. This template gets deployed to all configured TFTP servers. For example, this template can be used to make new hosts in a network boot into [Foreman Discovery](http://theforeman.org/plugins/foreman_discovery/).
 * Default: none
 
-##### host_group_matchers_inheritance
+##### matchers_inheritance
 
-Matchers used in smart variables or class parameters to match host groups can be inherited by children of those matching host groups too (e.g. a matcher for hostgroup=Base will also apply to Base/Web). Set this to false to make matchers only match a particular hostgroup and not its children.
+Matchers used in smart variables or smart class parameters to match host groups, organizations or locations can be inherited by children too (e.g. a matcher for hostgroup=Base will also apply to Base/Web). Set this to false to make matchers only match a particular hostgroup, organization or location and not its children.
 Default: true
 
 ##### host_power_status

--- a/_includes/manuals/nightly/4.2.6_matchers.md
+++ b/_includes/manuals/nightly/4.2.6_matchers.md
@@ -15,10 +15,10 @@ Overrides are processed in the order of precedence set in the *Order* field, fro
 Example attributes that may be listed are:
 
 * `fqdn` - host's FQDN ("host.example.com")
-* `hostgroup` - full name of the host group, including parents ("Europe/Web servers"). Matchers on host groups can be inherited by their children, see documentation for `host_group_matchers_inheritance` in [configuration options.](manuals/{{page.version}}/index.html#3.5.2ConfigurationOptions)
+* `hostgroup` - full name of the host group, including parents ("Europe/Web servers"). Matchers on host groups can be inherited by their children, see documentation for `matchers_inheritance` in [configuration options.](manuals/{{page.version}}/index.html#3.5.2ConfigurationOptions)
 * `os` - name and version of operating system ("RedHat 6.4")
 * `domain` - host's domain name ("example.com")
-* `location` or `organization` - full name of the location/organization, including parents ("Company/Subsidiary")
+* `location` or `organization` - full name of the location/organization, including parents ("Company/Subsidiary"). Matchers on location/organization can be inherited by their children, see documentation for `matchers_inheritance` in [configuration options.](man    uals/{{page.version}}/index.html#3.5.2ConfigurationOptions)
 * `is_virtual` - a fact [supplied by Facter](https://docs.puppetlabs.com/facter/latest/core_facts.html#isvirtual)
 
 The default order is set under *Administer > Settings > Puppet > Default_variables_Lookup_Path* and is "fqdn", "hostgroup", "os", "domain".


### PR DESCRIPTION
Add upgrade warning related to https://github.com/theforeman/foreman/pull/7037 and update the docs accordingly