### PR TITLE
fix foreman/katello nightly installation instructions

### DIFF
--- a/_includes/manuals/2.1/2.1_quickstart_installation.md
+++ b/_includes/manuals/2.1/2.1_quickstart_installation.md
@@ -88,7 +88,7 @@ sudo yum -y install https://yum.theforeman.org/releases/{{page.version}}/el7/x86
 {% highlight bash %}
 sudo yum -y install http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 sudo yum -y install https://yum.theforeman.org/releases/{{page.version}}/el7/x86_64/foreman-release.rpm
-sudo yum -y install foreman-release-scl
+sudo yum -y install centos-release-scl-rh
 {% endhighlight %}
 </div>
 

--- a/_includes/manuals/nightly/2.1_quickstart_installation.md
+++ b/_includes/manuals/nightly/2.1_quickstart_installation.md
@@ -88,7 +88,7 @@ sudo yum -y install https://yum.theforeman.org/releases/{{page.version}}/el7/x86
 {% highlight bash %}
 sudo yum -y install http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 sudo yum -y install https://yum.theforeman.org/releases/{{page.version}}/el7/x86_64/foreman-release.rpm
-sudo yum -y install foreman-release-scl
+sudo yum -y install centos-release-scl-rh
 {% endhighlight %}
 </div>
 

--- a/plugins/katello/nightly/installation/index.md
+++ b/plugins/katello/nightly/installation/index.md
@@ -101,7 +101,7 @@ yum -y localinstall https://yum.theforeman.org/releases/{{ page.foreman_version 
 yum -y localinstall https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el7/x86_64/katello-repos-latest.rpm
 yum -y localinstall https://yum.puppet.com/puppet6-release-el-7.noarch.rpm
 yum -y localinstall https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
-yum -y install foreman-release-scl
+yum -y install centos-release-scl-rh
 {% endhighlight %}
 </div>
 


### PR DESCRIPTION
`foreman-release-scl` has been dropped in favor of `centos-release-scl-rh`