### PR TITLE
Add scl for 2.x installer options generation

### DIFF
--- a/scripts/installer/Dockerfile
+++ b/scripts/installer/Dockerfile
@@ -4,4 +4,9 @@ RUN yum -y install epel-release https://yum.puppetlabs.com/puppet5/puppet5-relea
 
 ARG FOREMAN_VERSION
 RUN yum -y install https://yum.theforeman.org/releases/$FOREMAN_VERSION/el7/x86_64/foreman-release.rpm
+RUN yum -y install centos-release-scl-rh
 RUN yum -y install foreman-installer
+
+COPY entrypoint.sh /usr/bin/entrypoint.sh
+RUN chmod +x /usr/bin/entrypoint.sh
+ENTRYPOINT ["/usr/bin/entrypoint.sh"]

--- a/scripts/installer/entrypoint.sh
+++ b/scripts/installer/entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+if [ -x "$(command -v scl_source)" ]; then
+  source scl_source enable tfm
+fi
+
+exec "$@"


### PR DESCRIPTION
From 2.0 we need ruby from scl and kafo-export-params also requires scl. Adding this change which is working for 1.y and 2.y both versions.