### PR TITLE
Update puppet master to puppet server in the manual

### DIFF
--- a/_includes/manuals/2.0/2.1_quickstart_installation.md
+++ b/_includes/manuals/2.0/2.1_quickstart_installation.md
@@ -162,13 +162,12 @@ sudo foreman-installer
 {% endhighlight %}
 </div>
 
-After it completes, the installer will print some details about where to find Foreman and the Smart Proxy and Puppet master if they were installed along Foreman. Output should be similar to this:
+After it completes, the installer will print some details about where to find Foreman and the Smart Proxy. Output should be similar to this:
 
 {% highlight bash %}
   * Foreman is running at https://theforeman.example.com
       Initial credentials are admin / 3ekw5xtyXCoXxS29
   * Foreman Proxy is running at https://theforeman.example.com:8443
-  * Puppetmaster is running at port 8140
   The full log is at /var/log/foreman-installer/foreman-installer.log
 {% endhighlight %}
 

--- a/_includes/manuals/2.0/3.2.1_installation.md
+++ b/_includes/manuals/2.0/3.2.1_installation.md
@@ -11,12 +11,11 @@ The installation run is non-interactive, but the configuration can be customized
 foreman-installer
 {% endhighlight %}
 
-After it completes, the installer will print some details about where to find Foreman and the Smart Proxy and Puppet master if they were installed along Foreman. Output should be similar to this:
+After it completes, the installer will print some details about where to find Foreman and the Smart Proxy. Output should be similar to this:
 
 {% highlight bash %}
   * Foreman is running at https://theforeman.example.com
       Initial credentials are admin / 3ekw5xtyXCoXxS29
   * Foreman Proxy is running at https://theforeman.example.com:8443
-  * Puppetmaster is running at port 8140
   * The full log is at /var/log/foreman-installer/foreman-installer.log
 {% endhighlight %}

--- a/_includes/manuals/2.1/2.1_quickstart_installation.md
+++ b/_includes/manuals/2.1/2.1_quickstart_installation.md
@@ -182,13 +182,12 @@ sudo foreman-installer
 {% endhighlight %}
 </div>
 
-After it completes, the installer will print some details about where to find Foreman and the Smart Proxy and Puppet master if they were installed along Foreman. Output should be similar to this:
+After it completes, the installer will print some details about where to find Foreman and the Smart Proxy. Output should be similar to this:
 
 {% highlight bash %}
   * Foreman is running at https://theforeman.example.com
       Initial credentials are admin / 3ekw5xtyXCoXxS29
   * Foreman Proxy is running at https://theforeman.example.com:8443
-  * Puppetmaster is running at port 8140
   The full log is at /var/log/foreman-installer/foreman-installer.log
 {% endhighlight %}
 

--- a/_includes/manuals/2.1/3.2.1_installation.md
+++ b/_includes/manuals/2.1/3.2.1_installation.md
@@ -11,12 +11,11 @@ The installation run is non-interactive, but the configuration can be customized
 foreman-installer
 {% endhighlight %}
 
-After it completes, the installer will print some details about where to find Foreman and the Smart Proxy and Puppet master if they were installed along Foreman. Output should be similar to this:
+After it completes, the installer will print some details about where to find Foreman and the Smart Proxy. Output should be similar to this:
 
 {% highlight bash %}
   * Foreman is running at https://theforeman.example.com
       Initial credentials are admin / 3ekw5xtyXCoXxS29
   * Foreman Proxy is running at https://theforeman.example.com:8443
-  * Puppetmaster is running at port 8140
   * The full log is at /var/log/foreman-installer/foreman-installer.log
 {% endhighlight %}

--- a/_includes/manuals/2.2/2.1_quickstart_installation.md
+++ b/_includes/manuals/2.2/2.1_quickstart_installation.md
@@ -196,13 +196,12 @@ sudo foreman-installer
 {% endhighlight %}
 </div>
 
-After it completes, the installer will print some details about where to find Foreman and the Smart Proxy and Puppet master if they were installed along Foreman. Output should be similar to this:
+After it completes, the installer will print some details about where to find Foreman and the Smart Proxy. Output should be similar to this:
 
 {% highlight bash %}
   * Foreman is running at https://theforeman.example.com
       Initial credentials are admin / 3ekw5xtyXCoXxS29
   * Foreman Proxy is running at https://theforeman.example.com:8443
-  * Puppetmaster is running at port 8140
   The full log is at /var/log/foreman-installer/foreman-installer.log
 {% endhighlight %}
 

--- a/_includes/manuals/2.2/3.2.1_installation.md
+++ b/_includes/manuals/2.2/3.2.1_installation.md
@@ -11,12 +11,11 @@ The installation run is non-interactive, but the configuration can be customized
 foreman-installer
 {% endhighlight %}
 
-After it completes, the installer will print some details about where to find Foreman and the Smart Proxy and Puppet master if they were installed along Foreman. Output should be similar to this:
+After it completes, the installer will print some details about where to find Foreman and the Smart Proxy. Output should be similar to this:
 
 {% highlight bash %}
   * Foreman is running at https://theforeman.example.com
       Initial credentials are admin / 3ekw5xtyXCoXxS29
   * Foreman Proxy is running at https://theforeman.example.com:8443
-  * Puppetmaster is running at port 8140
   * The full log is at /var/log/foreman-installer/foreman-installer.log
 {% endhighlight %}

--- a/_includes/manuals/nightly/2.1_quickstart_installation.md
+++ b/_includes/manuals/nightly/2.1_quickstart_installation.md
@@ -1,4 +1,4 @@
-[The Foreman installer](/manuals/{{page.version}}/index.html#3.2ForemanInstaller) uses Puppet **(4 or later required)** to install Foreman. This guide assumes that you have a newly installed operating system, on which the installer will setup Foreman, a Puppet master, and the [Smart Proxy](/manuals/{{page.version}}/index.html#4.3SmartProxies) by default. It's **not advisable** to follow the steps below on an existing system, since the installer will affect the configuration of several components.
+[The Foreman installer](/manuals/{{page.version}}/index.html#3.2ForemanInstaller) uses Puppet **(5 or later required)** to install Foreman. This guide assumes that you have a newly installed operating system, on which the installer will setup Foreman, a Puppet server, and the [Smart Proxy](/manuals/{{page.version}}/index.html#4.3SmartProxies) by default. It's **not advisable** to follow the steps below on an existing system, since the installer will affect the configuration of several components.
 
 <div class="alert alert-info">
 
@@ -196,13 +196,12 @@ sudo foreman-installer
 {% endhighlight %}
 </div>
 
-After it completes, the installer will print some details about where to find Foreman and the Smart Proxy and Puppet master if they were installed along Foreman. Output should be similar to this:
+After it completes, the installer will print some details about where to find Foreman and the Smart Proxy. Output should be similar to this:
 
 {% highlight bash %}
   * Foreman is running at https://theforeman.example.com
       Initial credentials are admin / 3ekw5xtyXCoXxS29
   * Foreman Proxy is running at https://theforeman.example.com:8443
-  * Puppetmaster is running at port 8140
   The full log is at /var/log/foreman-installer/foreman-installer.log
 {% endhighlight %}
 

--- a/_includes/manuals/nightly/2.1_quickstart_installation.md
+++ b/_includes/manuals/nightly/2.1_quickstart_installation.md
@@ -60,7 +60,7 @@ sudo yum-config-manager --enable rhel-7-server-optional-rpms rhel-server-rhscl-7
 
   <p>
     Using a recent version of Puppet is recommended, which is available from the Puppet Labs repository.
-    To use Puppet 6.x with Puppet Agent and Puppet Server:
+    To use Puppet 6.x with Puppet Agent and Puppet server:
   </p>
 
 {% highlight bash %}
@@ -71,7 +71,7 @@ sudo yum -y install https://yum.puppet.com/puppet6-release-el-7.noarch.rpm
 <div class="quickstart_os quickstart_os_rhel8 quickstart_os_el8">
   <p>
     Using a recent version of Puppet is recommended, which is available from the Puppet Labs repository.
-    To use Puppet 6.x with Puppet Agent and Puppet Server:
+    To use Puppet 6.x with Puppet Agent and Puppet server:
   </p>
 
 {% highlight bash %}
@@ -122,7 +122,7 @@ sudo yum -y install https://yum.theforeman.org/releases/{{page.version}}/el8/x86
   <p>
     Using Puppet 6.x is recommended, which is available from the Puppet Labs repository.
 
-    To use Puppet 6.x with Puppet Agent and Puppet Server:
+    To use Puppet 6.x with Puppet Agent and Puppet server:
   </p>
 
 {% highlight bash %}
@@ -145,7 +145,7 @@ wget -q https://deb.theforeman.org/pubkey.gpg -O- | sudo apt-key add -
   <p>
     Using Puppet 6.x is recommended, which is available from the Puppet Labs repository.
 
-    To use Puppet 6.x with Puppet Agent and Puppet Server:
+    To use Puppet 6.x with Puppet Agent and Puppet server:
   </p>
 
 {% highlight bash %}

--- a/_includes/manuals/nightly/2.2_quickstart_puppet.md
+++ b/_includes/manuals/nightly/2.2_quickstart_puppet.md
@@ -1,5 +1,5 @@
 
-After installation, the Foreman installer will have set up a puppet server on the host, fully integrated with Foreman.  First run the Puppet agent on the Foreman host which will send the first Puppet report to Foreman, automatically creating the host in Foreman's database.
+After installation, the Foreman installer will have set up a Puppet server on the host, fully integrated with Foreman.  First run the Puppet agent on the Foreman host which will send the first Puppet report to Foreman, automatically creating the host in Foreman's database.
 
 {% highlight bash %}
 sudo puppet agent --test
@@ -17,7 +17,7 @@ Next, we'll install a Puppet module for managing the NTP service from [Puppet Fo
 sudo puppet module install puppetlabs/ntp
 {% endhighlight %}
 
-In Foreman, go to *Configure > Classes* and click *Import from hostname* (top right) to read the available Puppet classes from the puppet server and populate Foreman's database.  The "ntp" class will appear in the Puppet class list if installed correctly.
+In Foreman, go to *Configure > Classes* and click *Import from hostname* (top right) to read the available Puppet classes from the Puppet server and populate Foreman's database.  The "ntp" class will appear in the Puppet class list if installed correctly.
 
 #### Using the Puppet module
 
@@ -34,6 +34,6 @@ Clicking the *YAML* button when back on the host page will show the *ntp* class 
 
 #### Adding more Puppet-managed hosts
 
-Other hosts with Puppet agents installed can use this puppet server by setting `server = foreman.example.com` in puppet.conf.  Sign their certificates in Foreman by going to *Infrastructure > Smart Proxies > Certificates* or using `puppet cert list` and `puppet cert sign` on the puppet server.
+Other hosts with Puppet agents installed can use this Puppet server by setting `server = foreman.example.com` in puppet.conf.  Sign their certificates in Foreman by going to *Infrastructure > Smart Proxies > Certificates* or using `puppet cert list` and `puppet cert sign` on the Puppet server.
 
 Puppet classes can be added to host groups in Foreman instead of individual hosts, enabling a standard configuration of many hosts simultaneously.  Host groups are typically used to represent server roles.

--- a/_includes/manuals/nightly/2.2_quickstart_puppet.md
+++ b/_includes/manuals/nightly/2.2_quickstart_puppet.md
@@ -1,5 +1,5 @@
 
-After installation, the Foreman installer will have set up a puppet master on the host, fully integrated with Foreman.  First run the Puppet agent on the Foreman host which will send the first Puppet report to Foreman, automatically creating the host in Foreman's database.
+After installation, the Foreman installer will have set up a puppet server on the host, fully integrated with Foreman.  First run the Puppet agent on the Foreman host which will send the first Puppet report to Foreman, automatically creating the host in Foreman's database.
 
 {% highlight bash %}
 sudo puppet agent --test
@@ -17,7 +17,7 @@ Next, we'll install a Puppet module for managing the NTP service from [Puppet Fo
 sudo puppet module install puppetlabs/ntp
 {% endhighlight %}
 
-In Foreman, go to *Configure > Classes* and click *Import from hostname* (top right) to read the available Puppet classes from the puppet master and populate Foreman's database.  The "ntp" class will appear in the Puppet class list if installed correctly.
+In Foreman, go to *Configure > Classes* and click *Import from hostname* (top right) to read the available Puppet classes from the puppet server and populate Foreman's database.  The "ntp" class will appear in the Puppet class list if installed correctly.
 
 #### Using the Puppet module
 
@@ -34,6 +34,6 @@ Clicking the *YAML* button when back on the host page will show the *ntp* class 
 
 #### Adding more Puppet-managed hosts
 
-Other hosts with Puppet agents installed can use this puppet master by setting `server = foreman.example.com` in puppet.conf.  Sign their certificates in Foreman by going to *Infrastructure > Smart Proxies > Certificates* or using `puppet cert list` and `puppet cert sign` on the puppet master.
+Other hosts with Puppet agents installed can use this puppet server by setting `server = foreman.example.com` in puppet.conf.  Sign their certificates in Foreman by going to *Infrastructure > Smart Proxies > Certificates* or using `puppet cert list` and `puppet cert sign` on the puppet server.
 
 Puppet classes can be added to host groups in Foreman instead of individual hosts, enabling a standard configuration of many hosts simultaneously.  Host groups are typically used to represent server roles.

--- a/_includes/manuals/nightly/2_quickstart_guide.md
+++ b/_includes/manuals/nightly/2_quickstart_guide.md
@@ -1,7 +1,7 @@
 
 The Foreman installer is a collection of Puppet modules that installs everything required for a full working Foreman setup.  It uses native OS packaging (e.g. RPM and .deb packages) and adds necessary configuration for the complete installation.
 
-Components include the Foreman web UI, Smart Proxy, Passenger, a Puppet master (either Puppet Server or under Passenger), and optionally TFTP, DNS and DHCP servers.  It is configurable and the Puppet modules can be read or run in "no-op" mode to see what changes it will make.
+Components include the Foreman web UI, Smart Proxy, Passenger, a Puppet server, and optionally TFTP, DNS and DHCP servers.  It is configurable and the Puppet modules can be read or run in "no-op" mode to see what changes it will make.
 
 #### Supported platforms
 * CentOS 7 x86_64

--- a/_includes/manuals/nightly/3.1.2_hardware_requirements.md
+++ b/_includes/manuals/nightly/3.1.2_hardware_requirements.md
@@ -1,7 +1,7 @@
 
 The hardware requirements for Foreman depend primarily on the number of requests that it will receive, which depends on the number of configuration management clients, web UI activity and other systems using the API.
 
-The default installation when including Puppet Server will require:
+The default installation when including Puppet server will require:
 
 * 4GB memory
 * 2GB disk space
@@ -14,5 +14,5 @@ For a bare minimum installation with few clients and no Puppet server, the requi
 #### Scaling notes
 
 * The default installation when using Passenger will increase the number of running processes based on the number of simultaneous requests, up to a default maximum of six instances. Each instance will typically require 0.5-1GB of memory, depending on the number of configured plugins.
-* When using a Puppet server, consult the requirements outlined in the [Puppet Server System Requirements](https://puppet.com/docs/puppet/latest/server/install_from_packages.html#system-requirements).
-* Disk usage will increase as more data is stored in the database (PostgreSQL by default), mostly for facts and reports. See the [reports cronjob configuration](manuals/{{page.version}}/index.html#3.5.4PuppetReports) to change how they are expired.
+* When using a Puppet server, consult the requirements outlined in the [Puppet server system requirements](https://puppet.com/docs/puppet/latest/server/install_from_packages.html#system-requirements).
+* Disk usage will increase as more data is stored in the database, mostly for facts and reports. See the [reports cronjob configuration](manuals/{{page.version}}/index.html#3.5.4PuppetReports) to change how they are expired.

--- a/_includes/manuals/nightly/3.1.2_hardware_requirements.md
+++ b/_includes/manuals/nightly/3.1.2_hardware_requirements.md
@@ -6,7 +6,7 @@ The default installation when including Puppet Server will require:
 * 4GB memory
 * 2GB disk space
 
-For a bare minimum installation with few clients and no Puppet master, the requirements are:
+For a bare minimum installation with few clients and no Puppet server, the requirements are:
 
 * 2GB memory
 * 1GB disk space
@@ -14,5 +14,5 @@ For a bare minimum installation with few clients and no Puppet master, the requi
 #### Scaling notes
 
 * The default installation when using Passenger will increase the number of running processes based on the number of simultaneous requests, up to a default maximum of six instances. Each instance will typically require 0.5-1GB of memory, depending on the number of configured plugins.
-* When using the Puppet master, consult the requirements outlined in the [Puppet System Requirements](https://docs.puppet.com/puppet/latest/reference/system_requirements.html#hardware) and [Puppet Server System Requirements](https://docs.puppet.com/puppetserver/2.4/install_from_packages.html#system-requirements).
+* When using a Puppet server, consult the requirements outlined in the [Puppet Server System Requirements](https://puppet.com/docs/puppet/latest/server/install_from_packages.html#system-requirements).
 * Disk usage will increase as more data is stored in the database (PostgreSQL by default), mostly for facts and reports. See the [reports cronjob configuration](manuals/{{page.version}}/index.html#3.5.4PuppetReports) to change how they are expired.

--- a/_includes/manuals/nightly/3.1.3_puppet_versions.md
+++ b/_includes/manuals/nightly/3.1.3_puppet_versions.md
@@ -37,7 +37,7 @@ Foreman integrates with Puppet and Facter in a few places, but generally using a
 
 The Foreman installer has code for both AIO and non-AIO configurations, switching behavior automatically based on the version of Puppet installed (usually during the first run when answers are stored). Only AIO installations are tested.
 
-#### Puppet Server compatibility
+#### Puppet server compatibility
 
 Puppetserver is the application for serving Puppet agents used by default since Puppet 4. Both Fedora and Debian have not packaged Puppetserver for their non-AIO packages. The Puppetlabs packages must be used.
 

--- a/_includes/manuals/nightly/3.1.5_firewall_configuration.md
+++ b/_includes/manuals/nightly/3.1.5_firewall_configuration.md
@@ -44,7 +44,7 @@ Protect your Foreman environment by blocking all unnecessary and unused ports.
   <tr>
     <td>8140</td>
     <td>TCP</td>
-    <td><span class='footnote'>*</span> Puppet Master</td>
+    <td><span class='footnote'>*</span> Puppet Server</td>
   </tr>
   <tr>
     <td>8443</td>

--- a/_includes/manuals/nightly/3.1.5_firewall_configuration.md
+++ b/_includes/manuals/nightly/3.1.5_firewall_configuration.md
@@ -44,7 +44,7 @@ Protect your Foreman environment by blocking all unnecessary and unused ports.
   <tr>
     <td>8140</td>
     <td>TCP</td>
-    <td><span class='footnote'>*</span> Puppet Server</td>
+    <td><span class='footnote'>*</span> Puppet server</td>
   </tr>
   <tr>
     <td>8443</td>

--- a/_includes/manuals/nightly/3.2.1_installation.md
+++ b/_includes/manuals/nightly/3.2.1_installation.md
@@ -11,12 +11,11 @@ The installation run is non-interactive, but the configuration can be customized
 foreman-installer
 {% endhighlight %}
 
-After it completes, the installer will print some details about where to find Foreman and the Smart Proxy and Puppet master if they were installed along Foreman. Output should be similar to this:
+After it completes, the installer will print some details about where to find Foreman and the Smart Proxy. Output should be similar to this:
 
 {% highlight bash %}
   * Foreman is running at https://theforeman.example.com
       Initial credentials are admin / 3ekw5xtyXCoXxS29
   * Foreman Proxy is running at https://theforeman.example.com:8443
-  * Puppetmaster is running at port 8140
   * The full log is at /var/log/foreman-installer/foreman-installer.log
 {% endhighlight %}

--- a/_includes/manuals/nightly/3.3.2_software_collections.md
+++ b/_includes/manuals/nightly/3.3.2_software_collections.md
@@ -15,7 +15,7 @@ More general information about software collections is available from these link
 
 #### Passenger under the SCL
 
-When running Foreman under Passenger, a specific configuration is needed for SCL (on EL), since Foreman operates under the SCL Ruby and other apps such as the puppet server will use the system Ruby.  Passenger 4 is shipped in the Foreman repos as it can be configured with separate Ruby binaries per VirtualHost.  The full configuration is described below.
+When running Foreman under Passenger, a specific configuration is needed for SCL (on EL), since Foreman operates under the SCL Ruby and other apps such as the Puppet server will use the system Ruby.  Passenger 4 is shipped in the Foreman repos as it can be configured with separate Ruby binaries per VirtualHost.  The full configuration is described below.
 
 The following packages must be installed:
 
@@ -37,7 +37,7 @@ The `/etc/httpd/conf.d/passenger.conf` file is supplied by mod_passenger and sho
        PassengerRuby /usr/bin/ruby
     </IfModule>
 
-Check for .rpmsave or .rpmnew config backup files if this isn't correct.  Note that this refers to the system Ruby paths by default, allowing everything except Foreman (i.e. the puppet server) to run under the system Ruby.
+Check for .rpmsave or .rpmnew config backup files if this isn't correct.  Note that this refers to the system Ruby paths by default, allowing everything except Foreman (i.e. the Puppet server) to run under the system Ruby.
 
 Next, the Foreman config file at `/etc/httpd/conf.d/foreman.conf` must contain this entry in both HTTP and HTTPS VirtualHost sections:
 

--- a/_includes/manuals/nightly/3.3.2_software_collections.md
+++ b/_includes/manuals/nightly/3.3.2_software_collections.md
@@ -15,7 +15,7 @@ More general information about software collections is available from these link
 
 #### Passenger under the SCL
 
-When running Foreman under Passenger, a specific configuration is needed for SCL (on EL), since Foreman operates under the SCL Ruby and other apps such as the puppetmaster will use the system Ruby.  Passenger 4 is shipped in the Foreman repos as it can be configured with separate Ruby binaries per VirtualHost.  The full configuration is described below.
+When running Foreman under Passenger, a specific configuration is needed for SCL (on EL), since Foreman operates under the SCL Ruby and other apps such as the puppet server will use the system Ruby.  Passenger 4 is shipped in the Foreman repos as it can be configured with separate Ruby binaries per VirtualHost.  The full configuration is described below.
 
 The following packages must be installed:
 
@@ -37,7 +37,7 @@ The `/etc/httpd/conf.d/passenger.conf` file is supplied by mod_passenger and sho
        PassengerRuby /usr/bin/ruby
     </IfModule>
 
-Check for .rpmsave or .rpmnew config backup files if this isn't correct.  Note that this refers to the system Ruby paths by default, allowing everything except Foreman (i.e. the puppetmaster) to run under the system Ruby.
+Check for .rpmsave or .rpmnew config backup files if this isn't correct.  Note that this refers to the system Ruby paths by default, allowing everything except Foreman (i.e. the puppet server) to run under the system Ruby.
 
 Next, the Foreman config file at `/etc/httpd/conf.d/foreman.conf` must contain this entry in both HTTP and HTTPS VirtualHost sections:
 

--- a/_includes/manuals/nightly/3.5.2_configuration_options.md
+++ b/_includes/manuals/nightly/3.5.2_configuration_options.md
@@ -363,7 +363,7 @@ Default: 35
 
 ##### puppet_server
 
-The default puppet server hostname. For larger organizations this is often a non fqdn so that a name like _puppet_ can be a different host within each DNS domain.
+The default Puppet server hostname. For larger organizations this is often a non fqdn so that a name like _puppet_ can be a different host within each DNS domain.
 Default: puppet
 
 ##### query_local_nameservers

--- a/_includes/manuals/nightly/3.5.2_configuration_options.md
+++ b/_includes/manuals/nightly/3.5.2_configuration_options.md
@@ -154,7 +154,7 @@ Specifies, which language is set for newly created users. This also applies to n
 Default: '', but 'Browser language' is used for newly created users. This also applies to new users managed via LDAP.
 
 ##### default_timezone
-Specifies, which timezone is set for newly created users. 
+Specifies, which timezone is set for newly created users.
 
 Default: '', but 'Browser timezone' is used for newly created users.
 
@@ -385,12 +385,12 @@ Default: 127.0.0.1
 
 ##### require_ssl_smart_proxies
 
-When set to _true_, Foreman requires a client SSL certificate on requests from smart proxies or services on them (e.g. Puppet masters), and will verify the CN of the certificate against the known smart proxies. If false, it uses the reverse DNS of the IP address making the request. require_ssl in ```config/settings.yaml``` should be enabled too. For more information about securing the connection between Puppet masters or smart proxies and Foreman, see [Section 5.4.1](manuals/{{page.version}}/index.html#5.4.1SecuringPuppetMasterRequests)
+When set to _true_, Foreman requires a client SSL certificate on requests from smart proxies or services on them (e.g. Puppet servers), and will verify the CN of the certificate against the known smart proxies. If false, it uses the reverse DNS of the IP address making the request. require_ssl in ```config/settings.yaml``` should be enabled too. For more information about securing the connection between Puppet servers or smart proxies and Foreman, see [Section 5.4.1](manuals/{{page.version}}/index.html#5.4.1SecuringPuppetMasterRequests)
 Default: true
 
 ##### restrict_registered_smart_proxies
 
-When set to _true_, services such as Puppet masters (or Salt, Chef) need to have a smart proxy registered with the appropriate feature (e.g. Puppet) to access fact/report importers and ENC output.
+When set to _true_, services such as Puppet servers (or Salt, Chef) need to have a smart proxy registered with the appropriate feature (e.g. Puppet) to access fact/report importers and ENC output.
 Default: true
 
 ##### root_pass
@@ -502,7 +502,7 @@ Default: 360 (6 hours)
 
 ##### trusted_hosts
 
-Other trusted hosts in addition to Smart Proxies allowed to access fact/report importers and ENC output. i.e: [puppetmaster1.yourdomain.com, puppetmaster2.yourdomain.com]
+Other trusted hosts in addition to Smart Proxies allowed to access fact/report importers and ENC output. i.e: [puppetserver1.yourdomain.com, puppetserver2.yourdomain.com]
 Default: []
 
 ##### unattended_url

--- a/_includes/manuals/nightly/3.5.4_puppet_reports.md
+++ b/_includes/manuals/nightly/3.5.4_puppet_reports.md
@@ -10,7 +10,7 @@ Ensure that the puppet clients has the following option in their puppet.conf:
 
 Without it, no reports will be sent.
 
-##### Puppet master
+##### Puppet server
 
 First identify the directory containing report processors, e.g.
 
@@ -24,7 +24,7 @@ Copy [the report processor source](https://raw.githubusercontent.com/theforeman/
 Create a new configuration file at `/etc/puppetlabs/puppet/foreman.yaml` (Puppet 4 AIO) or `/etc/puppet/foreman.yaml` (non-AIO) containing:
 <pre>
 ---
-# Update for your Foreman and Puppet master hostname(s)
+# Update for your Foreman and Puppet server hostname(s)
 :url: "https://foreman.example.com"
 :ssl_ca: "/etc/puppetlabs/puppet/ssl/certs/ca.pem"
 :ssl_cert: "/etc/puppetlabs/puppet/ssl/certs/puppet.example.com.pem"
@@ -38,13 +38,13 @@ Create a new configuration file at `/etc/puppetlabs/puppet/foreman.yaml` (Puppet
 :threads: null
 </pre>
 
-Edit the URL field to point to your Foreman instance, and the SSL fields for the hostname of the Puppet master (which may be the same host). Paths to Puppet's SSL certificates will be under /var/lib/puppet/ssl/ when using Puppet with non-AIO.
+Edit the URL field to point to your Foreman instance, and the SSL fields for the hostname of the Puppet server (which may be the same host). Paths to Puppet's SSL certificates will be under /var/lib/puppet/ssl/ when using Puppet with non-AIO.
 
-Lastly add this report processor to your Puppet master configuration.  In your master puppet.conf under the `[main]` section add:
+Lastly add this report processor to your Puppet server configuration.  In your server puppet.conf under the `[main]` section add:
 
 <pre>reports=log, foreman</pre>
 
-and restart your Puppet master.
+and restart your Puppet server.
 
 You should start seeing reports coming in under the reports link.
 

--- a/_includes/manuals/nightly/3.5.5_facts_and_the_enc.md
+++ b/_includes/manuals/nightly/3.5.5_facts_and_the_enc.md
@@ -1,11 +1,11 @@
 
-Foreman can act as a classifier to Puppet through the External Nodes interface. This is a mechanism provided by Puppet to ask for configuration data from an external service, via a script on the puppetmaster.
+Foreman can act as a classifier to Puppet through the External Nodes interface. This is a mechanism provided by Puppet to ask for configuration data from an external service, via a script on the puppet server.
 
 The external nodes script we supply also deals with uploading facts from hosts to Foreman, so we will discuss the two things together.
 
 #### Configuration
 
-##### Puppet master
+##### Puppet server
 
 Download [the ENC script](https://raw.githubusercontent.com/theforeman/puppet-foreman/master/files/external_node_v2.rb) to `/etc/puppetlabs/puppet/node.rb` (Puppet AIO) or `/etc/puppet/node.rb` (non-AIO). The name is arbitrary, but must match configuration below, and ensure it's executable by "puppet" with `chmod +x /etc/puppet/node.rb`.
 
@@ -13,7 +13,7 @@ Unless it already exists from setting up reporting, create a new configuration f
 
 <pre>
 ---
-# Update for your Foreman and Puppet master hostname(s)
+# Update for your Foreman and Puppet server hostname(s)
 :url: "https://foreman.example.com"
 :ssl_ca: "/etc/puppetlabs/puppet/ssl/certs/ca.pem"
 :ssl_cert: "/etc/puppetlabs/puppet/ssl/certs/puppet.example.com.pem"
@@ -27,7 +27,7 @@ Unless it already exists from setting up reporting, create a new configuration f
 :threads: null
 </pre>
 
-Edit the URL field to point to your Foreman instance, and the SSL fields for the hostname of the Puppet master (which may be the same host). Paths to Puppet's SSL certificates will be under /var/lib/puppet/ssl/ and puppetdir will be under /var/lib/puppet when using Puppet with non-AIO. More information on SSL certificates is at [Securing communications with SSL](/manuals/{{page.version}}/index.html#5.4SecuringCommunicationswithSSL).
+Edit the URL field to point to your Foreman instance, and the SSL fields for the hostname of the Puppet server (which may be the same host). Paths to Puppet's SSL certificates will be under /var/lib/puppet/ssl/ and puppetdir will be under /var/lib/puppet when using Puppet with non-AIO. More information on SSL certificates is at [Securing communications with SSL](/manuals/{{page.version}}/index.html#5.4SecuringCommunicationswithSSL).
 
 Add the following lines to the [master] section of puppet.conf:
 
@@ -37,7 +37,7 @@ Add the following lines to the [master] section of puppet.conf:
   node_terminus  = exec
 </pre>
 
-Restart the Puppet master. When the next agent checks in, the script will upload
+Restart the Puppet server. When the next agent checks in, the script will upload
 fact data for this host to Foreman, and download the ENC data.
 
 The `--no-environment` option can be optionally specified to stop the ENC from
@@ -108,7 +108,7 @@ for reporting/inventory only.
 ##### Using node.rb
 
 The ENC script (node.rb) accepts an option to run in 'batch-mode'. In this mode,
-the script iterates over the cached fact data stored on the puppet master, and uploads
+the script iterates over the cached fact data stored on the puppet server, and uploads
 all of it to Foreman.
 
 Download and configure the node.rb script as above, and then call it like this:

--- a/_includes/manuals/nightly/3.5.5_facts_and_the_enc.md
+++ b/_includes/manuals/nightly/3.5.5_facts_and_the_enc.md
@@ -1,5 +1,5 @@
 
-Foreman can act as a classifier to Puppet through the External Nodes interface. This is a mechanism provided by Puppet to ask for configuration data from an external service, via a script on the puppet server.
+Foreman can act as a classifier to Puppet through the External Nodes interface. This is a mechanism provided by Puppet to ask for configuration data from an external service, via a script on the Puppet server.
 
 The external nodes script we supply also deals with uploading facts from hosts to Foreman, so we will discuss the two things together.
 
@@ -108,7 +108,7 @@ for reporting/inventory only.
 ##### Using node.rb
 
 The ENC script (node.rb) accepts an option to run in 'batch-mode'. In this mode,
-the script iterates over the cached fact data stored on the puppet server, and uploads
+the script iterates over the cached fact data stored on the Puppet server, and uploads
 all of it to Foreman.
 
 Download and configure the node.rb script as above, and then call it like this:

--- a/_includes/manuals/nightly/4.2.1_puppet_envs.md
+++ b/_includes/manuals/nightly/4.2.1_puppet_envs.md
@@ -7,15 +7,15 @@ There are several ways to create Puppet environments within Foreman.
 
 ##### Importing from Puppet
 
-Foreman can detect all the environments and classes contained on a Puppet master, and import them automatically. To do this, go to *Configure > Environments* and click on *Import from &lt;proxy-name&gt;*. Foreman will scan the Puppet master via the Smart Proxy, and display a confirmation of the detected changes. Select the changes you wish to apply and confirm.
+Foreman can detect all the environments and classes contained on a Puppet server, and import them automatically. To do this, go to *Configure > Environments* and click on *Import from &lt;proxy-name&gt;*. Foreman will scan the Puppet server via the Smart Proxy, and display a confirmation of the detected changes. Select the changes you wish to apply and confirm.
 
 More information about configuring the Smart Proxy to read environments and Puppet classes is in the [Smart Proxy Puppet](/manuals/{{page.version}}/index.html#4.3.6Puppet) section.
 
-Note that the Smart Proxy will only detect environments that contain one or more Puppet classes, so ensure that at least one Puppet module containing a class has been deployed to the Puppet master.
+Note that the Smart Proxy will only detect environments that contain one or more Puppet classes, so ensure that at least one Puppet module containing a class has been deployed to the Puppet server.
 
 ##### Manual creation
 
-To create an environment by hand, simply go to *Configure > Environments* and click *New Puppet Environment*. Give the new environment a name and save.  Note that if the environment doesn't exist on the Puppet master and you subsequently run an import (above), Foreman will prompt for the environment to be deleted.
+To create an environment by hand, simply go to *Configure > Environments* and click *New Puppet Environment*. Give the new environment a name and save.  Note that if the environment doesn't exist on the Puppet server and you subsequently run an import (above), Foreman will prompt for the environment to be deleted.
 
 #### Assigning environments to hosts
 

--- a/_includes/manuals/nightly/4.2.2_puppet_classes.md
+++ b/_includes/manuals/nightly/4.2.2_puppet_classes.md
@@ -1,11 +1,11 @@
 
-Puppet classes are generally imported from the Puppet Master(s) via the Import
+Puppet classes are generally imported from the Puppet server(s) via the Import
 button on the Puppet Classes page. They can also be created by hand, and
 manually associated with a set of environments (for filtering purposes).
 
 #### Importing Classes
 
-Go to *Configure > Classes* and click the Import button. This will not be visible unless you have at least one Puppet Master with a puppet-enabled Smart Proxy. Only classes from modules will be imported, and the Puppet manifests *must* be valid in order for the Smart Proxy to parse them.  Use `puppet parser validate` to test the syntax of Puppet manifests.
+Go to *Configure > Classes* and click the Import button. This will not be visible unless you have at least one Puppet server with a puppet-enabled Smart Proxy. Only classes from modules will be imported, and the Puppet manifests *must* be valid in order for the Smart Proxy to parse them.  Use `puppet parser validate` to test the syntax of Puppet manifests.
 
 More information about configuring the Smart Proxy to read environments and Puppet classes is in the [Smart Proxy Puppet](/manuals/{{page.version}}/index.html#4.3.7Puppet) section.
 
@@ -127,4 +127,4 @@ attribute.
 
 ##### Checking the results
 
-To see how Foreman is passing the classes to Puppet, go to a Host and click the YAML button. You will be shown the exact YAML data sent to the Puppet master - the classes will be in the "classes" hash.
+To see how Foreman is passing the classes to Puppet, go to a Host and click the YAML button. You will be shown the exact YAML data sent to the Puppet server - the classes will be in the "classes" hash.

--- a/_includes/manuals/nightly/4.2.3_puppet_params.md
+++ b/_includes/manuals/nightly/4.2.3_puppet_params.md
@@ -58,4 +58,4 @@ Global parameters support multiple data types and validation as per type selecte
 
 #### Checking the results
 
-To see how Foreman is passing the parameters to Puppet, go to a Host and click the YAML button. You will be shown the exact YAML data sent to the Puppet master - the parameters will be in the "parameters" hash.
+To see how Foreman is passing the parameters to Puppet, go to a Host and click the YAML button. You will be shown the exact YAML data sent to the Puppet server - the parameters will be in the "parameters" hash.

--- a/_includes/manuals/nightly/4.2.4_param_classes.md
+++ b/_includes/manuals/nightly/4.2.4_param_classes.md
@@ -7,7 +7,7 @@ By default, parameterized class support is enabled in Foreman.  This can be chec
 
 ![Settings](/static/images/screenshots/param_classes/settings.png)
 
-Now you'll need to import some parameterized classes from your Puppet master.
+Now you'll need to import some parameterized classes from your Puppet server.
 If you don't have any parameterized classes in your modules dir, the
 foreman-installer has several, you can download a few modules from the Puppet
 Forge. Once you have some parameterized modules, import your classes (see

--- a/_includes/manuals/nightly/4.3.10_smartproxy_ssl.md
+++ b/_includes/manuals/nightly/4.3.10_smartproxy_ssl.md
@@ -54,8 +54,8 @@ Certain users may require to disable certain cipher suites due to security polic
 
 To generate a certificate for a proxy host that isn't managed by Puppet, do the following:
 
-1. Generate a new certificate on your puppetmaster: `puppet cert --generate <proxy-FQDN>`
-2. Copy the certificates and key from the puppetmaster to the smart proxy in `/etc/foreman-proxy`:
+1. Generate a new certificate on your puppetserver: `puppet cert --generate <proxy-FQDN>`
+2. Copy the certificates and key from the puppetserver to the smart proxy in `/etc/foreman-proxy`:
   - /etc/puppetlabs/puppet/ssl/certs/ca.pem
   - /etc/puppetlabs/puppet/ssl/certs/proxy-FQDN.pem
   - /etc/puppetlabs/puppet/ssl/private_keys/proxy-FQDN.pem

--- a/_includes/manuals/nightly/4.3.1_smartproxy_installation.md
+++ b/_includes/manuals/nightly/4.3.1_smartproxy_installation.md
@@ -39,12 +39,12 @@ The Microsoft smart-proxy installation procedure is very basic compared to the R
 
 ##### General configuration
 1. Create the SSL certificate and key
-    1. Login to your puppetmaster
+    1. Login to your puppetserver
     1. On the command line, type the following command. Take care not to use an alias nor upper case characters.
 
            puppet cert generate new-smart-proxy-FQDN
 
-    1. Copy the private key, the public certificate and the ca.pem from /var/lib/puppet/ssl on your puppetmaster over to a location accessible by your new smart proxy, e.g. `<smart-proxy location>\ssl\` (create the directory if necessary - this location will be referred to by the settings.yml in the next step)
+    1. Copy the private key, the public certificate and the ca.pem from /var/lib/puppet/ssl on your puppetserver over to a location accessible by your new smart proxy, e.g. `<smart-proxy location>\ssl\` (create the directory if necessary - this location will be referred to by the settings.yml in the next step)
 1. Copy *settings.yml.example* inside *config* to *settings.yml*
 1. At very least, modify the settings for `:bind_host:` and `:log_file:` and SSL, for example:
 

--- a/_includes/manuals/nightly/4.3.6_smartproxy_puppet.md
+++ b/_includes/manuals/nightly/4.3.6_smartproxy_puppet.md
@@ -18,7 +18,7 @@ To enable this module, make sure these lines are present in `/etc/foreman-proxy/
 To get a list of environments, classes and their parameters, the proxy queries the Puppetserver on its own API. The URL and settings used for the proxy to Puppetserver API query can be controlled with the following settings in `/etc/foreman-proxy/settings.d/puppet_proxy_puppet_api.yml`:
 
 ```yaml
-# URL of the puppet server itself for API requests
+# URL of the Puppet server itself for API requests
 #:puppet_url: https://puppet.example.com:8140
 #
 # SSL certificates used to access the puppet API

--- a/_includes/manuals/nightly/4.3.6_smartproxy_puppet.md
+++ b/_includes/manuals/nightly/4.3.6_smartproxy_puppet.md
@@ -18,7 +18,7 @@ To enable this module, make sure these lines are present in `/etc/foreman-proxy/
 To get a list of environments, classes and their parameters, the proxy queries the Puppetserver on its own API. The URL and settings used for the proxy to Puppetserver API query can be controlled with the following settings in `/etc/foreman-proxy/settings.d/puppet_proxy_puppet_api.yml`:
 
 ```yaml
-# URL of the puppet master itself for API requests
+# URL of the puppet server itself for API requests
 #:puppet_url: https://puppet.example.com:8140
 #
 # SSL certificates used to access the puppet API

--- a/_includes/manuals/nightly/4.3.7_smartproxy_puppetca.md
+++ b/_includes/manuals/nightly/4.3.7_smartproxy_puppetca.md
@@ -66,7 +66,7 @@ You can also change the certificate used for encrypting the token file by settin
 To integrate this in Puppet the script `puppet_sign.rb` provided by the Smart Proxy has to be used for verfication of the tokens during certificate signing.
 If installed via package the script should be already located at `/usr/libexec/foreman-proxy/puppet_sign.rb`.
 For manual installation the script can be found on [Github](https://github.com/theforeman/smart-proxy/blob/develop/extra/puppet_sign.rb). Using the latest version should be fine, if you encounter problems try the one released with your Smart Proxy version.
-The script has to be executable by the same user running the Puppet master, typically puppet.
+The script has to be executable by the same user running the Puppet server, typically puppet.
 
 After deploying the script the Puppet configuration has to be changed to point the **autosign** setting to the script.
 

--- a/_includes/manuals/nightly/5.4.1_comms_puppetserver.md
+++ b/_includes/manuals/nightly/5.4.1_comms_puppetserver.md
@@ -1,19 +1,19 @@
 
-In a typical ENC-based setup with reporting, puppet servers require access to Foreman for three tasks:
+In a typical ENC-based setup with reporting, Puppet servers require access to Foreman for three tasks:
 
 1. Retrieval of external nodes information (classes, parameters)
 2. Uploading of host facts
 3. Uploading of host reports
 
-All traffic here is initiated by the puppet server itself.  Other traffic from Foreman to the puppet server for certificate signing etc. is handled via smart proxies (SSL configuration covered in the next section).
+All traffic here is initiated by the Puppet server itself.  Other traffic from Foreman to the Puppet server for certificate signing etc. is handled via smart proxies (SSL configuration covered in the next section).
 
 #### Configuration options
 
-The Foreman interface authorizes access to puppet server interfaces based on its list of registered smart proxies with the *Puppet* feature, and identifies hosts using client SSL certificates.
+The Foreman interface authorizes access to Puppet server interfaces based on its list of registered smart proxies with the *Puppet* feature, and identifies hosts using client SSL certificates.
 
 Five main settings control the authentication, the first are in Foreman under *Settings*, *Authentication*:
 
-* *require_ssl_smart_proxies* (default: true), requires a client SSL certificate on the puppet server requests, and will verify the CN of the certificate against the smart proxies.  If false, it uses the reverse DNS of the IP address making the request.
+* *require_ssl_smart_proxies* (default: true), requires a client SSL certificate on the Puppet server requests, and will verify the CN of the certificate against the smart proxies.  If false, it uses the reverse DNS of the IP address making the request.
 * *restrict_registered_smart_proxies* (default: true), only permits access to hosts that have a registered smart proxy with the *Puppet* feature.
 * *trusted_hosts*, a whitelist of hosts that overrides the check for a registered smart proxy
 
@@ -33,8 +33,8 @@ Using Apache HTTP with mod_ssl and mod_passenger is recommended.  For simple set
   <li>*SSLOptions +StdEnvVars +ExportCertData*</li></ol>
 3. Puppet ENC/report processor configuration (e.g. `/etc/puppetlabs/puppet/foreman.yaml` or `/etc/puppet/foreman.yaml`) should have these settings:
   <ol><li>*:ssl_ca* set to the Puppet CA</li>
-  <li>*:ssl_cert* set to the puppet server's certificate</li>
-  <li>*:ssl_key* set to the puppet server's private key</li></ol>
+  <li>*:ssl_cert* set to the Puppet server's certificate</li>
+  <li>*:ssl_key* set to the Puppet server's private key</li></ol>
 
 ##### Troubleshooting
 
@@ -47,10 +47,10 @@ Warning messages will be printed to Foreman's log file (typically `/var/log/fore
 
 ##### Advanced SSL notes
 
-A typical small setup will use a single Puppet CA and certificates it provides for the Foreman host and puppet server hosts.  In larger setups with multiple CAs or an internal CA, this will require more careful configuration to ensure all hosts can trust each other.
+A typical small setup will use a single Puppet CA and certificates it provides for the Foreman host and Puppet server hosts.  In larger setups with multiple CAs or an internal CA, this will require more careful configuration to ensure all hosts can trust each other.
 
-* Ensure the Common Name (CN) is present in certificates used by Foreman (as clients will validate it) and puppet server clients (used to verify against smart proxies).
-* Foreman's SSL terminator must be able to validate puppet server client SSL certificates.  In Apache with mod_ssl, the *SSLCACertificateFile* option must point to the CA used to validate clients and *SSLVerifyClient* set to _optional_.
+* Ensure the Common Name (CN) is present in certificates used by Foreman (as clients will validate it) and Puppet server clients (used to verify against smart proxies).
+* Foreman's SSL terminator must be able to validate Puppet server client SSL certificates.  In Apache with mod_ssl, the *SSLCACertificateFile* option must point to the CA used to validate clients and *SSLVerifyClient* set to _optional_.
 * Environment variables from the SSL terminator are used to get the client certificate and verification status.  mod_ssl's *SSLOptions +StdEnvVars +ExportCertData* setting enables this.  Variable names are defined by *ssl_client_cert_env*, *ssl_client_dn_env* and *ssl_client_verify_env* settings in Foreman.
 
 #### Reduced security: HTTP host-based authentication

--- a/_includes/manuals/nightly/5.4.1_comms_puppetserver.md
+++ b/_includes/manuals/nightly/5.4.1_comms_puppetserver.md
@@ -1,19 +1,19 @@
 
-In a typical ENC-based setup with reporting, puppet masters require access to Foreman for three tasks:
+In a typical ENC-based setup with reporting, puppet servers require access to Foreman for three tasks:
 
 1. Retrieval of external nodes information (classes, parameters)
 2. Uploading of host facts
 3. Uploading of host reports
 
-All traffic here is initiated by the puppet master itself.  Other traffic from Foreman to the puppet master for certificate signing etc. is handled via smart proxies (SSL configuration covered in the next section).
+All traffic here is initiated by the puppet server itself.  Other traffic from Foreman to the puppet server for certificate signing etc. is handled via smart proxies (SSL configuration covered in the next section).
 
 #### Configuration options
 
-The Foreman interface authorizes access to puppet master interfaces based on its list of registered smart proxies with the *Puppet* feature, and identifies hosts using client SSL certificates.
+The Foreman interface authorizes access to puppet server interfaces based on its list of registered smart proxies with the *Puppet* feature, and identifies hosts using client SSL certificates.
 
 Five main settings control the authentication, the first are in Foreman under *Settings*, *Authentication*:
 
-* *require_ssl_smart_proxies* (default: true), requires a client SSL certificate on the puppet master requests, and will verify the CN of the certificate against the smart proxies.  If false, it uses the reverse DNS of the IP address making the request.
+* *require_ssl_smart_proxies* (default: true), requires a client SSL certificate on the puppet server requests, and will verify the CN of the certificate against the smart proxies.  If false, it uses the reverse DNS of the IP address making the request.
 * *restrict_registered_smart_proxies* (default: true), only permits access to hosts that have a registered smart proxy with the *Puppet* feature.
 * *trusted_hosts*, a whitelist of hosts that overrides the check for a registered smart proxy
 
@@ -33,8 +33,8 @@ Using Apache HTTP with mod_ssl and mod_passenger is recommended.  For simple set
   <li>*SSLOptions +StdEnvVars +ExportCertData*</li></ol>
 3. Puppet ENC/report processor configuration (e.g. `/etc/puppetlabs/puppet/foreman.yaml` or `/etc/puppet/foreman.yaml`) should have these settings:
   <ol><li>*:ssl_ca* set to the Puppet CA</li>
-  <li>*:ssl_cert* set to the puppet master's certificate</li>
-  <li>*:ssl_key* set to the puppet master's private key</li></ol>
+  <li>*:ssl_cert* set to the puppet server's certificate</li>
+  <li>*:ssl_key* set to the puppet server's private key</li></ol>
 
 ##### Troubleshooting
 
@@ -47,10 +47,10 @@ Warning messages will be printed to Foreman's log file (typically `/var/log/fore
 
 ##### Advanced SSL notes
 
-A typical small setup will use a single Puppet CA and certificates it provides for the Foreman host and puppet master hosts.  In larger setups with multiple CAs or an internal CA, this will require more careful configuration to ensure all hosts can trust each other.
+A typical small setup will use a single Puppet CA and certificates it provides for the Foreman host and puppet server hosts.  In larger setups with multiple CAs or an internal CA, this will require more careful configuration to ensure all hosts can trust each other.
 
-* Ensure the Common Name (CN) is present in certificates used by Foreman (as clients will validate it) and puppet master clients (used to verify against smart proxies).
-* Foreman's SSL terminator must be able to validate puppet master client SSL certificates.  In Apache with mod_ssl, the *SSLCACertificateFile* option must point to the CA used to validate clients and *SSLVerifyClient* set to _optional_.
+* Ensure the Common Name (CN) is present in certificates used by Foreman (as clients will validate it) and puppet server clients (used to verify against smart proxies).
+* Foreman's SSL terminator must be able to validate puppet server client SSL certificates.  In Apache with mod_ssl, the *SSLCACertificateFile* option must point to the CA used to validate clients and *SSLVerifyClient* set to _optional_.
 * Environment variables from the SSL terminator are used to get the client certificate and verification status.  mod_ssl's *SSLOptions +StdEnvVars +ExportCertData* setting enables this.  Variable names are defined by *ssl_client_cert_env*, *ssl_client_dn_env* and *ssl_client_verify_env* settings in Foreman.
 
 #### Reduced security: HTTP host-based authentication

--- a/_includes/manuals/nightly/5.4_communications.md
+++ b/_includes/manuals/nightly/5.4_communications.md
@@ -1,2 +1,2 @@
 
-The Foreman web application needs to communicate securely with associated smart proxies and puppet masters, plus users and applications connecting to the web interface.  This section details recommended SSL configurations.
+The Foreman web application needs to communicate securely with associated smart proxies and puppet servers, plus users and applications connecting to the web interface.  This section details recommended SSL configurations.

--- a/_includes/manuals/nightly/5.4_communications.md
+++ b/_includes/manuals/nightly/5.4_communications.md
@@ -1,2 +1,2 @@
 
-The Foreman web application needs to communicate securely with associated smart proxies and puppet servers, plus users and applications connecting to the web interface.  This section details recommended SSL configurations.
+The Foreman web application needs to communicate securely with associated smart proxies and Puppet servers, plus users and applications connecting to the web interface.  This section details recommended SSL configurations.

--- a/_includes/manuals/nightly/5.5.1_backup.md
+++ b/_includes/manuals/nightly/5.5.1_backup.md
@@ -19,7 +19,7 @@ For all other distribution do similar command:
 
 #### Puppet server
 
-On the puppet server node, issue the following command to backup Puppet
+On the Puppet server node, issue the following command to backup Puppet
 certificates on Red Hat compatible systems
 
     tar --selinux -czvf var_lib_puppet_dir.tar.gz /etc/puppetlabs/puppet/ssl

--- a/_includes/manuals/nightly/5.5.1_backup.md
+++ b/_includes/manuals/nightly/5.5.1_backup.md
@@ -17,9 +17,9 @@ For all other distribution do similar command:
 
     tar -czvf etc_foreman_dir.tar.gz /etc/foreman
 
-#### Puppet master
+#### Puppet server
 
-On the puppet master node, issue the following command to backup Puppet
+On the puppet server node, issue the following command to backup Puppet
 certificates on Red Hat compatible systems
 
     tar --selinux -czvf var_lib_puppet_dir.tar.gz /etc/puppetlabs/puppet/ssl

--- a/_includes/manuals/nightly/5.5.2_recovery.md
+++ b/_includes/manuals/nightly/5.5.2_recovery.md
@@ -33,7 +33,7 @@ directory).
 
 #### Puppet server
 
-On the puppet server node, issue the following command to restore Puppet
+On the Puppet server node, issue the following command to restore Puppet
 certificates on Red Hat compatible systems
 
     tar --selinux -xzvf var_lib_puppet_dir.tar.gz -C /

--- a/_includes/manuals/nightly/5.5.2_recovery.md
+++ b/_includes/manuals/nightly/5.5.2_recovery.md
@@ -31,9 +31,9 @@ It is recommended to extract files to an empty directory first and inspect the
 content before overwriting current files (change -C option to an empty
 directory).
 
-#### Puppet master
+#### Puppet server
 
-On the puppet master node, issue the following command to restore Puppet
+On the puppet server node, issue the following command to restore Puppet
 certificates on Red Hat compatible systems
 
     tar --selinux -xzvf var_lib_puppet_dir.tar.gz -C /
@@ -71,4 +71,4 @@ However if the FQDN does change, check and update the following items:
     * `settings.d/puppet_proxy_puppet_api.yml` - update SSL cert/key filenames
     * `settings.d/realm.yml` - update `realm_principal` if the principal name has changed
     * `settings.d/templates.yml` - update `template_url` for URL of the Foreman web API
-* Puppet masters: URLs and cert/key filenames in `/etc/puppetlabs/puppet/foreman.yaml` or `/etc/puppet/foreman.yaml`
+* Puppet servers: URLs and cert/key filenames in `/etc/puppetlabs/puppet/foreman.yaml` or `/etc/puppet/foreman.yaml`

--- a/manuals/nightly/index.md
+++ b/manuals/nightly/index.md
@@ -274,8 +274,8 @@ previous_version: "2.2"
 
 ## 5.4 Securing Communications with SSL
 {%include manuals/{{ page.version }}/5.4_communications.md %}
-### 5.4.1 Securing Puppet Master Requests
-{%include manuals/{{ page.version }}/5.4.1_comms_puppetmaster.md %}
+### 5.4.1 Securing Puppet Server Requests
+{%include manuals/{{ page.version }}/5.4.1_comms_puppetserver.md %}
 ### 5.4.2 Securing Smart Proxy Requests
 {%include manuals/{{ page.version }}/5.4.2_comms_proxy.md %}
 ## 5.5 Backup, Recovery and Migration


### PR DESCRIPTION
Puppet has been using Puppet server since at least Puppet 4, though we
still have a lot of references to Puppet master in the manual. This is
an attempt at clearing this up and being consistent across all pages.