### PR TITLE
Generate apipie docs for english lang only

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Generate API docs in Foreman
 1. cd to foreman directory and checkout the relevant stable branch
 1. disable any plugins installed locally 
 1. `APIPIE_RECORD=examples rake test`
-1. `rake apipie:cache`
+1. `FOREMAN_APIPIE_LANGS=en rake apipie:cache`
 
 Prepare folder for the new version (X.Y)
 


### PR DESCRIPTION
As per the discussion and decision on [discourse](https://community.theforeman.org/t/publishing-apidocs-in-english-language-only/17811) we are limiting the apidocs for english language only. Updating the readme file with same. 