### PR TITLE
Katello 4.0 extended Pulp 3 deprecation warnings

### DIFF
--- a/plugins/katello/3.16/release_notes/release_notes.md
+++ b/plugins/katello/3.16/release_notes/release_notes.md
@@ -22,6 +22,8 @@ For the full release notes, see the [Changelog](https://github.com/Katello/katel
 * katello-agent will be removed in Katello 4.0
 * Background download policy will be removed in Katello 4.0
 * Pulp 3 will replace Pulp 2 in Katello 4.0
+    * MongoDB will be removed in Katello 4.0
+    * The Foreman installer MongoDB Storage Engine Migration Hook will be removed for Katello 4.0 
 
 ## Bug Fixes
 


### PR DESCRIPTION
MongoDB Storage Engine Migration Hook is being removed from the foreman installer.  I figured we should also make it more obvious that Mongo will be going away in general as well.  Related issue: https://projects.theforeman.org/issues/30006