### PR TITLE
Update Katello docs to fix yum dep issue

### DIFF
--- a/plugins/katello/3.14/installation/index.md
+++ b/plugins/katello/3.14/installation/index.md
@@ -96,8 +96,8 @@ yum install -y yum-utils
 
 <div id="el7" markdown="1">
 {% highlight bash %}
-yum -y localinstall https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el7/x86_64/katello-repos-latest.rpm
 yum -y localinstall https://yum.theforeman.org/releases/{{ page.foreman_version }}/el7/x86_64/foreman-release.rpm
+yum -y localinstall https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el7/x86_64/katello-repos-latest.rpm
 yum -y localinstall https://yum.puppet.com/puppet6-release-el-7.noarch.rpm
 yum -y localinstall https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 yum -y install foreman-release-scl

--- a/plugins/katello/nightly/installation/index.md
+++ b/plugins/katello/nightly/installation/index.md
@@ -97,8 +97,8 @@ yum install -y yum-utils
 
 <div id="el7" markdown="1">
 {% highlight bash %}
-yum -y localinstall https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el7/x86_64/katello-repos-latest.rpm
 yum -y localinstall https://yum.theforeman.org/releases/{{ page.foreman_version }}/el7/x86_64/foreman-release.rpm
+yum -y localinstall https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el7/x86_64/katello-repos-latest.rpm
 yum -y localinstall https://yum.puppet.com/puppet6-release-el-7.noarch.rpm
 yum -y localinstall https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 yum -y install foreman-release-scl


### PR DESCRIPTION
@jturel here is the pr we talked about:

If we follow the steps here we get the following Katello dependency error that it needs Foreman. This PR moves Foreman to the first repo so Katello will install correctly.

```bash
[root@katello ~]# yum -y localinstall https://fedorapeople.org/groups/katello/releases/yum/3.14/katello/el7/x86_64/katello-repos-latest.rpm
Loaded plugins: fastestmirror, langpacks
katello-repos-latest.rpm                                                                                                                                                                                                            |  11 kB  00:00:00
Examining /var/tmp/yum-root-KjhMkz/katello-repos-latest.rpm: katello-repos-3.14.0-0.4.rc2.el7.noarch
Marking /var/tmp/yum-root-KjhMkz/katello-repos-latest.rpm to be installed
Resolving Dependencies
--> Running transaction check
---> Package katello-repos.noarch 0:3.14.0-0.4.rc2.el7 will be installed
--> Processing Dependency: foreman-release for package: katello-repos-3.14.0-0.4.rc2.el7.noarch
Loading mirror speeds from cached hostfile
 * base: distro.ibiblio.org
 * extras: distro.ibiblio.org
 * updates: distro.ibiblio.org
--> Finished Dependency Resolution
Error: Package: katello-repos-3.14.0-0.4.rc2.el7.noarch (/katello-repos-latest)
           Requires: foreman-release
 You could try using --skip-broken to work around the problem
 You could try running: rpm -Va --nofiles --nodigest
```