### PR TITLE
Use correct SCL for 3.18 and nightly upgrades

### DIFF
--- a/plugins/katello/3.18/installation/index.md
+++ b/plugins/katello/3.18/installation/index.md
@@ -69,6 +69,7 @@ subscription-manager repos --disable "*"
 subscription-manager repos --enable rhel-7-server-rpms
 subscription-manager repos --enable rhel-7-server-optional-rpms
 subscription-manager repos --enable rhel-7-server-extras-rpms
+subscription-manager repos --enable rhel-server-rhscl-7-rpms
 yum install -y yum-utils
 {% endhighlight %}
 </div>

--- a/plugins/katello/3.18/upgrade/index.md
+++ b/plugins/katello/3.18/upgrade/index.md
@@ -30,13 +30,27 @@ yum -y update
 
 Update the Foreman and Katello release packages:
 
-  * RHEL7 / CentOS 7:
+<p>Select your Operating System: <select id="operatingSystems">
+   <option value="rhel7">Red Hat Enterprise Linux 7</option>
+   <option value="el7">Enterprise Linux 7 (CentOS, etc.)</option>
+   </select>
+</p>
 
+<div id="rhel7" markdown="1">
 {% highlight bash %}
   yum update -y https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el7/x86_64/katello-repos-latest.rpm
   yum update -y https://yum.theforeman.org/releases/{{ page.foreman_version }}/el7/x86_64/foreman-release.rpm
-  yum update -y foreman-release-scl
+  subscription-manager repos --enable=rhel-server-rhscl-7-rpms
 {% endhighlight %}
+</div>
+
+<div id="el7" markdown="1">
+{% highlight bash %}
+  yum update -y https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el7/x86_64/katello-repos-latest.rpm
+  yum update -y https://yum.theforeman.org/releases/{{ page.foreman_version }}/el7/x86_64/foreman-release.rpm
+  yum install -y centos-release-scl-rh
+{% endhighlight %}
+</div>
 
 ## Step 4 - Update Packages
 

--- a/plugins/katello/nightly/installation/index.md
+++ b/plugins/katello/nightly/installation/index.md
@@ -70,6 +70,7 @@ subscription-manager repos --disable "*"
 subscription-manager repos --enable rhel-7-server-rpms
 subscription-manager repos --enable rhel-7-server-optional-rpms
 subscription-manager repos --enable rhel-7-server-extras-rpms
+subscription-manager repos --enable rhel-server-rhscl-7-rpms
 yum install -y yum-utils
 {% endhighlight %}
 </div>

--- a/plugins/katello/nightly/upgrade/index.md
+++ b/plugins/katello/nightly/upgrade/index.md
@@ -30,13 +30,27 @@ yum -y update
 
 Update the Foreman and Katello release packages:
 
-  * RHEL7 / CentOS 7:
+<p>Select your Operating System: <select id="operatingSystems">
+   <option value="rhel7">Red Hat Enterprise Linux 7</option>
+   <option value="el7">Enterprise Linux 7 (CentOS, etc.)</option>
+   </select>
+</p>
 
+<div id="rhel7" markdown="1">
 {% highlight bash %}
   yum update -y https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el7/x86_64/katello-repos-latest.rpm
   yum update -y https://yum.theforeman.org/releases/{{ page.foreman_version }}/el7/x86_64/foreman-release.rpm
-  yum update -y foreman-release-scl
+  subscription-manager repos --enable=rhel-server-rhscl-7-rpms
 {% endhighlight %}
+</div>
+
+<div id="el7" markdown="1">
+{% highlight bash %}
+  yum update -y https://fedorapeople.org/groups/katello/releases/yum/{{ page.version }}/katello/el7/x86_64/katello-repos-latest.rpm
+  yum update -y https://yum.theforeman.org/releases/{{ page.foreman_version }}/el7/x86_64/foreman-release.rpm
+  yum install -y centos-release-scl-rh
+{% endhighlight %}
+</div>
 
 ## Step 4 - Update Packages
 


### PR DESCRIPTION
Since version 3.18 there is no longer any `foreman-release-scl`

Installation docs were already updated but it looks like upgrades were missed