### PR TITLE
Update Katello 3.17 display to RC2

### DIFF
--- a/_data/plugins/katello.yml
+++ b/_data/plugins/katello.yml
@@ -1,6 +1,6 @@
 versions:
   - name: "3.17"
-    display: "3.17 RC1"
+    display: "3.17 RC2"
   - name: "3.16"
     display: "3.16"
   - name: "3.15"


### PR DESCRIPTION
When 3.17 RC2 get published by the release team