### PR TITLE
corrected latest version from 2.2.1 to 2.2.2

### DIFF
--- a/_includes/version.html
+++ b/_includes/version.html
@@ -3,7 +3,7 @@
     Latest versions:
       <a href="{{ site.baseurl }}manuals/2.3/index.html#Releasenotesfor2.3">2.3.1</a>
       /
-      <a href="{{ site.baseurl }}manuals/2.2/index.html#Releasenotesfor2.2">2.2.1</a>
+      <a href="{{ site.baseurl }}manuals/2.2/index.html#Releasenotesfor2.2">2.2.2</a>
       /
       <a href="{{ site.baseurl }}manuals/2.1/index.html#Releasenotesfor2.1">2.1.4</a>
   </p>


### PR DESCRIPTION
Latest 2.2 version on the theforeman.org front page seems to be wrong. Should be 2.2.2 not 2.2.1.