### PR TITLE
Update Katello 3.16 notes for the 3.16.2 release

### DIFF
--- a/plugins/katello/3.16/api/apidoc.en.html
+++ b/plugins/katello/3.16/api/apidoc.en.html
@@ -2812,13 +2812,13 @@
     <tbody>
           <tr>
             <td>
-              <a href='./apidoc/v2/host_tracer/index.en.html'>GET /katello/api/hosts/:host_id/traces</a>
+              <a href='./apidoc/v2/host_tracer/index.en.html'>GET /api/hosts/:host_id/traces</a>
             </td>
             <td width='60%'>List services that need restarting on the host</td>
           </tr>
           <tr>
             <td>
-              <a href='./apidoc/v2/host_tracer/resolve.en.html'>PUT /katello/api/traces/resolve</a>
+              <a href='./apidoc/v2/host_tracer/resolve.en.html'>PUT /api/hosts/:host_id/traces/resolve</a>
             </td>
             <td width='60%'>Resolve Traces</td>
           </tr>
@@ -3183,6 +3183,12 @@
               <a href='./apidoc/v2/hosts_bulk_actions/traces.en.html'>POST /api/hosts/bulk/traces</a>
             </td>
             <td width='60%'>Fetch traces for one or more hosts</td>
+          </tr>
+          <tr>
+            <td>
+              <a href='./apidoc/v2/hosts_bulk_actions/resolve_traces.en.html'>PUT /api/hosts/bulk/resolve_traces</a>
+            </td>
+            <td width='60%'>Resolve traces for one or more hosts</td>
           </tr>
           <tr>
             <td>

--- a/plugins/katello/3.16/api/apidoc.html
+++ b/plugins/katello/3.16/api/apidoc.html
@@ -2812,13 +2812,13 @@
     <tbody>
           <tr>
             <td>
-              <a href='./apidoc/v2/host_tracer/index.html'>GET /katello/api/hosts/:host_id/traces</a>
+              <a href='./apidoc/v2/host_tracer/index.html'>GET /api/hosts/:host_id/traces</a>
             </td>
             <td width='60%'>List services that need restarting on the host</td>
           </tr>
           <tr>
             <td>
-              <a href='./apidoc/v2/host_tracer/resolve.html'>PUT /katello/api/traces/resolve</a>
+              <a href='./apidoc/v2/host_tracer/resolve.html'>PUT /api/hosts/:host_id/traces/resolve</a>
             </td>
             <td width='60%'>Resolve Traces</td>
           </tr>
@@ -3183,6 +3183,12 @@
               <a href='./apidoc/v2/hosts_bulk_actions/traces.html'>POST /api/hosts/bulk/traces</a>
             </td>
             <td width='60%'>Fetch traces for one or more hosts</td>
+          </tr>
+          <tr>
+            <td>
+              <a href='./apidoc/v2/hosts_bulk_actions/resolve_traces.html'>PUT /api/hosts/bulk/resolve_traces</a>
+            </td>
+            <td width='60%'>Resolve traces for one or more hosts</td>
           </tr>
           <tr>
             <td>

--- a/plugins/katello/3.16/api/apidoc/v2.en.html
+++ b/plugins/katello/3.16/api/apidoc/v2.en.html
@@ -2812,13 +2812,13 @@
     <tbody>
           <tr>
             <td>
-              <a href='../apidoc/v2/host_tracer/index.en.html'>GET /katello/api/hosts/:host_id/traces</a>
+              <a href='../apidoc/v2/host_tracer/index.en.html'>GET /api/hosts/:host_id/traces</a>
             </td>
             <td width='60%'>List services that need restarting on the host</td>
           </tr>
           <tr>
             <td>
-              <a href='../apidoc/v2/host_tracer/resolve.en.html'>PUT /katello/api/traces/resolve</a>
+              <a href='../apidoc/v2/host_tracer/resolve.en.html'>PUT /api/hosts/:host_id/traces/resolve</a>
             </td>
             <td width='60%'>Resolve Traces</td>
           </tr>
@@ -3183,6 +3183,12 @@
               <a href='../apidoc/v2/hosts_bulk_actions/traces.en.html'>POST /api/hosts/bulk/traces</a>
             </td>
             <td width='60%'>Fetch traces for one or more hosts</td>
+          </tr>
+          <tr>
+            <td>
+              <a href='../apidoc/v2/hosts_bulk_actions/resolve_traces.en.html'>PUT /api/hosts/bulk/resolve_traces</a>
+            </td>
+            <td width='60%'>Resolve traces for one or more hosts</td>
           </tr>
           <tr>
             <td>

--- a/plugins/katello/3.16/api/apidoc/v2.html
+++ b/plugins/katello/3.16/api/apidoc/v2.html
@@ -2812,13 +2812,13 @@
     <tbody>
           <tr>
             <td>
-              <a href='../apidoc/v2/host_tracer/index.html'>GET /katello/api/hosts/:host_id/traces</a>
+              <a href='../apidoc/v2/host_tracer/index.html'>GET /api/hosts/:host_id/traces</a>
             </td>
             <td width='60%'>List services that need restarting on the host</td>
           </tr>
           <tr>
             <td>
-              <a href='../apidoc/v2/host_tracer/resolve.html'>PUT /katello/api/traces/resolve</a>
+              <a href='../apidoc/v2/host_tracer/resolve.html'>PUT /api/hosts/:host_id/traces/resolve</a>
             </td>
             <td width='60%'>Resolve Traces</td>
           </tr>
@@ -3183,6 +3183,12 @@
               <a href='../apidoc/v2/hosts_bulk_actions/traces.html'>POST /api/hosts/bulk/traces</a>
             </td>
             <td width='60%'>Fetch traces for one or more hosts</td>
+          </tr>
+          <tr>
+            <td>
+              <a href='../apidoc/v2/hosts_bulk_actions/resolve_traces.html'>PUT /api/hosts/bulk/resolve_traces</a>
+            </td>
+            <td width='60%'>Resolve traces for one or more hosts</td>
           </tr>
           <tr>
             <td>

--- a/plugins/katello/3.16/api/apidoc/v2/content_uploads.en.html
+++ b/plugins/katello/3.16/api/apidoc/v2/content_uploads.en.html
@@ -164,7 +164,7 @@
         <p><strong>Validations:</strong></p>
         <ul>
             <li>
-<p>Must be one of: <code>deb</code>, <code>docker_manifest</code>, <code>file</code>, <code>ostree</code>, <code>puppet_module</code>, <code>rpm</code>, <code>srpm</code>.</p>
+<p>Must be one of: <code>docker_manifest</code>, <code>file</code>, <code>ostree</code>, <code>puppet_module</code>, <code>rpm</code>, <code>srpm</code>, <code>deb</code>.</p>
 </li>
         </ul>
 

--- a/plugins/katello/3.16/api/apidoc/v2/content_uploads.html
+++ b/plugins/katello/3.16/api/apidoc/v2/content_uploads.html
@@ -164,7 +164,7 @@
         <p><strong>Validations:</strong></p>
         <ul>
             <li>
-<p>Must be one of: <code>deb</code>, <code>docker_manifest</code>, <code>file</code>, <code>ostree</code>, <code>puppet_module</code>, <code>rpm</code>, <code>srpm</code>.</p>
+<p>Must be one of: <code>docker_manifest</code>, <code>file</code>, <code>ostree</code>, <code>puppet_module</code>, <code>rpm</code>, <code>srpm</code>, <code>deb</code>.</p>
 </li>
         </ul>
 

--- a/plugins/katello/3.16/api/apidoc/v2/content_uploads/create.en.html
+++ b/plugins/katello/3.16/api/apidoc/v2/content_uploads/create.en.html
@@ -145,7 +145,7 @@
         <p><strong>Validations:</strong></p>
         <ul>
             <li>
-<p>Must be one of: <code>deb</code>, <code>docker_manifest</code>, <code>file</code>, <code>ostree</code>, <code>puppet_module</code>, <code>rpm</code>, <code>srpm</code>.</p>
+<p>Must be one of: <code>docker_manifest</code>, <code>file</code>, <code>ostree</code>, <code>puppet_module</code>, <code>rpm</code>, <code>srpm</code>, <code>deb</code>.</p>
 </li>
         </ul>
 

--- a/plugins/katello/3.16/api/apidoc/v2/content_uploads/create.html
+++ b/plugins/katello/3.16/api/apidoc/v2/content_uploads/create.html
@@ -145,7 +145,7 @@
         <p><strong>Validations:</strong></p>
         <ul>
             <li>
-<p>Must be one of: <code>deb</code>, <code>docker_manifest</code>, <code>file</code>, <code>ostree</code>, <code>puppet_module</code>, <code>rpm</code>, <code>srpm</code>.</p>
+<p>Must be one of: <code>docker_manifest</code>, <code>file</code>, <code>ostree</code>, <code>puppet_module</code>, <code>rpm</code>, <code>srpm</code>, <code>deb</code>.</p>
 </li>
         </ul>
 

--- a/plugins/katello/3.16/api/apidoc/v2/host_tracer.en.html
+++ b/plugins/katello/3.16/api/apidoc/v2/host_tracer.en.html
@@ -54,7 +54,7 @@
            class='accordion-toggle'
            data-toggle='collapse'
            data-parent='#accordion'>
-            GET /katello/api/hosts/:host_id/traces
+            GET /api/hosts/:host_id/traces
           </a>
           <br>
           <small>List services that need restarting on the host</small>
@@ -119,7 +119,7 @@
            class='accordion-toggle'
            data-toggle='collapse'
            data-parent='#accordion'>
-            PUT /katello/api/traces/resolve
+            PUT /api/hosts/:host_id/traces/resolve
           </a>
           <br>
           <small>Resolve Traces</small>
@@ -143,6 +143,30 @@
     </thead>
     <tbody>
         <tr style='background-color:rgb(255,255,255);'>
+    <td>
+      <strong>host_id </strong><br>
+      <small>
+        required
+        
+      </small>
+    </td>
+    <td>
+      
+<p>ID of the host</p>
+
+        <p><strong>Validations:</strong></p>
+        <ul>
+            <li>
+<p>Must be a number.</p>
+</li>
+        </ul>
+
+    </td>
+
+  </tr>
+
+  
+  <tr style='background-color:rgb(255,255,255);'>
     <td>
       <strong>trace_ids </strong><br>
       <small>

--- a/plugins/katello/3.16/api/apidoc/v2/host_tracer.html
+++ b/plugins/katello/3.16/api/apidoc/v2/host_tracer.html
@@ -54,7 +54,7 @@
            class='accordion-toggle'
            data-toggle='collapse'
            data-parent='#accordion'>
-            GET /katello/api/hosts/:host_id/traces
+            GET /api/hosts/:host_id/traces
           </a>
           <br>
           <small>List services that need restarting on the host</small>
@@ -119,7 +119,7 @@
            class='accordion-toggle'
            data-toggle='collapse'
            data-parent='#accordion'>
-            PUT /katello/api/traces/resolve
+            PUT /api/hosts/:host_id/traces/resolve
           </a>
           <br>
           <small>Resolve Traces</small>
@@ -143,6 +143,30 @@
     </thead>
     <tbody>
         <tr style='background-color:rgb(255,255,255);'>
+    <td>
+      <strong>host_id </strong><br>
+      <small>
+        required
+        
+      </small>
+    </td>
+    <td>
+      
+<p>ID of the host</p>
+
+        <p><strong>Validations:</strong></p>
+        <ul>
+            <li>
+<p>Must be a number.</p>
+</li>
+        </ul>
+
+    </td>
+
+  </tr>
+
+  
+  <tr style='background-color:rgb(255,255,255);'>
     <td>
       <strong>trace_ids </strong><br>
       <small>

--- a/plugins/katello/3.16/api/apidoc/v2/host_tracer/index.en.html
+++ b/plugins/katello/3.16/api/apidoc/v2/host_tracer/index.en.html
@@ -36,7 +36,7 @@
 
   <div class='page-header'>
     <h1>
-      GET /katello/api/hosts/:host_id/traces
+      GET /api/hosts/:host_id/traces
       <br>
       <small>List services that need restarting on the host</small>
     </h1>

--- a/plugins/katello/3.16/api/apidoc/v2/host_tracer/index.html
+++ b/plugins/katello/3.16/api/apidoc/v2/host_tracer/index.html
@@ -36,7 +36,7 @@
 
   <div class='page-header'>
     <h1>
-      GET /katello/api/hosts/:host_id/traces
+      GET /api/hosts/:host_id/traces
       <br>
       <small>List services that need restarting on the host</small>
     </h1>

--- a/plugins/katello/3.16/api/apidoc/v2/host_tracer/resolve.en.html
+++ b/plugins/katello/3.16/api/apidoc/v2/host_tracer/resolve.en.html
@@ -36,7 +36,7 @@
 
   <div class='page-header'>
     <h1>
-      PUT /katello/api/traces/resolve
+      PUT /api/hosts/:host_id/traces/resolve
       <br>
       <small>Resolve Traces</small>
     </h1>
@@ -59,6 +59,30 @@
     </thead>
     <tbody>
         <tr style='background-color:rgb(255,255,255);'>
+    <td>
+      <strong>host_id </strong><br>
+      <small>
+        required
+        
+      </small>
+    </td>
+    <td>
+      
+<p>ID of the host</p>
+
+        <p><strong>Validations:</strong></p>
+        <ul>
+            <li>
+<p>Must be a number.</p>
+</li>
+        </ul>
+
+    </td>
+
+  </tr>
+
+  
+  <tr style='background-color:rgb(255,255,255);'>
     <td>
       <strong>trace_ids </strong><br>
       <small>

--- a/plugins/katello/3.16/api/apidoc/v2/host_tracer/resolve.html
+++ b/plugins/katello/3.16/api/apidoc/v2/host_tracer/resolve.html
@@ -36,7 +36,7 @@
 
   <div class='page-header'>
     <h1>
-      PUT /katello/api/traces/resolve
+      PUT /api/hosts/:host_id/traces/resolve
       <br>
       <small>Resolve Traces</small>
     </h1>
@@ -59,6 +59,30 @@
     </thead>
     <tbody>
         <tr style='background-color:rgb(255,255,255);'>
+    <td>
+      <strong>host_id </strong><br>
+      <small>
+        required
+        
+      </small>
+    </td>
+    <td>
+      
+<p>ID of the host</p>
+
+        <p><strong>Validations:</strong></p>
+        <ul>
+            <li>
+<p>Must be a number.</p>
+</li>
+        </ul>
+
+    </td>
+
+  </tr>
+
+  
+  <tr style='background-color:rgb(255,255,255);'>
     <td>
       <strong>trace_ids </strong><br>
       <small>

--- a/plugins/katello/3.16/api/apidoc/v2/hosts_bulk_actions.en.html
+++ b/plugins/katello/3.16/api/apidoc/v2/hosts_bulk_actions.en.html
@@ -3309,6 +3309,211 @@
     </div>
     <hr>
     <div class='pull-right small'>
+      <a href='../../apidoc/v2/hosts_bulk_actions/resolve_traces.en.html'> >>> </a>
+    </div>
+    <div>
+        <h2>
+          <a href='#description-resolve_traces'
+           class='accordion-toggle'
+           data-toggle='collapse'
+           data-parent='#accordion'>
+            PUT /api/hosts/bulk/resolve_traces
+          </a>
+          <br>
+          <small>Resolve traces for one or more hosts</small>
+        </h2>
+    </div>
+
+
+    <div id='description-resolve_traces' class='collapse accordion-body'>
+      
+
+
+
+
+  <h3>Params</h3>
+  <table class='table'>
+    <thead>
+      <tr>
+        <th>Param name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+        <tr style='background-color:rgb(255,255,255);'>
+    <td>
+      <strong>organization_id </strong><br>
+      <small>
+        required
+        
+      </small>
+    </td>
+    <td>
+      
+<p>ID of the organization</p>
+
+        <p><strong>Validations:</strong></p>
+        <ul>
+            <li>
+<p>Must be a number.</p>
+</li>
+        </ul>
+
+    </td>
+
+  </tr>
+
+  
+  <tr style='background-color:rgb(255,255,255);'>
+    <td>
+      <strong>included </strong><br>
+      <small>
+        required
+        
+      </small>
+    </td>
+    <td>
+      
+        <p><strong>Validations:</strong></p>
+        <ul>
+            <li>
+<p>Hash</p>
+</li>
+        </ul>
+
+    </td>
+
+  </tr>
+
+    <tr style='background-color:rgb(250,250,250);'>
+    <td>
+      <strong>included[search] </strong><br>
+      <small>
+        optional
+        , nil allowed
+      </small>
+    </td>
+    <td>
+      
+<p>Search string for hosts to perform an action on</p>
+
+        <p><strong>Validations:</strong></p>
+        <ul>
+            <li>
+<p>String</p>
+</li>
+        </ul>
+
+    </td>
+
+  </tr>
+
+  
+  <tr style='background-color:rgb(250,250,250);'>
+    <td>
+      <strong>included[ids] </strong><br>
+      <small>
+        optional
+        , nil allowed
+      </small>
+    </td>
+    <td>
+      
+<p>List of host ids to perform an action on</p>
+
+        <p><strong>Validations:</strong></p>
+        <ul>
+            <li>
+<p>Must be an array of any type</p>
+</li>
+        </ul>
+
+    </td>
+
+  </tr>
+
+  
+
+  <tr style='background-color:rgb(255,255,255);'>
+    <td>
+      <strong>excluded </strong><br>
+      <small>
+        required
+        
+      </small>
+    </td>
+    <td>
+      
+        <p><strong>Validations:</strong></p>
+        <ul>
+            <li>
+<p>Hash</p>
+</li>
+        </ul>
+
+    </td>
+
+  </tr>
+
+    <tr style='background-color:rgb(250,250,250);'>
+    <td>
+      <strong>excluded[ids] </strong><br>
+      <small>
+        optional
+        , nil allowed
+      </small>
+    </td>
+    <td>
+      
+<p>List of host ids to exclude and not run an action on</p>
+
+        <p><strong>Validations:</strong></p>
+        <ul>
+            <li>
+<p>Must be an array of any type</p>
+</li>
+        </ul>
+
+    </td>
+
+  </tr>
+
+  
+
+  <tr style='background-color:rgb(255,255,255);'>
+    <td>
+      <strong>trace_ids </strong><br>
+      <small>
+        required
+        
+      </small>
+    </td>
+    <td>
+      
+<p>Array of Trace IDs</p>
+
+        <p><strong>Validations:</strong></p>
+        <ul>
+            <li>
+<p>Must be an array of any type</p>
+</li>
+        </ul>
+
+    </td>
+
+  </tr>
+
+  
+
+    </tbody>
+  </table>
+
+
+
+
+    </div>
+    <hr>
+    <div class='pull-right small'>
       <a href='../../apidoc/v2/hosts_bulk_actions/available_incremental_updates.en.html'> >>> </a>
     </div>
     <div>

--- a/plugins/katello/3.16/api/apidoc/v2/hosts_bulk_actions.html
+++ b/plugins/katello/3.16/api/apidoc/v2/hosts_bulk_actions.html
@@ -3309,6 +3309,211 @@
     </div>
     <hr>
     <div class='pull-right small'>
+      <a href='../../apidoc/v2/hosts_bulk_actions/resolve_traces.html'> >>> </a>
+    </div>
+    <div>
+        <h2>
+          <a href='#description-resolve_traces'
+           class='accordion-toggle'
+           data-toggle='collapse'
+           data-parent='#accordion'>
+            PUT /api/hosts/bulk/resolve_traces
+          </a>
+          <br>
+          <small>Resolve traces for one or more hosts</small>
+        </h2>
+    </div>
+
+
+    <div id='description-resolve_traces' class='collapse accordion-body'>
+      
+
+
+
+
+  <h3>Params</h3>
+  <table class='table'>
+    <thead>
+      <tr>
+        <th>Param name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+        <tr style='background-color:rgb(255,255,255);'>
+    <td>
+      <strong>organization_id </strong><br>
+      <small>
+        required
+        
+      </small>
+    </td>
+    <td>
+      
+<p>ID of the organization</p>
+
+        <p><strong>Validations:</strong></p>
+        <ul>
+            <li>
+<p>Must be a number.</p>
+</li>
+        </ul>
+
+    </td>
+
+  </tr>
+
+  
+  <tr style='background-color:rgb(255,255,255);'>
+    <td>
+      <strong>included </strong><br>
+      <small>
+        required
+        
+      </small>
+    </td>
+    <td>
+      
+        <p><strong>Validations:</strong></p>
+        <ul>
+            <li>
+<p>Hash</p>
+</li>
+        </ul>
+
+    </td>
+
+  </tr>
+
+    <tr style='background-color:rgb(250,250,250);'>
+    <td>
+      <strong>included[search] </strong><br>
+      <small>
+        optional
+        , nil allowed
+      </small>
+    </td>
+    <td>
+      
+<p>Search string for hosts to perform an action on</p>
+
+        <p><strong>Validations:</strong></p>
+        <ul>
+            <li>
+<p>String</p>
+</li>
+        </ul>
+
+    </td>
+
+  </tr>
+
+  
+  <tr style='background-color:rgb(250,250,250);'>
+    <td>
+      <strong>included[ids] </strong><br>
+      <small>
+        optional
+        , nil allowed
+      </small>
+    </td>
+    <td>
+      
+<p>List of host ids to perform an action on</p>
+
+        <p><strong>Validations:</strong></p>
+        <ul>
+            <li>
+<p>Must be an array of any type</p>
+</li>
+        </ul>
+
+    </td>
+
+  </tr>
+
+  
+
+  <tr style='background-color:rgb(255,255,255);'>
+    <td>
+      <strong>excluded </strong><br>
+      <small>
+        required
+        
+      </small>
+    </td>
+    <td>
+      
+        <p><strong>Validations:</strong></p>
+        <ul>
+            <li>
+<p>Hash</p>
+</li>
+        </ul>
+
+    </td>
+
+  </tr>
+
+    <tr style='background-color:rgb(250,250,250);'>
+    <td>
+      <strong>excluded[ids] </strong><br>
+      <small>
+        optional
+        , nil allowed
+      </small>
+    </td>
+    <td>
+      
+<p>List of host ids to exclude and not run an action on</p>
+
+        <p><strong>Validations:</strong></p>
+        <ul>
+            <li>
+<p>Must be an array of any type</p>
+</li>
+        </ul>
+
+    </td>
+
+  </tr>
+
+  
+
+  <tr style='background-color:rgb(255,255,255);'>
+    <td>
+      <strong>trace_ids </strong><br>
+      <small>
+        required
+        
+      </small>
+    </td>
+    <td>
+      
+<p>Array of Trace IDs</p>
+
+        <p><strong>Validations:</strong></p>
+        <ul>
+            <li>
+<p>Must be an array of any type</p>
+</li>
+        </ul>
+
+    </td>
+
+  </tr>
+
+  
+
+    </tbody>
+  </table>
+
+
+
+
+    </div>
+    <hr>
+    <div class='pull-right small'>
       <a href='../../apidoc/v2/hosts_bulk_actions/available_incremental_updates.html'> >>> </a>
     </div>
     <div>

--- a/plugins/katello/3.16/api/apidoc/v2/hosts_bulk_actions/resolve_traces.en.html
+++ b/plugins/katello/3.16/api/apidoc/v2/hosts_bulk_actions/resolve_traces.en.html
@@ -23,51 +23,28 @@
     <span class='divider'>/</span>
   </li>
   <li>
-    <a href='../../../apidoc/v2/repositories.en.html'>
-      Repositories
+    <a href='../../../apidoc/v2/hosts_bulk_actions.en.html'>
+      Hosts bulk actions
       
     </a>
     <span class='divider'>/</span>
   </li>
-  <li class='active'>remove_content</li>
+  <li class='active'>resolve_traces</li>
   
 
 </ul>
 
   <div class='page-header'>
     <h1>
-      PUT /katello/api/repositories/:id/remove_packages
+      PUT /api/hosts/bulk/resolve_traces
       <br>
-      <small></small>
-    </h1>
-  </div>
-  <div class='page-header'>
-    <h1>
-      PUT /katello/api/repositories/:id/remove_docker_manifests
-      <br>
-      <small></small>
-    </h1>
-  </div>
-  <div class='page-header'>
-    <h1>
-      PUT /katello/api/repositories/:id/remove_puppet_modules
-      <br>
-      <small></small>
-    </h1>
-  </div>
-  <div class='page-header'>
-    <h1>
-      PUT /katello/api/repositories/:id/remove_content
-      <br>
-      <small></small>
+      <small>Resolve traces for one or more hosts</small>
     </h1>
   </div>
 
 <div>
 
   
-<p>Remove content from a repository</p>
-
 
 
 
@@ -83,7 +60,7 @@
     <tbody>
         <tr style='background-color:rgb(255,255,255);'>
     <td>
-      <strong>id </strong><br>
+      <strong>organization_id </strong><br>
       <small>
         required
         
@@ -91,7 +68,7 @@
     </td>
     <td>
       
-<p>repository ID</p>
+<p>ID of the organization</p>
 
         <p><strong>Validations:</strong></p>
         <ul>
@@ -107,7 +84,7 @@
   
   <tr style='background-color:rgb(255,255,255);'>
     <td>
-      <strong>ids </strong><br>
+      <strong>included </strong><br>
       <small>
         required
         
@@ -115,7 +92,52 @@
     </td>
     <td>
       
-<p>Array of content ids to remove</p>
+        <p><strong>Validations:</strong></p>
+        <ul>
+            <li>
+<p>Hash</p>
+</li>
+        </ul>
+
+    </td>
+
+  </tr>
+
+    <tr style='background-color:rgb(250,250,250);'>
+    <td>
+      <strong>included[search] </strong><br>
+      <small>
+        optional
+        , nil allowed
+      </small>
+    </td>
+    <td>
+      
+<p>Search string for hosts to perform an action on</p>
+
+        <p><strong>Validations:</strong></p>
+        <ul>
+            <li>
+<p>String</p>
+</li>
+        </ul>
+
+    </td>
+
+  </tr>
+
+  
+  <tr style='background-color:rgb(250,250,250);'>
+    <td>
+      <strong>included[ids] </strong><br>
+      <small>
+        optional
+        , nil allowed
+      </small>
+    </td>
+    <td>
+      
+<p>List of host ids to perform an action on</p>
 
         <p><strong>Validations:</strong></p>
         <ul>
@@ -129,22 +151,44 @@
   </tr>
 
   
+
   <tr style='background-color:rgb(255,255,255);'>
     <td>
-      <strong>content_type </strong><br>
+      <strong>excluded </strong><br>
       <small>
-        optional
+        required
         
       </small>
     </td>
     <td>
       
-<p>content type (‘deb’, ‘docker_manifest’, ‘file’, ‘ostree’, ‘puppet_module’, ‘rpm’, ‘srpm’)</p>
+        <p><strong>Validations:</strong></p>
+        <ul>
+            <li>
+<p>Hash</p>
+</li>
+        </ul>
+
+    </td>
+
+  </tr>
+
+    <tr style='background-color:rgb(250,250,250);'>
+    <td>
+      <strong>excluded[ids] </strong><br>
+      <small>
+        optional
+        , nil allowed
+      </small>
+    </td>
+    <td>
+      
+<p>List of host ids to exclude and not run an action on</p>
 
         <p><strong>Validations:</strong></p>
         <ul>
             <li>
-<p>Must be one of: <code>docker_manifest</code>, <code>file</code>, <code>ostree</code>, <code>puppet_module</code>, <code>rpm</code>, <code>srpm</code>, <code>deb</code>.</p>
+<p>Must be an array of any type</p>
 </li>
         </ul>
 
@@ -153,22 +197,23 @@
   </tr>
 
   
+
   <tr style='background-color:rgb(255,255,255);'>
     <td>
-      <strong>sync_capsule </strong><br>
+      <strong>trace_ids </strong><br>
       <small>
-        optional
+        required
         
       </small>
     </td>
     <td>
       
-<p>Whether or not to sync an external capsule after upload. Default: true</p>
+<p>Array of Trace IDs</p>
 
         <p><strong>Validations:</strong></p>
         <ul>
             <li>
-<p>Must be one of: <code>true</code>, <code>false</code>, <code>1</code>, <code>0</code>.</p>
+<p>Must be an array of any type</p>
 </li>
         </ul>
 

--- a/plugins/katello/3.16/api/apidoc/v2/hosts_bulk_actions/resolve_traces.html
+++ b/plugins/katello/3.16/api/apidoc/v2/hosts_bulk_actions/resolve_traces.html
@@ -19,55 +19,32 @@
       <div id='container'>
         <ul class='breadcrumb'>
   <li>
-    <a href='../../../apidoc/v2.en.html'>Foreman v2</a>
+    <a href='../../../apidoc/v2.html'>Foreman v2</a>
     <span class='divider'>/</span>
   </li>
   <li>
-    <a href='../../../apidoc/v2/repositories.en.html'>
-      Repositories
+    <a href='../../../apidoc/v2/hosts_bulk_actions.html'>
+      Hosts bulk actions
       
     </a>
     <span class='divider'>/</span>
   </li>
-  <li class='active'>remove_content</li>
+  <li class='active'>resolve_traces</li>
   
 
 </ul>
 
   <div class='page-header'>
     <h1>
-      PUT /katello/api/repositories/:id/remove_packages
+      PUT /api/hosts/bulk/resolve_traces
       <br>
-      <small></small>
-    </h1>
-  </div>
-  <div class='page-header'>
-    <h1>
-      PUT /katello/api/repositories/:id/remove_docker_manifests
-      <br>
-      <small></small>
-    </h1>
-  </div>
-  <div class='page-header'>
-    <h1>
-      PUT /katello/api/repositories/:id/remove_puppet_modules
-      <br>
-      <small></small>
-    </h1>
-  </div>
-  <div class='page-header'>
-    <h1>
-      PUT /katello/api/repositories/:id/remove_content
-      <br>
-      <small></small>
+      <small>Resolve traces for one or more hosts</small>
     </h1>
   </div>
 
 <div>
 
   
-<p>Remove content from a repository</p>
-
 
 
 
@@ -83,7 +60,7 @@
     <tbody>
         <tr style='background-color:rgb(255,255,255);'>
     <td>
-      <strong>id </strong><br>
+      <strong>organization_id </strong><br>
       <small>
         required
         
@@ -91,7 +68,7 @@
     </td>
     <td>
       
-<p>repository ID</p>
+<p>ID of the organization</p>
 
         <p><strong>Validations:</strong></p>
         <ul>
@@ -107,7 +84,7 @@
   
   <tr style='background-color:rgb(255,255,255);'>
     <td>
-      <strong>ids </strong><br>
+      <strong>included </strong><br>
       <small>
         required
         
@@ -115,7 +92,52 @@
     </td>
     <td>
       
-<p>Array of content ids to remove</p>
+        <p><strong>Validations:</strong></p>
+        <ul>
+            <li>
+<p>Hash</p>
+</li>
+        </ul>
+
+    </td>
+
+  </tr>
+
+    <tr style='background-color:rgb(250,250,250);'>
+    <td>
+      <strong>included[search] </strong><br>
+      <small>
+        optional
+        , nil allowed
+      </small>
+    </td>
+    <td>
+      
+<p>Search string for hosts to perform an action on</p>
+
+        <p><strong>Validations:</strong></p>
+        <ul>
+            <li>
+<p>String</p>
+</li>
+        </ul>
+
+    </td>
+
+  </tr>
+
+  
+  <tr style='background-color:rgb(250,250,250);'>
+    <td>
+      <strong>included[ids] </strong><br>
+      <small>
+        optional
+        , nil allowed
+      </small>
+    </td>
+    <td>
+      
+<p>List of host ids to perform an action on</p>
 
         <p><strong>Validations:</strong></p>
         <ul>
@@ -129,22 +151,44 @@
   </tr>
 
   
+
   <tr style='background-color:rgb(255,255,255);'>
     <td>
-      <strong>content_type </strong><br>
+      <strong>excluded </strong><br>
       <small>
-        optional
+        required
         
       </small>
     </td>
     <td>
       
-<p>content type (‘deb’, ‘docker_manifest’, ‘file’, ‘ostree’, ‘puppet_module’, ‘rpm’, ‘srpm’)</p>
+        <p><strong>Validations:</strong></p>
+        <ul>
+            <li>
+<p>Hash</p>
+</li>
+        </ul>
+
+    </td>
+
+  </tr>
+
+    <tr style='background-color:rgb(250,250,250);'>
+    <td>
+      <strong>excluded[ids] </strong><br>
+      <small>
+        optional
+        , nil allowed
+      </small>
+    </td>
+    <td>
+      
+<p>List of host ids to exclude and not run an action on</p>
 
         <p><strong>Validations:</strong></p>
         <ul>
             <li>
-<p>Must be one of: <code>docker_manifest</code>, <code>file</code>, <code>ostree</code>, <code>puppet_module</code>, <code>rpm</code>, <code>srpm</code>, <code>deb</code>.</p>
+<p>Must be an array of any type</p>
 </li>
         </ul>
 
@@ -153,22 +197,23 @@
   </tr>
 
   
+
   <tr style='background-color:rgb(255,255,255);'>
     <td>
-      <strong>sync_capsule </strong><br>
+      <strong>trace_ids </strong><br>
       <small>
-        optional
+        required
         
       </small>
     </td>
     <td>
       
-<p>Whether or not to sync an external capsule after upload. Default: true</p>
+<p>Array of Trace IDs</p>
 
         <p><strong>Validations:</strong></p>
         <ul>
             <li>
-<p>Must be one of: <code>true</code>, <code>false</code>, <code>1</code>, <code>0</code>.</p>
+<p>Must be an array of any type</p>
 </li>
         </ul>
 

--- a/plugins/katello/3.16/api/apidoc/v2/repositories.en.html
+++ b/plugins/katello/3.16/api/apidoc/v2/repositories.en.html
@@ -454,7 +454,7 @@
         <p><strong>Validations:</strong></p>
         <ul>
             <li>
-<p>Must be one of: <code>deb</code>, <code>docker</code>, <code>file</code>, <code>ostree</code>, <code>puppet</code>, <code>yum</code>.</p>
+<p>Must be one of: <code>ansible_collection</code>, <code>docker</code>, <code>file</code>, <code>ostree</code>, <code>puppet</code>, <code>yum</code>, <code>deb</code>.</p>
 </li>
         </ul>
 
@@ -574,7 +574,7 @@
         <p><strong>Validations:</strong></p>
         <ul>
             <li>
-<p>Must be one of: <code>deb</code>, <code>docker_manifest</code>, <code>docker_manifest_list</code>, <code>docker_tag</code>, <code>docker_blob</code>, <code>file</code>, <code>ostree</code>, <code>puppet_module</code>, <code>rpm</code>, <code>modulemd</code>, <code>erratum</code>, <code>distribution</code>, <code>package_category</code>, <code>package_group</code>, <code>yum_repo_metadata_file</code>, <code>srpm</code>.</p>
+<p>Must be one of: <code>ansible collection</code>, <code>docker_manifest</code>, <code>docker_manifest_list</code>, <code>docker_tag</code>, <code>docker_blob</code>, <code>file</code>, <code>ostree</code>, <code>puppet_module</code>, <code>rpm</code>, <code>modulemd</code>, <code>erratum</code>, <code>distribution</code>, <code>package_category</code>, <code>package_group</code>, <code>yum_repo_metadata_file</code>, <code>srpm</code>, <code>deb</code>.</p>
 </li>
         </ul>
 
@@ -807,7 +807,7 @@
     </tr>
     <tr>
       <td>distribution_uuid</td>
-      <td>string</td>
+      <td></td>
       <td></td>
     </tr>
     <tr>
@@ -1001,7 +1001,7 @@
         <p><strong>Validations:</strong></p>
         <ul>
             <li>
-<p>Must be one of: <code>deb</code>, <code>docker</code>, <code>file</code>, <code>ostree</code>, <code>puppet</code>, <code>yum</code>.</p>
+<p>Must be one of: <code>ansible_collection</code>, <code>docker</code>, <code>file</code>, <code>ostree</code>, <code>puppet</code>, <code>yum</code>, <code>deb</code>.</p>
 </li>
         </ul>
 
@@ -3030,7 +3030,7 @@
         <p><strong>Validations:</strong></p>
         <ul>
             <li>
-<p>Must be one of: <code>deb</code>, <code>docker_manifest</code>, <code>file</code>, <code>ostree</code>, <code>puppet_module</code>, <code>rpm</code>, <code>srpm</code>.</p>
+<p>Must be one of: <code>docker_manifest</code>, <code>file</code>, <code>ostree</code>, <code>puppet_module</code>, <code>rpm</code>, <code>srpm</code>, <code>deb</code>.</p>
 </li>
         </ul>
 
@@ -3167,7 +3167,7 @@
         <p><strong>Validations:</strong></p>
         <ul>
             <li>
-<p>Must be one of: <code>deb</code>, <code>docker_manifest</code>, <code>file</code>, <code>ostree</code>, <code>puppet_module</code>, <code>rpm</code>, <code>srpm</code>.</p>
+<p>Must be one of: <code>docker_manifest</code>, <code>file</code>, <code>ostree</code>, <code>puppet_module</code>, <code>rpm</code>, <code>srpm</code>, <code>deb</code>.</p>
 </li>
         </ul>
 
@@ -3328,7 +3328,7 @@
         <p><strong>Validations:</strong></p>
         <ul>
             <li>
-<p>Must be one of: <code>deb</code>, <code>docker_manifest</code>, <code>file</code>, <code>ostree</code>, <code>puppet_module</code>, <code>rpm</code>, <code>srpm</code>.</p>
+<p>Must be one of: <code>docker_manifest</code>, <code>file</code>, <code>ostree</code>, <code>puppet_module</code>, <code>rpm</code>, <code>srpm</code>, <code>deb</code>.</p>
 </li>
         </ul>
 

--- a/plugins/katello/3.16/api/apidoc/v2/repositories.html
+++ b/plugins/katello/3.16/api/apidoc/v2/repositories.html
@@ -454,7 +454,7 @@
         <p><strong>Validations:</strong></p>
         <ul>
             <li>
-<p>Must be one of: <code>deb</code>, <code>docker</code>, <code>file</code>, <code>ostree</code>, <code>puppet</code>, <code>yum</code>.</p>
+<p>Must be one of: <code>ansible_collection</code>, <code>docker</code>, <code>file</code>, <code>ostree</code>, <code>puppet</code>, <code>yum</code>, <code>deb</code>.</p>
 </li>
         </ul>
 
@@ -574,7 +574,7 @@
         <p><strong>Validations:</strong></p>
         <ul>
             <li>
-<p>Must be one of: <code>deb</code>, <code>docker_manifest</code>, <code>docker_manifest_list</code>, <code>docker_tag</code>, <code>docker_blob</code>, <code>file</code>, <code>ostree</code>, <code>puppet_module</code>, <code>rpm</code>, <code>modulemd</code>, <code>erratum</code>, <code>distribution</code>, <code>package_category</code>, <code>package_group</code>, <code>yum_repo_metadata_file</code>, <code>srpm</code>.</p>
+<p>Must be one of: <code>ansible collection</code>, <code>docker_manifest</code>, <code>docker_manifest_list</code>, <code>docker_tag</code>, <code>docker_blob</code>, <code>file</code>, <code>ostree</code>, <code>puppet_module</code>, <code>rpm</code>, <code>modulemd</code>, <code>erratum</code>, <code>distribution</code>, <code>package_category</code>, <code>package_group</code>, <code>yum_repo_metadata_file</code>, <code>srpm</code>, <code>deb</code>.</p>
 </li>
         </ul>
 
@@ -807,7 +807,7 @@
     </tr>
     <tr>
       <td>distribution_uuid</td>
-      <td>string</td>
+      <td></td>
       <td></td>
     </tr>
     <tr>
@@ -1001,7 +1001,7 @@
         <p><strong>Validations:</strong></p>
         <ul>
             <li>
-<p>Must be one of: <code>deb</code>, <code>docker</code>, <code>file</code>, <code>ostree</code>, <code>puppet</code>, <code>yum</code>.</p>
+<p>Must be one of: <code>ansible_collection</code>, <code>docker</code>, <code>file</code>, <code>ostree</code>, <code>puppet</code>, <code>yum</code>, <code>deb</code>.</p>
 </li>
         </ul>
 
@@ -3030,7 +3030,7 @@
         <p><strong>Validations:</strong></p>
         <ul>
             <li>
-<p>Must be one of: <code>deb</code>, <code>docker_manifest</code>, <code>file</code>, <code>ostree</code>, <code>puppet_module</code>, <code>rpm</code>, <code>srpm</code>.</p>
+<p>Must be one of: <code>docker_manifest</code>, <code>file</code>, <code>ostree</code>, <code>puppet_module</code>, <code>rpm</code>, <code>srpm</code>, <code>deb</code>.</p>
 </li>
         </ul>
 
@@ -3167,7 +3167,7 @@
         <p><strong>Validations:</strong></p>
         <ul>
             <li>
-<p>Must be one of: <code>deb</code>, <code>docker_manifest</code>, <code>file</code>, <code>ostree</code>, <code>puppet_module</code>, <code>rpm</code>, <code>srpm</code>.</p>
+<p>Must be one of: <code>docker_manifest</code>, <code>file</code>, <code>ostree</code>, <code>puppet_module</code>, <code>rpm</code>, <code>srpm</code>, <code>deb</code>.</p>
 </li>
         </ul>
 
@@ -3328,7 +3328,7 @@
         <p><strong>Validations:</strong></p>
         <ul>
             <li>
-<p>Must be one of: <code>deb</code>, <code>docker_manifest</code>, <code>file</code>, <code>ostree</code>, <code>puppet_module</code>, <code>rpm</code>, <code>srpm</code>.</p>
+<p>Must be one of: <code>docker_manifest</code>, <code>file</code>, <code>ostree</code>, <code>puppet_module</code>, <code>rpm</code>, <code>srpm</code>, <code>deb</code>.</p>
 </li>
         </ul>
 

--- a/plugins/katello/3.16/api/apidoc/v2/repositories/create.en.html
+++ b/plugins/katello/3.16/api/apidoc/v2/repositories/create.en.html
@@ -167,7 +167,7 @@
         <p><strong>Validations:</strong></p>
         <ul>
             <li>
-<p>Must be one of: <code>deb</code>, <code>docker</code>, <code>file</code>, <code>ostree</code>, <code>puppet</code>, <code>yum</code>.</p>
+<p>Must be one of: <code>ansible_collection</code>, <code>docker</code>, <code>file</code>, <code>ostree</code>, <code>puppet</code>, <code>yum</code>, <code>deb</code>.</p>
 </li>
         </ul>
 

--- a/plugins/katello/3.16/api/apidoc/v2/repositories/create.html
+++ b/plugins/katello/3.16/api/apidoc/v2/repositories/create.html
@@ -167,7 +167,7 @@
         <p><strong>Validations:</strong></p>
         <ul>
             <li>
-<p>Must be one of: <code>deb</code>, <code>docker</code>, <code>file</code>, <code>ostree</code>, <code>puppet</code>, <code>yum</code>.</p>
+<p>Must be one of: <code>ansible_collection</code>, <code>docker</code>, <code>file</code>, <code>ostree</code>, <code>puppet</code>, <code>yum</code>, <code>deb</code>.</p>
 </li>
         </ul>
 

--- a/plugins/katello/3.16/api/apidoc/v2/repositories/import_uploads.en.html
+++ b/plugins/katello/3.16/api/apidoc/v2/repositories/import_uploads.en.html
@@ -169,7 +169,7 @@
         <p><strong>Validations:</strong></p>
         <ul>
             <li>
-<p>Must be one of: <code>deb</code>, <code>docker_manifest</code>, <code>file</code>, <code>ostree</code>, <code>puppet_module</code>, <code>rpm</code>, <code>srpm</code>.</p>
+<p>Must be one of: <code>docker_manifest</code>, <code>file</code>, <code>ostree</code>, <code>puppet_module</code>, <code>rpm</code>, <code>srpm</code>, <code>deb</code>.</p>
 </li>
         </ul>
 

--- a/plugins/katello/3.16/api/apidoc/v2/repositories/import_uploads.html
+++ b/plugins/katello/3.16/api/apidoc/v2/repositories/import_uploads.html
@@ -169,7 +169,7 @@
         <p><strong>Validations:</strong></p>
         <ul>
             <li>
-<p>Must be one of: <code>deb</code>, <code>docker_manifest</code>, <code>file</code>, <code>ostree</code>, <code>puppet_module</code>, <code>rpm</code>, <code>srpm</code>.</p>
+<p>Must be one of: <code>docker_manifest</code>, <code>file</code>, <code>ostree</code>, <code>puppet_module</code>, <code>rpm</code>, <code>srpm</code>, <code>deb</code>.</p>
 </li>
         </ul>
 

--- a/plugins/katello/3.16/api/apidoc/v2/repositories/index.en.html
+++ b/plugins/katello/3.16/api/apidoc/v2/repositories/index.en.html
@@ -420,7 +420,7 @@
         <p><strong>Validations:</strong></p>
         <ul>
             <li>
-<p>Must be one of: <code>deb</code>, <code>docker</code>, <code>file</code>, <code>ostree</code>, <code>puppet</code>, <code>yum</code>.</p>
+<p>Must be one of: <code>ansible_collection</code>, <code>docker</code>, <code>file</code>, <code>ostree</code>, <code>puppet</code>, <code>yum</code>, <code>deb</code>.</p>
 </li>
         </ul>
 
@@ -540,7 +540,7 @@
         <p><strong>Validations:</strong></p>
         <ul>
             <li>
-<p>Must be one of: <code>deb</code>, <code>docker_manifest</code>, <code>docker_manifest_list</code>, <code>docker_tag</code>, <code>docker_blob</code>, <code>file</code>, <code>ostree</code>, <code>puppet_module</code>, <code>rpm</code>, <code>modulemd</code>, <code>erratum</code>, <code>distribution</code>, <code>package_category</code>, <code>package_group</code>, <code>yum_repo_metadata_file</code>, <code>srpm</code>.</p>
+<p>Must be one of: <code>ansible collection</code>, <code>docker_manifest</code>, <code>docker_manifest_list</code>, <code>docker_tag</code>, <code>docker_blob</code>, <code>file</code>, <code>ostree</code>, <code>puppet_module</code>, <code>rpm</code>, <code>modulemd</code>, <code>erratum</code>, <code>distribution</code>, <code>package_category</code>, <code>package_group</code>, <code>yum_repo_metadata_file</code>, <code>srpm</code>, <code>deb</code>.</p>
 </li>
         </ul>
 
@@ -773,7 +773,7 @@
     </tr>
     <tr>
       <td>distribution_uuid</td>
-      <td>string</td>
+      <td></td>
       <td></td>
     </tr>
     <tr>

--- a/plugins/katello/3.16/api/apidoc/v2/repositories/index.html
+++ b/plugins/katello/3.16/api/apidoc/v2/repositories/index.html
@@ -420,7 +420,7 @@
         <p><strong>Validations:</strong></p>
         <ul>
             <li>
-<p>Must be one of: <code>deb</code>, <code>docker</code>, <code>file</code>, <code>ostree</code>, <code>puppet</code>, <code>yum</code>.</p>
+<p>Must be one of: <code>ansible_collection</code>, <code>docker</code>, <code>file</code>, <code>ostree</code>, <code>puppet</code>, <code>yum</code>, <code>deb</code>.</p>
 </li>
         </ul>
 
@@ -540,7 +540,7 @@
         <p><strong>Validations:</strong></p>
         <ul>
             <li>
-<p>Must be one of: <code>deb</code>, <code>docker_manifest</code>, <code>docker_manifest_list</code>, <code>docker_tag</code>, <code>docker_blob</code>, <code>file</code>, <code>ostree</code>, <code>puppet_module</code>, <code>rpm</code>, <code>modulemd</code>, <code>erratum</code>, <code>distribution</code>, <code>package_category</code>, <code>package_group</code>, <code>yum_repo_metadata_file</code>, <code>srpm</code>.</p>
+<p>Must be one of: <code>ansible collection</code>, <code>docker_manifest</code>, <code>docker_manifest_list</code>, <code>docker_tag</code>, <code>docker_blob</code>, <code>file</code>, <code>ostree</code>, <code>puppet_module</code>, <code>rpm</code>, <code>modulemd</code>, <code>erratum</code>, <code>distribution</code>, <code>package_category</code>, <code>package_group</code>, <code>yum_repo_metadata_file</code>, <code>srpm</code>, <code>deb</code>.</p>
 </li>
         </ul>
 
@@ -773,7 +773,7 @@
     </tr>
     <tr>
       <td>distribution_uuid</td>
-      <td>string</td>
+      <td></td>
       <td></td>
     </tr>
     <tr>

--- a/plugins/katello/3.16/api/apidoc/v2/repositories/remove_content.html
+++ b/plugins/katello/3.16/api/apidoc/v2/repositories/remove_content.html
@@ -144,7 +144,7 @@
         <p><strong>Validations:</strong></p>
         <ul>
             <li>
-<p>Must be one of: <code>deb</code>, <code>docker_manifest</code>, <code>file</code>, <code>ostree</code>, <code>puppet_module</code>, <code>rpm</code>, <code>srpm</code>.</p>
+<p>Must be one of: <code>docker_manifest</code>, <code>file</code>, <code>ostree</code>, <code>puppet_module</code>, <code>rpm</code>, <code>srpm</code>, <code>deb</code>.</p>
 </li>
         </ul>
 

--- a/plugins/katello/3.16/api/apidoc/v2/repositories/upload_content.en.html
+++ b/plugins/katello/3.16/api/apidoc/v2/repositories/upload_content.en.html
@@ -121,7 +121,7 @@
         <p><strong>Validations:</strong></p>
         <ul>
             <li>
-<p>Must be one of: <code>deb</code>, <code>docker_manifest</code>, <code>file</code>, <code>ostree</code>, <code>puppet_module</code>, <code>rpm</code>, <code>srpm</code>.</p>
+<p>Must be one of: <code>docker_manifest</code>, <code>file</code>, <code>ostree</code>, <code>puppet_module</code>, <code>rpm</code>, <code>srpm</code>, <code>deb</code>.</p>
 </li>
         </ul>
 

--- a/plugins/katello/3.16/api/apidoc/v2/repositories/upload_content.html
+++ b/plugins/katello/3.16/api/apidoc/v2/repositories/upload_content.html
@@ -121,7 +121,7 @@
         <p><strong>Validations:</strong></p>
         <ul>
             <li>
-<p>Must be one of: <code>deb</code>, <code>docker_manifest</code>, <code>file</code>, <code>ostree</code>, <code>puppet_module</code>, <code>rpm</code>, <code>srpm</code>.</p>
+<p>Must be one of: <code>docker_manifest</code>, <code>file</code>, <code>ostree</code>, <code>puppet_module</code>, <code>rpm</code>, <code>srpm</code>, <code>deb</code>.</p>
 </li>
         </ul>
 

--- a/plugins/katello/3.16/release_notes/release_notes.md
+++ b/plugins/katello/3.16/release_notes/release_notes.md
@@ -35,7 +35,7 @@ For the full release notes, see the [Changelog](https://github.com/Katello/katel
 
 ## Bug Fixes
 
-Katello 3.16 includes 189 bug fixes, which can be seen [here](https://projects.theforeman.org/projects/katello/issues?utf8=%E2%9C%93&set_filter=1&sort=id%3Adesc&f%5B%5D=status_id&op%5Bstatus_id%5D=c&f%5B%5D=fixed_version_id&op%5Bfixed_version_id%5D=%3D&v%5Bfixed_version_id%5D%5B%5D=1184&v%5Bfixed_version_id%5D%5B%5D=1226&v%5Bfixed_version_id%5D%5B%5D=1312&v%5Bfixed_version_id%5D%5B%5D=1313&f%5B%5D=&c%5B%5D=tracker&c%5B%5D=status&c%5B%5D=priority&c%5B%5D=subject&c%5B%5D=author&c%5B%5D=assigned_to&c%5B%5D=updated_on&c%5B%5D=category&c%5B%5D=fixed_version&group_by=)
+Katello 3.16 includes 155 bug fixes, which can be seen [here](https://projects.theforeman.org/projects/katello/issues?utf8=%E2%9C%93&set_filter=1&sort=id%3Adesc&f%5B%5D=status_id&op%5Bstatus_id%5D=c&f%5B%5D=fixed_version_id&op%5Bfixed_version_id%5D=%3D&v%5Bfixed_version_id%5D%5B%5D=1184&v%5Bfixed_version_id%5D%5B%5D=1226&v%5Bfixed_version_id%5D%5B%5D=1308&v%5Bfixed_version_id%5D%5B%5D=1312&v%5Bfixed_version_id%5D%5B%5D=1313&f%5B%5D=tracker_id&op%5Btracker_id%5D=%3D&v%5Btracker_id%5D%5B%5D=1&f%5B%5D=&c%5B%5D=status&c%5B%5D=priority&c%5B%5D=subject&c%5B%5D=author&c%5B%5D=assigned_to&c%5B%5D=updated_on&c%5B%5D=category&c%5B%5D=fixed_version&group_by=)
 
 ## Contributors
 


### PR DESCRIPTION
3.16.2 is ready for release.

Note: It appears the number of bugs decreases because, for 3.16.1.2, the release note's bug count was for all issues, not just bugs. This has been fixed.