### PR TITLE
don't end viewport data with a semicolon

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -44,7 +44,7 @@
   <meta name="robots" content="{{page.robots}}" />
 {% endif %}
   <meta name="apple-mobile-web-app-capable" content="yes">
-  <meta name="viewport" content="user-scalable=no, width=device-width, initial-scale=1.0, maximum-scale=1.0;" />
+  <meta name="viewport" content="user-scalable=no, width=device-width, initial-scale=1.0, maximum-scale=1.0" />
   {% if page.redirect != nil %}
   <meta http-equiv="refresh" content="1; url={{ page.redirect }}" />
   {% endif %}


### PR DESCRIPTION
Chrome complains about it:

    Error parsing a meta element's content: ';' is not a valid key-value pair separator. Please use ',' instead.