### PR TITLE
Update RHEL installation docs

### DIFF
--- a/_includes/manuals/2.0/2.1_quickstart_installation.md
+++ b/_includes/manuals/2.0/2.1_quickstart_installation.md
@@ -46,8 +46,6 @@ sudo yum-config-manager --enable rhel-7-server-optional-rpms rhel-server-rhscl-7
   <p>
     Check the repositories are enabled with <code>yum repolist</code> after running the above command, as it can silently fail when subscription does not provide those.
   </p>
-
-  <p>If you're using RH Satellite 5, you should instead sync and enable the channel there.</p>
 </div>
 
 <div class="quickstart_os quickstart_os_rhel7 quickstart_os_el7">

--- a/_includes/manuals/2.0/3.1.1_supported_platforms.md
+++ b/_includes/manuals/2.0/3.1.1_supported_platforms.md
@@ -3,8 +3,8 @@ The following operating systems are supported by the installer, have packages an
 * Red Hat Enterprise Linux 7
   * Architectures: x86_64 only
   * [EPEL](https://fedoraproject.org/wiki/EPEL/FAQ#How_can_I_install_the_packages_from_the_EPEL_software_repository.3F) is required
-  * Enable the Optional repository/channel:
-    * `yum-config-manager --enable rhel-7-server-optional-rpms`
+  * Enable the Optional and RHSCL repositories/channels:
+    * `yum-config-manager --enable rhel-7-server-optional-rpms rhel-server-rhscl-7-rpms`
     * check the above repositories because the command can silently fail when subscription does not provide it: `yum repolist`
   * Apply all SELinux-related errata.
 * CentOS, Scientific Linux or Oracle Linux 7

--- a/_includes/manuals/2.1/2.1_quickstart_installation.md
+++ b/_includes/manuals/2.1/2.1_quickstart_installation.md
@@ -47,8 +47,6 @@ sudo yum-config-manager --enable rhel-7-server-optional-rpms rhel-server-rhscl-7
   <p>
     Check the repositories are enabled with <code>yum repolist</code> after running the above command, as it can silently fail when subscription does not provide those.
   </p>
-
-  <p>If you're using RH Satellite 5, you should instead sync and enable the channel there.</p>
 </div>
 
 <div class="quickstart_os quickstart_os_rhel7 quickstart_os_el7">

--- a/_includes/manuals/2.1/3.1.1_supported_platforms.md
+++ b/_includes/manuals/2.1/3.1.1_supported_platforms.md
@@ -3,8 +3,8 @@ The following operating systems are supported by the installer, have packages an
 * Red Hat Enterprise Linux 7
   * Architectures: x86_64 only
   * [EPEL](https://fedoraproject.org/wiki/EPEL/FAQ#How_can_I_install_the_packages_from_the_EPEL_software_repository.3F) is required
-  * Enable the Optional repository/channel:
-    * `yum-config-manager --enable rhel-7-server-optional-rpms`
+  * Enable the Optional and RHSCL repositories/channels:
+    * `yum-config-manager --enable rhel-7-server-optional-rpms rhel-server-rhscl-7-rpms`
     * check the above repositories because the command can silently fail when subscription does not provide it: `yum repolist`
   * Apply all SELinux-related errata.
 * Red Hat Enterprise Linux 8

--- a/_includes/manuals/2.2/2.1_quickstart_installation.md
+++ b/_includes/manuals/2.2/2.1_quickstart_installation.md
@@ -49,8 +49,6 @@ sudo yum-config-manager --enable rhel-7-server-optional-rpms rhel-server-rhscl-7
   <p>
     Check the repositories are enabled with <code>yum repolist</code> after running the above command, as it can silently fail when subscription does not provide those.
   </p>
-
-  <p>If you're using RH Satellite 5, you should instead sync and enable the channel there.</p>
 </div>
 
 <div class="quickstart_os quickstart_os_rhel7 quickstart_os_other_el7 quickstart_os_centos7">

--- a/_includes/manuals/2.2/3.1.1_supported_platforms.md
+++ b/_includes/manuals/2.2/3.1.1_supported_platforms.md
@@ -3,8 +3,8 @@ The following operating systems are supported by the installer, have packages an
 * Red Hat Enterprise Linux 7
   * Architectures: x86_64 only
   * [EPEL](https://fedoraproject.org/wiki/EPEL/FAQ#How_can_I_install_the_packages_from_the_EPEL_software_repository.3F) is required
-  * Enable the Optional repository/channel:
-    * `yum-config-manager --enable rhel-7-server-optional-rpms`
+  * Enable the Optional and RHSCL repositories/channels:
+    * `yum-config-manager --enable rhel-7-server-optional-rpms rhel-server-rhscl-7-rpms`
     * check the above repositories because the command can silently fail when subscription does not provide it: `yum repolist`
   * Apply all SELinux-related errata.
 * Red Hat Enterprise Linux 8

--- a/_includes/manuals/nightly/2.1_quickstart_installation.md
+++ b/_includes/manuals/nightly/2.1_quickstart_installation.md
@@ -49,8 +49,6 @@ sudo yum-config-manager --enable rhel-7-server-optional-rpms rhel-server-rhscl-7
   <p>
     Check the repositories are enabled with <code>yum repolist</code> after running the above command, as it can silently fail when subscription does not provide those.
   </p>
-
-  <p>If you're using RH Satellite 5, you should instead sync and enable the channel there.</p>
 </div>
 
 <div class="quickstart_os quickstart_os_rhel7 quickstart_os_other_el7 quickstart_os_centos7">

--- a/_includes/manuals/nightly/3.1.1_supported_platforms.md
+++ b/_includes/manuals/nightly/3.1.1_supported_platforms.md
@@ -3,8 +3,8 @@ The following operating systems are supported by the installer, have packages an
 * Red Hat Enterprise Linux 7
   * Architectures: x86_64 only
   * [EPEL](https://fedoraproject.org/wiki/EPEL/FAQ#How_can_I_install_the_packages_from_the_EPEL_software_repository.3F) is required
-  * Enable the Optional repository/channel:
-    * `yum-config-manager --enable rhel-7-server-optional-rpms`
+  * Enable the Optional and RHSCL repositories/channels:
+    * `yum-config-manager --enable rhel-7-server-optional-rpms rhel-server-rhscl-7-rpms`
     * check the above repositories because the command can silently fail when subscription does not provide it: `yum repolist`
   * Apply all SELinux-related errata.
 * Red Hat Enterprise Linux 8


### PR DESCRIPTION
511397791 Mention the requirement to enable RHSCL for RHEL. This is already part of the quickstart but not the real installation section.
e90f34d1b Drop mention of RH Satellite 5. This is EOL and should no longer be used.