### PR TITLE
Mark SL as unsupported

### DIFF
--- a/_includes/manuals/2.0/1.2_release_notes.md
+++ b/_includes/manuals/2.0/1.2_release_notes.md
@@ -442,7 +442,7 @@ External authentication sources can now be assigned to taxonomies using a new UI
 
 ### Upgrade warnings
 
-* The CentOS packages are not tested on Scientific Linux or Oracle Linux anymore. The Foreman installation on Scientific Linux or Oracle Linux may or may not work.
+* The CentOS packages are not tested on Scientific Linux or Oracle Linux. The Foreman installation on Scientific Linux or Oracle Linux may or may not work.
 * MySQL database is no longer supported. Users should migrate their data to PostgreSQL *Prior* to upgrading to 2.0. [Further details](https://theforeman.org/2019/09/dropping-support-for-mysql.html)
 * SQLite is officially not supported for production deployments any longer. While it shouldn't have been used as a production database and only be used for development, with this release we are officially declaring it unsupported in production. SQLite storage of boolean variables [has changed](https://projects.theforeman.org/issues/24838) due to changes in Ruby on Rails and data can not be easily migrated. Any developers using it can try running [this script](https://github.com/theforeman/foreman/pull/7171#issuecomment-552490998) to convert most of their database prior to performing the upgrade to 2.0. Additional manual actions may be needed to ensure all data is properly migrated. [Further details](https://community.theforeman.org/t/dropping-support-for-sqlite-as-production-database/16158/)
 * Ubuntu Xenial (16.04) is no longer supported. Users should upgrade to Bionic (18.04) prior to upgrading Foreman to this release.

--- a/_includes/manuals/2.0/1.2_release_notes.md
+++ b/_includes/manuals/2.0/1.2_release_notes.md
@@ -442,6 +442,7 @@ External authentication sources can now be assigned to taxonomies using a new UI
 
 ### Upgrade warnings
 
+* The CentOS packages are not tested on Scientific Linux or Oracle Linux anymore. The Foreman installation on Scientific Linux or Oracle Linux may or may not work.
 * MySQL database is no longer supported. Users should migrate their data to PostgreSQL *Prior* to upgrading to 2.0. [Further details](https://theforeman.org/2019/09/dropping-support-for-mysql.html)
 * SQLite is officially not supported for production deployments any longer. While it shouldn't have been used as a production database and only be used for development, with this release we are officially declaring it unsupported in production. SQLite storage of boolean variables [has changed](https://projects.theforeman.org/issues/24838) due to changes in Ruby on Rails and data can not be easily migrated. Any developers using it can try running [this script](https://github.com/theforeman/foreman/pull/7171#issuecomment-552490998) to convert most of their database prior to performing the upgrade to 2.0. Additional manual actions may be needed to ensure all data is properly migrated. [Further details](https://community.theforeman.org/t/dropping-support-for-sqlite-as-production-database/16158/)
 * Ubuntu Xenial (16.04) is no longer supported. Users should upgrade to Bionic (18.04) prior to upgrading Foreman to this release.

--- a/_includes/manuals/2.0/1.2_release_notes.md
+++ b/_includes/manuals/2.0/1.2_release_notes.md
@@ -442,7 +442,7 @@ External authentication sources can now be assigned to taxonomies using a new UI
 
 ### Upgrade warnings
 
-* The RPM packages are not tested on Scientific Linux or Oracle Linux. The Foreman installation on Scientific Linux or Oracle Linux may or may not work.
+* The RPM packages are not tested on Scientific Linux or Oracle Linux. The Foreman installation on Scientific Linux or Oracle Linux may or may not work. This has always been the case, but is now formalized.
 * MySQL database is no longer supported. Users should migrate their data to PostgreSQL *Prior* to upgrading to 2.0. [Further details](https://theforeman.org/2019/09/dropping-support-for-mysql.html)
 * SQLite is officially not supported for production deployments any longer. While it shouldn't have been used as a production database and only be used for development, with this release we are officially declaring it unsupported in production. SQLite storage of boolean variables [has changed](https://projects.theforeman.org/issues/24838) due to changes in Ruby on Rails and data can not be easily migrated. Any developers using it can try running [this script](https://github.com/theforeman/foreman/pull/7171#issuecomment-552490998) to convert most of their database prior to performing the upgrade to 2.0. Additional manual actions may be needed to ensure all data is properly migrated. [Further details](https://community.theforeman.org/t/dropping-support-for-sqlite-as-production-database/16158/)
 * Ubuntu Xenial (16.04) is no longer supported. Users should upgrade to Bionic (18.04) prior to upgrading Foreman to this release.

--- a/_includes/manuals/2.0/1.2_release_notes.md
+++ b/_includes/manuals/2.0/1.2_release_notes.md
@@ -442,7 +442,7 @@ External authentication sources can now be assigned to taxonomies using a new UI
 
 ### Upgrade warnings
 
-* The CentOS packages are not tested on Scientific Linux or Oracle Linux. The Foreman installation on Scientific Linux or Oracle Linux may or may not work.
+* The RPM packages are not tested on Scientific Linux or Oracle Linux. The Foreman installation on Scientific Linux or Oracle Linux may or may not work.
 * MySQL database is no longer supported. Users should migrate their data to PostgreSQL *Prior* to upgrading to 2.0. [Further details](https://theforeman.org/2019/09/dropping-support-for-mysql.html)
 * SQLite is officially not supported for production deployments any longer. While it shouldn't have been used as a production database and only be used for development, with this release we are officially declaring it unsupported in production. SQLite storage of boolean variables [has changed](https://projects.theforeman.org/issues/24838) due to changes in Ruby on Rails and data can not be easily migrated. Any developers using it can try running [this script](https://github.com/theforeman/foreman/pull/7171#issuecomment-552490998) to convert most of their database prior to performing the upgrade to 2.0. Additional manual actions may be needed to ensure all data is properly migrated. [Further details](https://community.theforeman.org/t/dropping-support-for-sqlite-as-production-database/16158/)
 * Ubuntu Xenial (16.04) is no longer supported. Users should upgrade to Bionic (18.04) prior to upgrading Foreman to this release.

--- a/_includes/manuals/2.0/2.1_quickstart_installation.md
+++ b/_includes/manuals/2.0/2.1_quickstart_installation.md
@@ -45,7 +45,7 @@ sudo yum-config-manager --enable rhel-7-server-optional-rpms rhel-server-rhscl-7
 
 <div class="quickstart_os quickstart_os_rhel7 quickstart_os_el7">
   <p>
-    <b>Note:</b> The CentOS packages are not tested on Scientific Linux or Oracle Linux. The Foreman installation on Scientific Linux or Oracle Linux may or may not work.
+    <b>Note:</b> The RPM packages are not tested on Scientific Linux or Oracle Linux. The Foreman installation on Scientific Linux or Oracle Linux may or may not work.
   </p>
 
   <p>

--- a/_includes/manuals/2.0/2.1_quickstart_installation.md
+++ b/_includes/manuals/2.0/2.1_quickstart_installation.md
@@ -45,8 +45,11 @@ sudo yum-config-manager --enable rhel-7-server-optional-rpms rhel-server-rhscl-7
 
 <div class="quickstart_os quickstart_os_rhel7 quickstart_os_el7">
   <p>
-    Using a recent version of Puppet is recommended, which is available from the Puppet Labs repository.
+    <b>Note:</b> The CentOS packages are not tested on Scientific Linux or Oracle Linux anymore. The Foreman installation on Scientific Linux or Oracle Linux may or may not work.
+  </p>
 
+  <p>
+    Using a recent version of Puppet is recommended, which is available from the Puppet Labs repository.
     To use Puppet 6.x with Puppet Agent and Puppet Server:
   </p>
 

--- a/_includes/manuals/2.0/2.1_quickstart_installation.md
+++ b/_includes/manuals/2.0/2.1_quickstart_installation.md
@@ -45,7 +45,7 @@ sudo yum-config-manager --enable rhel-7-server-optional-rpms rhel-server-rhscl-7
 
 <div class="quickstart_os quickstart_os_rhel7 quickstart_os_el7">
   <p>
-    <b>Note:</b> The CentOS packages are not tested on Scientific Linux or Oracle Linux anymore. The Foreman installation on Scientific Linux or Oracle Linux may or may not work.
+    <b>Note:</b> The CentOS packages are not tested on Scientific Linux or Oracle Linux. The Foreman installation on Scientific Linux or Oracle Linux may or may not work.
   </p>
 
   <p>

--- a/_includes/manuals/2.0/2_quickstart_guide.md
+++ b/_includes/manuals/2.0/2_quickstart_guide.md
@@ -9,7 +9,7 @@ Components include the Foreman web UI, Smart Proxy, Passenger, a Puppet master (
 * Red Hat Enterprise Linux 7, x86_64
 * Ubuntu 18.04 (Bionic), i386/amd64/aarch64
 
-#### Untested platforms(CentOS packages may not work on these)
+#### Untested platforms (CentOS packages may not work on these)
 * Scientific Linux and Oracle Linux
 
 Other operating systems will need to use alternative installation methods (see the manual).

--- a/_includes/manuals/2.0/2_quickstart_guide.md
+++ b/_includes/manuals/2.0/2_quickstart_guide.md
@@ -9,7 +9,7 @@ Components include the Foreman web UI, Smart Proxy, Passenger, a Puppet master (
 * Red Hat Enterprise Linux 7, x86_64
 * Ubuntu 18.04 (Bionic), i386/amd64/aarch64
 
-#### Untested platforms (CentOS packages may not work on these)
+#### Untested platforms (packages may not work on these)
 * Scientific Linux and Oracle Linux
 
 Other operating systems will need to use alternative installation methods (see the manual).

--- a/_includes/manuals/2.0/2_quickstart_guide.md
+++ b/_includes/manuals/2.0/2_quickstart_guide.md
@@ -10,7 +10,10 @@ Components include the Foreman web UI, Smart Proxy, Passenger, a Puppet master (
 * Ubuntu 18.04 (Bionic), i386/amd64/aarch64
 
 #### Untested platforms (packages may not work on these)
-* Scientific Linux and Oracle Linux
+
+These platforms are not tested by automatic installations. They are generally close to supported platforms so the packages may work, but additional work may be needed. For any queries for these platforms raise a question in [discourse support section](https://community.theforeman.org/c/support/10)
+
+  * Scientific Linux and Oracle Linux 7, x86_64
 
 Other operating systems will need to use alternative installation methods (see the manual).
 

--- a/_includes/manuals/2.0/2_quickstart_guide.md
+++ b/_includes/manuals/2.0/2_quickstart_guide.md
@@ -4,10 +4,13 @@ The Foreman installer is a collection of Puppet modules that installs everything
 Components include the Foreman web UI, Smart Proxy, Passenger, a Puppet master (either Puppet Server or under Passenger), and optionally TFTP, DNS and DHCP servers.  It is configurable and the Puppet modules can be read or run in "no-op" mode to see what changes it will make.
 
 #### Supported platforms
-* CentOS, Scientific Linux or Oracle Linux 7, x86_64
+* CentOS 7 x86_64
 * Debian 10 (Buster), i386/amd64/aarch64
 * Red Hat Enterprise Linux 7, x86_64
 * Ubuntu 18.04 (Bionic), i386/amd64/aarch64
+
+#### Untested platforms(CentOS packages may not work on these)
+* Scientific Linux and Oracle Linux
 
 Other operating systems will need to use alternative installation methods (see the manual).
 

--- a/_includes/manuals/2.0/3.1.1_supported_platforms.md
+++ b/_includes/manuals/2.0/3.1.1_supported_platforms.md
@@ -8,6 +8,7 @@ The following operating systems are supported by the installer, have packages an
     * check the above repositories because the command can silently fail when subscription does not provide it: `yum repolist`
   * Apply all SELinux-related errata.
 * CentOS, Scientific Linux or Oracle Linux 7
+  * **Note:** The CentOS packages are not tested on Scientific Linux or Oracle Linux anymore. The Foreman installation on Scientific Linux or Oracle Linux may or may not work.
   * Architectures: x86_64 only
   * [EPEL](http://fedoraproject.org/wiki/EPEL/FAQ#How_can_I_install_the_packages_from_the_EPEL_software_repository.3F) is required
 * Ubuntu 18.04 (Bionic)
@@ -15,9 +16,9 @@ The following operating systems are supported by the installer, have packages an
 * Debian 10 (Buster)
   * Architectures: i386, amd64, aarch64
 
-It is assumed to use the PostgreSQL version provided by the OS, which is currently:
+PostgreSQL from Software Collections:
 
-* PostgreSQL 9.2 or newer
+* PostgreSQL version 12
 
 It is recommended to apply all OS updates if possible.
 

--- a/_includes/manuals/2.0/3.1.1_supported_platforms.md
+++ b/_includes/manuals/2.0/3.1.1_supported_platforms.md
@@ -16,9 +16,7 @@ The following operating systems are supported by the installer, have packages an
 * Debian 10 (Buster)
   * Architectures: i386, amd64, aarch64
 
-PostgreSQL version 10 or newer
-  * For Ubuntu and Debian PostgreSQL is available from regular OS repositories.
-  * For CentOS PostgreSQL is available from Software Collections.
+PostgreSQL version 10 or newer. For EL 7 this is available from Software Collections.
 
 It is recommended to apply all OS updates if possible.
 

--- a/_includes/manuals/2.0/3.1.1_supported_platforms.md
+++ b/_includes/manuals/2.0/3.1.1_supported_platforms.md
@@ -8,7 +8,7 @@ The following operating systems are supported by the installer, have packages an
     * check the above repositories because the command can silently fail when subscription does not provide it: `yum repolist`
   * Apply all SELinux-related errata.
 * CentOS, Scientific Linux or Oracle Linux 7
-  * **Note:** The CentOS packages are not tested on Scientific Linux or Oracle Linux. The Foreman installation on Scientific Linux or Oracle Linux may or may not work.
+  * **Note:** The RPM packages are not tested on Scientific Linux or Oracle Linux. The Foreman installation on Scientific Linux or Oracle Linux may or may not work.
   * Architectures: x86_64 only
   * [EPEL](http://fedoraproject.org/wiki/EPEL/FAQ#How_can_I_install_the_packages_from_the_EPEL_software_repository.3F) is required
 * Ubuntu 18.04 (Bionic)

--- a/_includes/manuals/2.0/3.1.1_supported_platforms.md
+++ b/_includes/manuals/2.0/3.1.1_supported_platforms.md
@@ -8,7 +8,7 @@ The following operating systems are supported by the installer, have packages an
     * check the above repositories because the command can silently fail when subscription does not provide it: `yum repolist`
   * Apply all SELinux-related errata.
 * CentOS, Scientific Linux or Oracle Linux 7
-  * **Note:** The CentOS packages are not tested on Scientific Linux or Oracle Linux anymore. The Foreman installation on Scientific Linux or Oracle Linux may or may not work.
+  * **Note:** The CentOS packages are not tested on Scientific Linux or Oracle Linux. The Foreman installation on Scientific Linux or Oracle Linux may or may not work.
   * Architectures: x86_64 only
   * [EPEL](http://fedoraproject.org/wiki/EPEL/FAQ#How_can_I_install_the_packages_from_the_EPEL_software_repository.3F) is required
 * Ubuntu 18.04 (Bionic)
@@ -18,7 +18,7 @@ The following operating systems are supported by the installer, have packages an
 
 PostgreSQL from Software Collections:
 
-* PostgreSQL version 12
+* PostgreSQL version 10
 
 It is recommended to apply all OS updates if possible.
 

--- a/_includes/manuals/2.0/3.1.1_supported_platforms.md
+++ b/_includes/manuals/2.0/3.1.1_supported_platforms.md
@@ -16,9 +16,9 @@ The following operating systems are supported by the installer, have packages an
 * Debian 10 (Buster)
   * Architectures: i386, amd64, aarch64
 
-PostgreSQL from Software Collections:
-
-* PostgreSQL version 10
+PostgreSQL version 10 or newer
+  * For Ubuntu and Debian PostgreSQL is available from regular OS repositories.
+  * For CentOS PostgreSQL is available from Software Collections.
 
 It is recommended to apply all OS updates if possible.
 

--- a/_includes/manuals/2.0/3.3.1_rpm_packages.md
+++ b/_includes/manuals/2.0/3.3.1_rpm_packages.md
@@ -3,7 +3,7 @@ Foreman is packaged for the following RPM based distributions:
 
 * RHEL and derivatives, version 7
 
-**Note:** The CentOS packages are not tested on Scientific Linux or Oracle Linux. The Foreman installation on Scientific Linux or Oracle Linux may or may not work.
+**Note:** The RPM packages are not tested on Scientific Linux or Oracle Linux. The Foreman installation on Scientific Linux or Oracle Linux may or may not work.
 
 For most users, it's highly recommended to use the [installer](manuals/{{page.version}}/index.html#3.2ForemanInstaller) as the packages only provide the software and a standalone Foreman service.  The installer installs these packages, then additionally configures Foreman to run under Apache and Passenger with PostgreSQL, plus can configure a complete Puppet setup integrated with Foreman.
 

--- a/_includes/manuals/2.0/3.3.1_rpm_packages.md
+++ b/_includes/manuals/2.0/3.3.1_rpm_packages.md
@@ -3,6 +3,8 @@ Foreman is packaged for the following RPM based distributions:
 
 * RHEL and derivatives, version 7
 
+**Note:** The CentOS packages are not tested on Scientific Linux or Oracle Linux anymore. The Foreman installation on Scientific Linux or Oracle Linux may or may not work.
+
 For most users, it's highly recommended to use the [installer](manuals/{{page.version}}/index.html#3.2ForemanInstaller) as the packages only provide the software and a standalone Foreman service.  The installer installs these packages, then additionally configures Foreman to run under Apache and Passenger with PostgreSQL, plus can configure a complete Puppet setup integrated with Foreman.
 
 #### Pre-requisites: EPEL

--- a/_includes/manuals/2.0/3.3.1_rpm_packages.md
+++ b/_includes/manuals/2.0/3.3.1_rpm_packages.md
@@ -3,7 +3,7 @@ Foreman is packaged for the following RPM based distributions:
 
 * RHEL and derivatives, version 7
 
-**Note:** The CentOS packages are not tested on Scientific Linux or Oracle Linux anymore. The Foreman installation on Scientific Linux or Oracle Linux may or may not work.
+**Note:** The CentOS packages are not tested on Scientific Linux or Oracle Linux. The Foreman installation on Scientific Linux or Oracle Linux may or may not work.
 
 For most users, it's highly recommended to use the [installer](manuals/{{page.version}}/index.html#3.2ForemanInstaller) as the packages only provide the software and a standalone Foreman service.  The installer installs these packages, then additionally configures Foreman to run under Apache and Passenger with PostgreSQL, plus can configure a complete Puppet setup integrated with Foreman.
 

--- a/_includes/manuals/nightly/1.2_release_notes.md
+++ b/_includes/manuals/nightly/1.2_release_notes.md
@@ -10,13 +10,9 @@ This section will be updated prior to the next release.
 
 ### Upgrade warnings
 
-<<<<<<< HEAD
 * Due to changes in the build process, the API docs shipped with foreman and its plugins will no longer contain information about the data types of search fields. These will still be available in the API documentation on the website, and can be generated locally if needed by running `foreman-rake apipie:cache` on your Foreman server.
 
-* The CentOS packages are not tested on Scientific Linux or Oracle Linux. The Foreman installation on Scientific Linux or Oracle Linux may or may not work.
-=======
 * The RPM packages are not tested on Scientific Linux or Oracle Linux. The Foreman installation on Scientific Linux or Oracle Linux may or may not work.
->>>>>>> Modify deprecation message about SL and OL
 
 ### Contributors
 

--- a/_includes/manuals/nightly/1.2_release_notes.md
+++ b/_includes/manuals/nightly/1.2_release_notes.md
@@ -12,6 +12,8 @@ This section will be updated prior to the next release.
 
 * Due to changes in the build process, the API docs shipped with foreman and its plugins will no longer contain information about the data types of search fields. These will still be available in the API documentation on the website, and can be generated locally if needed by running `foreman-rake apipie:cache` on your Foreman server.
 
+* The CentOS packages are not tested on Scientific Linux or Oracle Linux. The Foreman installation on Scientific Linux or Oracle Linux may or may not work.
+
 ### Contributors
 
 We'd like to thank the following people who contributed to the Foreman {{page.version}} release:

--- a/_includes/manuals/nightly/1.2_release_notes.md
+++ b/_includes/manuals/nightly/1.2_release_notes.md
@@ -10,9 +10,13 @@ This section will be updated prior to the next release.
 
 ### Upgrade warnings
 
+<<<<<<< HEAD
 * Due to changes in the build process, the API docs shipped with foreman and its plugins will no longer contain information about the data types of search fields. These will still be available in the API documentation on the website, and can be generated locally if needed by running `foreman-rake apipie:cache` on your Foreman server.
 
 * The CentOS packages are not tested on Scientific Linux or Oracle Linux. The Foreman installation on Scientific Linux or Oracle Linux may or may not work.
+=======
+* The RPM packages are not tested on Scientific Linux or Oracle Linux. The Foreman installation on Scientific Linux or Oracle Linux may or may not work.
+>>>>>>> Modify deprecation message about SL and OL
 
 ### Contributors
 

--- a/_includes/manuals/nightly/2.1_quickstart_installation.md
+++ b/_includes/manuals/nightly/2.1_quickstart_installation.md
@@ -45,7 +45,7 @@ sudo yum-config-manager --enable rhel-7-server-optional-rpms rhel-server-rhscl-7
 
 <div class="quickstart_os quickstart_os_rhel7 quickstart_os_el7">
   <p>
-    <b>Note:</b> The CentOS packages are not tested on Scientific Linux or Oracle Linux. The Foreman installation on Scientific Linux or Oracle Linux may or may not work.
+    <b>Note:</b> The RPM packages are not tested on Scientific Linux or Oracle Linux. The Foreman installation on Scientific Linux or Oracle Linux may or may not work.
   </p>
 
   <p>

--- a/_includes/manuals/nightly/2.1_quickstart_installation.md
+++ b/_includes/manuals/nightly/2.1_quickstart_installation.md
@@ -45,8 +45,11 @@ sudo yum-config-manager --enable rhel-7-server-optional-rpms rhel-server-rhscl-7
 
 <div class="quickstart_os quickstart_os_rhel7 quickstart_os_el7">
   <p>
-    Using a recent version of Puppet is recommended, which is available from the Puppet Labs repository.
+    <b>Note:</b> The CentOS packages are not tested on Scientific Linux or Oracle Linux. The Foreman installation on Scientific Linux or Oracle Linux may or may not work.
+  </p>
 
+  <p>
+    Using a recent version of Puppet is recommended, which is available from the Puppet Labs repository.
     To use Puppet 6.x with Puppet Agent and Puppet Server:
   </p>
 

--- a/_includes/manuals/nightly/2_quickstart_guide.md
+++ b/_includes/manuals/nightly/2_quickstart_guide.md
@@ -9,7 +9,7 @@ Components include the Foreman web UI, Smart Proxy, Passenger, a Puppet master (
 * Red Hat Enterprise Linux 7, x86_64
 * Ubuntu 18.04 (Bionic), i386/amd64/aarch64
 
-#### Untested platforms(CentOS packages may not work on these)
+#### Untested platforms(packages may not work on these)
 * Scientific Linux and Oracle Linux
 
 Other operating systems will need to use alternative installation methods (see the manual).

--- a/_includes/manuals/nightly/2_quickstart_guide.md
+++ b/_includes/manuals/nightly/2_quickstart_guide.md
@@ -4,10 +4,13 @@ The Foreman installer is a collection of Puppet modules that installs everything
 Components include the Foreman web UI, Smart Proxy, Passenger, a Puppet master (either Puppet Server or under Passenger), and optionally TFTP, DNS and DHCP servers.  It is configurable and the Puppet modules can be read or run in "no-op" mode to see what changes it will make.
 
 #### Supported platforms
-* CentOS, Scientific Linux or Oracle Linux 7, x86_64
+* CentOS 7 x86_64
 * Debian 10 (Buster), i386/amd64/aarch64
 * Red Hat Enterprise Linux 7, x86_64
 * Ubuntu 18.04 (Bionic), i386/amd64/aarch64
+
+#### Untested platforms(CentOS packages may not work on these)
+* Scientific Linux and Oracle Linux
 
 Other operating systems will need to use alternative installation methods (see the manual).
 

--- a/_includes/manuals/nightly/2_quickstart_guide.md
+++ b/_includes/manuals/nightly/2_quickstart_guide.md
@@ -9,8 +9,11 @@ Components include the Foreman web UI, Smart Proxy, Passenger, a Puppet master (
 * Red Hat Enterprise Linux 7, x86_64
 * Ubuntu 18.04 (Bionic), i386/amd64/aarch64
 
-#### Untested platforms(packages may not work on these)
-* Scientific Linux and Oracle Linux
+#### Untested platforms (packages may not work on these)
+
+These platforms are not tested by automatic installations. They are generally close to supported platforms so the packages may work, but additional work may be needed. For any queries for these platforms raise a question in [discourse support section](https://community.theforeman.org/c/support/10)
+
+  * Scientific Linux and Oracle Linux 7, x86_64
 
 Other operating systems will need to use alternative installation methods (see the manual).
 

--- a/_includes/manuals/nightly/3.1.1_supported_platforms.md
+++ b/_includes/manuals/nightly/3.1.1_supported_platforms.md
@@ -16,9 +16,7 @@ The following operating systems are supported by the installer, have packages an
 * Debian 10 (Buster)
   * Architectures: i386, amd64, aarch64
 
-PostgreSQL version 10 or newer
-  * For Ubuntu and Debian PostgreSQL is available from regular OS repositories.
-  * For CentOS PostgreSQL is available from Software Collections.
+PostgreSQL version 10 or newer. For EL 7 this is available from Software Collections.
 
 It is recommended to apply all OS updates if possible.
 

--- a/_includes/manuals/nightly/3.1.1_supported_platforms.md
+++ b/_includes/manuals/nightly/3.1.1_supported_platforms.md
@@ -8,7 +8,7 @@ The following operating systems are supported by the installer, have packages an
     * check the above repositories because the command can silently fail when subscription does not provide it: `yum repolist`
   * Apply all SELinux-related errata.
 * CentOS, Scientific Linux or Oracle Linux 7
-  * **Note:** The CentOS packages are not tested on Scientific Linux or Oracle Linux. The Foreman installation on Scientific Linux or Oracle Linux may or may not work.
+  * **Note:** The RPM packages are not tested on Scientific Linux or Oracle Linux. The Foreman installation on Scientific Linux or Oracle Linux may or may not work.
   * Architectures: x86_64 only
   * [EPEL](http://fedoraproject.org/wiki/EPEL/FAQ#How_can_I_install_the_packages_from_the_EPEL_software_repository.3F) is required
 * Ubuntu 18.04 (Bionic)

--- a/_includes/manuals/nightly/3.1.1_supported_platforms.md
+++ b/_includes/manuals/nightly/3.1.1_supported_platforms.md
@@ -8,6 +8,7 @@ The following operating systems are supported by the installer, have packages an
     * check the above repositories because the command can silently fail when subscription does not provide it: `yum repolist`
   * Apply all SELinux-related errata.
 * CentOS, Scientific Linux or Oracle Linux 7
+  * **Note:** The CentOS packages are not tested on Scientific Linux or Oracle Linux. The Foreman installation on Scientific Linux or Oracle Linux may or may not work.
   * Architectures: x86_64 only
   * [EPEL](http://fedoraproject.org/wiki/EPEL/FAQ#How_can_I_install_the_packages_from_the_EPEL_software_repository.3F) is required
 * Ubuntu 18.04 (Bionic)
@@ -15,9 +16,9 @@ The following operating systems are supported by the installer, have packages an
 * Debian 10 (Buster)
   * Architectures: i386, amd64, aarch64
 
-It is assumed to use the PostgreSQL version provided by the OS, which is currently:
-
-* PostgreSQL 9.2 or newer
+PostgreSQL version 10 or newer
+  * For Ubuntu and Debian PostgreSQL is available from regular OS repositories.
+  * For CentOS PostgreSQL is available from Software Collections.
 
 It is recommended to apply all OS updates if possible.
 

--- a/_includes/manuals/nightly/3.3.1_rpm_packages.md
+++ b/_includes/manuals/nightly/3.3.1_rpm_packages.md
@@ -3,7 +3,7 @@ Foreman is packaged for the following RPM based distributions:
 
 * RHEL and derivatives, version 7
 
-**Note:** The CentOS packages are not tested on Scientific Linux or Oracle Linux. The Foreman installation on Scientific Linux or Oracle Linux may or may not work.
+**Note:** The RPM packages are not tested on Scientific Linux or Oracle Linux. The Foreman installation on Scientific Linux or Oracle Linux may or may not work.
 
 For most users, it's highly recommended to use the [installer](manuals/{{page.version}}/index.html#3.2ForemanInstaller) as the packages only provide the software and a standalone Foreman service.  The installer installs these packages, then additionally configures Foreman to run under Apache and Passenger with PostgreSQL, plus can configure a complete Puppet setup integrated with Foreman.
 

--- a/_includes/manuals/nightly/3.3.1_rpm_packages.md
+++ b/_includes/manuals/nightly/3.3.1_rpm_packages.md
@@ -3,6 +3,8 @@ Foreman is packaged for the following RPM based distributions:
 
 * RHEL and derivatives, version 7
 
+**Note:** The CentOS packages are not tested on Scientific Linux or Oracle Linux. The Foreman installation on Scientific Linux or Oracle Linux may or may not work.
+
 For most users, it's highly recommended to use the [installer](manuals/{{page.version}}/index.html#3.2ForemanInstaller) as the packages only provide the software and a standalone Foreman service.  The installer installs these packages, then additionally configures Foreman to run under Apache and Passenger with PostgreSQL, plus can configure a complete Puppet setup integrated with Foreman.
 
 #### Pre-requisites: EPEL


### PR DESCRIPTION
Mention Scientific Linux is no longer supported in upgrade warnings.