### PR TITLE
Fixes #31386 - Add an upgrade warning for TLS 1.2+

### DIFF
--- a/_includes/manuals/nightly/1.2_release_notes.md
+++ b/_includes/manuals/nightly/1.2_release_notes.md
@@ -10,6 +10,14 @@ This section will be updated prior to the next release.
 
 ### Upgrade warnings
 
+#### TLS 1.2+ by default
+
+The installer will configure all services to drop TLS 1.0 and 1.1 support. Back in Foreman 2.1 all internal services (Smart Proxy and friends) dropped TLS 1.0 and 1.1. Now the remaining parts are updated, which effectively is only Apache. This means clients need to support TLS 1.2.
+
+Users who have client systems that don't support TLS 1.2 should update those. RHEL 6.8 added support via [RHBA-2016:0915](https://access.redhat.com/errata/RHBA-2016:0915) back in 2016. Note that CentOS 6 is already End of Life. If you are on a supported release, it's very unlikely that this affects you. Also note that some older enterprise HTTP proxies or firewalls are known to cause problems.
+
+EL5 does [not support TLS 1.2](https://access.redhat.com/articles/1294573) but is EOL.
+
 ### Contributors
 
 We'd like to thank the following people who contributed to the Foreman {{page.version}} release:


### PR DESCRIPTION
Should only be merged once https://projects.theforeman.org/issues/31387 is closed.