### PR TITLE
Drop --foreman-db-type parameter documentation

### DIFF
--- a/_includes/manuals/2.0/3.2.2_installer_options.md
+++ b/_includes/manuals/2.0/3.2.2_installer_options.md
@@ -1,5 +1,5 @@
 
-The installer is a collection of Puppet modules, which have a large number of parameters available to customize the configuration.  Parameters can be set by running `foreman-installer` with arguments, e.g. `--foreman-db-type`, changing settings in interactive mode or by setting up an answers file.
+The installer is a collection of Puppet modules, which have a large number of parameters available to customize the configuration.  Parameters can be set by running `foreman-installer` with arguments, e.g. `--foreman-initial-admin-password`, changing settings in interactive mode or by setting up an answers file.
 
 The precedence for settings is for those set by arguments to foreman-installer or interactive mode, then the answers file, then the Puppet manifest defaults.
 

--- a/_includes/manuals/2.0/3.2.3_installation_scenarios.md
+++ b/_includes/manuals/2.0/3.2.3_installation_scenarios.md
@@ -3,11 +3,10 @@ The Foreman installer can accommodate more complex, multi-host setups when suppl
 
 #### Using an external database server
 
-Per default foreman-installer will install a PostgreSQL database server onto the Foreman host and create its database. An external MySQL or PostgreSQL database server with an already created database can be used with the following arguments:
+Per default foreman-installer will install a PostgreSQL database server onto the Foreman host and create its database. An external database server with an already created database can be used with the following arguments:
 
 {% highlight bash %}
 foreman-installer \
-  --foreman-db-type=mysql \
   --foreman-db-manage=false \
   --foreman-db-host=dbserver.example.com \
   --foreman-db-database=dbname \

--- a/_includes/manuals/nightly/3.2.2_installer_options.md
+++ b/_includes/manuals/nightly/3.2.2_installer_options.md
@@ -1,5 +1,5 @@
 
-The installer is a collection of Puppet modules, which have a large number of parameters available to customize the configuration.  Parameters can be set by running `foreman-installer` with arguments, e.g. `--foreman-db-type`, changing settings in interactive mode or by setting up an answers file.
+The installer is a collection of Puppet modules, which have a large number of parameters available to customize the configuration.  Parameters can be set by running `foreman-installer` with arguments, e.g. `--foreman-initial-admin-password`, changing settings in interactive mode or by setting up an answers file.
 
 The precedence for settings is for those set by arguments to foreman-installer or interactive mode, then the answers file, then the Puppet manifest defaults.
 

--- a/_includes/manuals/nightly/3.2.3_installation_scenarios.md
+++ b/_includes/manuals/nightly/3.2.3_installation_scenarios.md
@@ -3,11 +3,10 @@ The Foreman installer can accommodate more complex, multi-host setups when suppl
 
 #### Using an external database server
 
-Per default foreman-installer will install a PostgreSQL database server onto the Foreman host and create its database. An external MySQL or PostgreSQL database server with an already created database can be used with the following arguments:
+Per default foreman-installer will install a PostgreSQL database server onto the Foreman host and create its database. An external database server with an already created database can be used with the following arguments:
 
 {% highlight bash %}
 foreman-installer \
-  --foreman-db-type=mysql \
   --foreman-db-manage=false \
   --foreman-db-host=dbserver.example.com \
   --foreman-db-database=dbname \


### PR DESCRIPTION
Foreman 2.0 dropped this parameter and now only supports PostgreSQL.