### PR TITLE
Fix 2.1 release notes spelling errors

### DIFF
--- a/_includes/manuals/2.1/1.2_release_notes.md
+++ b/_includes/manuals/2.1/1.2_release_notes.md
@@ -110,7 +110,7 @@ By default it is deployed using [systemd socket activation](http://0pointer.de/b
 * vmrc not working 1.24 ([#29439](https://projects.theforeman.org/issues/29439))
 * Does not load datacenter when multiple compute resources are created for same VCenter
  ([#29265](https://projects.theforeman.org/issues/29265))
-* Internal Server Error under user with limited priviledges in vmware CR ([#29263](https://projects.theforeman.org/issues/29263))
+* Internal Server Error under user with limited privileges in vmware CR ([#29263](https://projects.theforeman.org/issues/29263))
 * Eager zero seems to do nothing ([#28874](https://projects.theforeman.org/issues/28874))
 * n+1 when listing VMs on VMware ([#26567](https://projects.theforeman.org/issues/26567))
 
@@ -284,7 +284,7 @@ By default it is deployed using [systemd socket activation](http://0pointer.de/b
 
 #### Parameters
 * Drop puppetclass_id column from Lookup_key along with smart variable ([#29714](https://projects.theforeman.org/issues/29714))
-* Rename settings refering to "smart variables" to "smart class parameters" ([#28618](https://projects.theforeman.org/issues/28618))
+* Rename settings referring to "smart variables" to "smart class parameters" ([#28618](https://projects.theforeman.org/issues/28618))
 * Remove VariableLookupKey from tests ([#28598](https://projects.theforeman.org/issues/28598))
 * Remove VariableLookupKey model ([#28597](https://projects.theforeman.org/issues/28597))
 * Remove Api::V2::LookupKeysCommonController ([#28596](https://projects.theforeman.org/issues/28596))
@@ -422,16 +422,16 @@ By default it is deployed using [systemd socket activation](http://0pointer.de/b
 
 #### Users
 * Session id out of range error ([#29027](https://projects.theforeman.org/issues/29027))
-* Error "Couldn't find Host::Managed with 'id'=" when sending Configuration Errror Reports ([#28960](https://projects.theforeman.org/issues/28960))
+* Error "Couldn't find Host::Managed with 'id'=" when sending Configuration Error Reports ([#28960](https://projects.theforeman.org/issues/28960))
 * Long role names are cut off in the roles UI ([#28849](https://projects.theforeman.org/issues/28849))
 * admin cannot edit a user without re-entering the user's password ([#25925](https://projects.theforeman.org/issues/25925))
 
 #### Web Interface
 * Login page background style is getting override by PF4 styles  ([#29741](https://projects.theforeman.org/issues/29741))
-* Puppet class names overflowing tab boundry ([#29740](https://projects.theforeman.org/issues/29740))
+* Puppet class names overflowing tab boundary ([#29740](https://projects.theforeman.org/issues/29740))
 * Bar chart on config report page is overflowing its card ([#29734](https://projects.theforeman.org/issues/29734))
 * csp policy is broken for dev ([#29712](https://projects.theforeman.org/issues/29712))
-* Headers of all tables should be bold as beofre vendor v4.2.0 ([#29700](https://projects.theforeman.org/issues/29700))
+* Headers of all tables should be bold as before vendor v4.2.0 ([#29700](https://projects.theforeman.org/issues/29700))
 * Small Foreman logo with package changes ([#29630](https://projects.theforeman.org/issues/29630))
 * Upgrade jquery-ui-rails ([#29522](https://projects.theforeman.org/issues/29522))
 * Hosts bulk actions - support URL with parameter ([#29369](https://projects.theforeman.org/issues/29369))

--- a/_includes/manuals/2.1/1.2_release_notes.md
+++ b/_includes/manuals/2.1/1.2_release_notes.md
@@ -6,7 +6,7 @@
 
 New Smart Proxy External IPAM API allows implementation of IPAM providers.
 Subnets can be now associated with IPAM plugins providing IP address management
-capabilities via external entities. An experimental implementaion for phpIPAM
+capabilities via external entities. An experimental implementation for phpIPAM
 is available as a [Smart Proxy plugin](https://github.com/grizzthedj/smart_proxy_ipam).
 
 #### Rails 6 upgrade


### PR DESCRIPTION
Other than the spelling of `implementation`, the other errors came from spelling mistakes in ticket titles.  I don't have the privileges to fix these, but perhaps someone else would?