### PR TITLE
Update Katello broken SCL rpm name

### DIFF
--- a/plugins/katello/3.16/installation/index.md
+++ b/plugins/katello/3.16/installation/index.md
@@ -78,8 +78,7 @@ yum install -y yum-utils
 yum -y localinstall https://yum.theforeman.org/releases/{{ page.foreman_version }}/el7/x86_64/foreman-release.rpm
 yum -y localinstall https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el7/x86_64/katello-repos-latest.rpm
 yum -y localinstall https://yum.puppet.com/puppet6-release-el-7.noarch.rpm
-yum -y localinstall https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
-yum -y install foreman-release-scl
+yum -y install epel-release centos-release-scl-rh
 {% endhighlight %}
 </div>
 

--- a/plugins/katello/nightly/installation/index.md
+++ b/plugins/katello/nightly/installation/index.md
@@ -78,8 +78,7 @@ yum install -y yum-utils
 yum -y localinstall https://yum.theforeman.org/releases/{{ page.foreman_version }}/el7/x86_64/foreman-release.rpm
 yum -y localinstall https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el7/x86_64/katello-repos-latest.rpm
 yum -y localinstall https://yum.puppet.com/puppet6-release-el-7.noarch.rpm
-yum -y localinstall https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
-yum -y install foreman-release-scl
+yum -y install epel-release centos-release-scl-rh
 {% endhighlight %}
 </div>
 


### PR DESCRIPTION
When testing Katello 3.17 and an upgrade from Katello 3.16 manually, it looks like `foreman-release-scl` no longer exists. I looked on the Foreman nightly docs and it has been replaced with `epel-release centos-release-scl-rh` which allows the install of of rpms to complete.