### PR TITLE
Update shared modules section; minor grammar fixes

### DIFF
--- a/handbook.md
+++ b/handbook.md
@@ -139,7 +139,7 @@ We follow the [Ruby Style Guide](https://github.com/bbatsov/ruby-style-guide) an
 * Squash exceptions
 
 ### JavaScript
-We are supporting and encouraging the use of es2015. (For more information see [Learn ES2015](http://babeljs.io/docs/learn-es2015/).) For browser compatibility, we use Babel to transform the code to es5.
+We are supporting and encouraging the use of ES2015. (For more information see [Learn ES2015](http://babeljs.io/docs/learn-es2015/).) For browser compatibility, we use Babel to transform the code to es5.
 
 We use eslint to enforce linting rules. Run eslint by typing `npm run lint` in the command line at the root directory.
 
@@ -153,10 +153,8 @@ We use eslint to enforce linting rules. Run eslint by typing `npm run lint` in t
 * Remove global functions from existing code without deprecating them first. Deprecation can be done by calling the `tfm.tools.deprecate` function.
 
 #### Shared modules
-Usually, when we add a new node-module, we want it to be shared with plugins (Unless we have a reason not to share it).
 
-In order to do so, we let [webpack](https://webpack.js.org/) create a `vendor.js` file with the relevant modules.
-We manage the shared-modules list in [config/webpack.vendor.js](https://github.com/theforeman/foreman/blob/develop/config/webpack.vendor.js), when adding/removing node-modules, need to update this file accordingly.
+Node modules shared between Foreman and plugins are contained in a separate repository, [foreman-js](https://github.com/theforeman/foreman-js).  This repository contains several NPM packages which are listed in Foreman's `package.json` as dependencies.  For more info, view the [README](https://github.com/theforeman/foreman-js/blob/master/README.md) for that repository.
 
 #### Linting rules
 
@@ -269,7 +267,7 @@ If there is conflict, point to this handbook for reference.
 
 #### Labels
 
-Labels help reviewers understand what is the status of a pull request. Thanks to them, reviewers can make sure no pull request remains unreviewed and when they get updated, they see it.
+Labels help reviewers understand the status of a pull request. Thanks to them, reviewers can make sure no pull request remains unreviewed and when they get updated, they see it.
 
 Not all our repositories use labels, so always make sure to comment after you update a pull request to notify the reviewer and explain the new changes.
 


### PR DESCRIPTION
Looks like the `handbook.md` hasn't been updated with info about the `foreman-js` repo.  This PR adds a new blurb about that (also with a couple typo/grammar fixes).