### PR TITLE
Drop EL6 instructions

### DIFF
--- a/_includes/manuals/1.23/5.7.3_kerberos.md
+++ b/_includes/manuals/1.23/5.7.3_kerberos.md
@@ -15,14 +15,6 @@ setsebool -P allow_httpd_mod_auth_pam on
 setsebool -P httpd_dbus_sssd on
 {% endhighlight %}
 
-Until all the packages are part of your operation system distribution, you can get them from Jan Pazdziora's copr yum repo. At http://copr.fedoraproject.org/coprs/adelton/identity_demo/ choose the correct .repo file. For example, for Foreman on RHEL 6, the following command will configure yum:
-
-{% highlight bash %}
-wget -O /etc/yum.repos.d/adelton-identity_demo.repo \
-  https://copr.fedoraproject.org/coprs/adelton/identity_demo/repo/epel-6/adelton-identity_demo-epel-6.repo
-{% endhighlight %}
-
-
 Get the keytab for the service and set correct permissions (we assume the FreeIPA server is *ipa.example.com*, adjust to match your setup):
 {% highlight bash %}
 kinit admin

--- a/_includes/manuals/1.24/5.7.3_kerberos.md
+++ b/_includes/manuals/1.24/5.7.3_kerberos.md
@@ -15,14 +15,6 @@ setsebool -P allow_httpd_mod_auth_pam on
 setsebool -P httpd_dbus_sssd on
 {% endhighlight %}
 
-Until all the packages are part of your operation system distribution, you can get them from Jan Pazdziora's copr yum repo. At http://copr.fedoraproject.org/coprs/adelton/identity_demo/ choose the correct .repo file. For example, for Foreman on RHEL 6, the following command will configure yum:
-
-{% highlight bash %}
-wget -O /etc/yum.repos.d/adelton-identity_demo.repo \
-  https://copr.fedoraproject.org/coprs/adelton/identity_demo/repo/epel-6/adelton-identity_demo-epel-6.repo
-{% endhighlight %}
-
-
 Get the keytab for the service and set correct permissions (we assume the FreeIPA server is *ipa.example.com*, adjust to match your setup):
 {% highlight bash %}
 kinit admin

--- a/_includes/manuals/nightly/5.7.3_kerberos.md
+++ b/_includes/manuals/nightly/5.7.3_kerberos.md
@@ -15,14 +15,6 @@ setsebool -P allow_httpd_mod_auth_pam on
 setsebool -P httpd_dbus_sssd on
 {% endhighlight %}
 
-Until all the packages are part of your operation system distribution, you can get them from Jan Pazdziora's copr yum repo. At http://copr.fedoraproject.org/coprs/adelton/identity_demo/ choose the correct .repo file. For example, for Foreman on RHEL 6, the following command will configure yum:
-
-{% highlight bash %}
-wget -O /etc/yum.repos.d/adelton-identity_demo.repo \
-  https://copr.fedoraproject.org/coprs/adelton/identity_demo/repo/epel-6/adelton-identity_demo-epel-6.repo
-{% endhighlight %}
-
-
 Get the keytab for the service and set correct permissions (we assume the FreeIPA server is *ipa.example.com*, adjust to match your setup):
 {% highlight bash %}
 kinit admin


### PR DESCRIPTION
Way back in Foreman 1.13 support for EL6 was dropped. The packages have been part of EL7 for a long time.