### PR TITLE
Rewrite upgrade instructions

### DIFF
--- a/_includes/manuals/2.4/3.6_upgrade.md
+++ b/_includes/manuals/2.4/3.6_upgrade.md
@@ -17,6 +17,30 @@ when planning to upgrade, as these change between releases. If your OS is no
 longer supported by Foreman, migrate or upgrade the OS (if supported) using a
 release of Foreman supported by both OS versions before upgrading Foreman.
 
+<script type="text/javascript">
+function update_upgrade_os(select) {
+  var os = select.value;
+  $(".upgrade_os").hide();
+  if (os) {
+    $(".upgrade_os_"+os).show();
+  } else {
+    $(".upgrade_os_none").show();
+  }
+}
+$(document).ready(function() {
+        $('#upgrade_os').trigger('change');
+});
+</script>
+
+To provide specific installation instructions, please select your operating system:
+<select id="upgrade_os" onChange="update_upgrade_os(this);">
+  <option value="none">-- select operating system --</option>
+  <option value="el7">CentOS 7 / Red Hat Enterprise Linux 7</option>
+  <option value="el8">CentOS 8 / Red Hat Enterprise Linux 8</option>
+  <option value="debian10">Debian 10 (Buster)</option>
+  <option value="ubuntu1804">Ubuntu 18.04 (Bionic)</option>
+</select>
+
 #### Step 1 - Backup
 
 It is recommended that you backup your database and modifications to Foreman
@@ -28,74 +52,117 @@ For more information about how to backup your instance head over to
 
 #### Step 2 - Perform the upgrade
 
-Before proceeding, it is necessary to shutdown the Foreman instance (e.g.
-`systemctl stop httpd foreman.service foreman.socket` or
-`systemctl stop apache foreman.service foreman.socket` usually).
+Before proceeding, it is necessary to shutdown the Foreman instance.
 
-Now it's time to perform the actual upgrade.  This process if different
-depending on how you downloaded Foreman.  You only need to perform *one* of
-the following options.
+<div class="upgrade_os upgrade_os_none">
+  <i>No operating system selected.</i>
+</div>
+<div class="upgrade_os upgrade_os_el7 upgrade_os_el8">
+{% highlight bash %}
+systemctl stop httpd foreman.service foreman.socket
+{% endhighlight %}
+</div>
+<div class="upgrade_os upgrade_os_debian10 upgrade_os_ubuntu1804">
+{% highlight bash %}
+systemctl stop apache foreman.service foreman.socket
+{% endhighlight %}
+</div>
 
-##### Step 2 (A) - RHEL package (RPM) and installer setups
+Now it's time to perform the actual upgrade.
 
+<div class="upgrade_os upgrade_os_none">
+  <i>No operating system selected.</i>
+</div>
+
+<div class="upgrade_os upgrade_os_el7">
 To upgrade an existing Foreman installation, first update with the
-appropriate foreman-release package for your operating system:
+appropriate foreman-release package:
 
-    yum upgrade https://yum.theforeman.org/releases/{{page.version}}/el7/x86_64/foreman-release.rpm
+{% highlight bash %}
+yum upgrade https://yum.theforeman.org/releases/{{page.version}}/el7/x86_64/foreman-release.rpm
+{% endhighlight %}
+
+Also make sure centos-release-scl-rh is up to date:
+
+{% highlight bash %}
+yum upgrade centos-release-scl-rh
+{% endhighlight %}
 
 Clean up the yum metadata cache:
 
-    yum clean metadata
-
-First install or upgrade the SCL release packages to add the RHSCL repository:
-
-    yum install centos-release-scl-rh
-
-or:
-
-    yum upgrade centos-release-scl-rh
-
-Clean up the yum metadata cache once more, to ensure the new repositories are used:
-
-    yum clean metadata
+{% highlight bash %}
+yum clean metadata
+{% endhighlight %}
 
 Next upgrade all Foreman packages:
 
-    yum upgrade tfm\* ruby\* foreman\*
+{% highlight bash %}
+yum upgrade tfm\* ruby\* foreman\*
+{% endhighlight %}
 
+Optionally, consider removing unused SCL packages:
 
-In order to catch all configuration changes and manage them properly you should install and run
-rpmconf from the EPEL repository along with vim-enhanced (for vimdiff):
+{% highlight bash %}
+yum erase rh-ruby22\* rh-ruby24\* rh-ror42\* tfm-ror52\*
+{% endhighlight %}
+</div>
 
-    rpmconf -a --frontend=vimdiff
+<div class="upgrade_os upgrade_os_el8">
+To upgrade an existing Foreman installation, first update with the
+appropriate foreman-release package:
 
-You can skip to Step 3.
+{% highlight bash %}
+dnf upgrade https://yum.theforeman.org/releases/{{page.version}}/el8/x86_64/foreman-release.rpm
+{% endhighlight %}
 
-##### Step 2 (B) - Debian or Ubuntu package (deb) and installer setups
+Clean up the yum metadata cache:
 
-Upgrading from the last release to {{page.version}} has been tested on both
-Debian and Ubuntu. Updating the packages will upgrade the application and
-automatically migrate the database.
+{% highlight bash %}
+dnf clean metadata
+{% endhighlight %}
+
+Next upgrade all Foreman packages:
+
+{% highlight bash %}
+dnf upgrade ruby\* foreman\*
+{% endhighlight %}
+</div>
+
+<div class="upgrade_os upgrade_os_debian10 upgrade_os_ubuntu1804">
+Upgrading from the last release to {{page.version}} has been tested. Updating
+the packages will upgrade the application and automatically migrate the
+database.
 
 First edit `/etc/apt/sources.list.d/foreman.list` and change the release
-number from the previous release or "stable" to `{{ page.version }}`:
+number from the previous release to `{{ page.version }}`:
 
-    deb http://deb.theforeman.org/ buster {{ page.version }}
-    deb http://deb.theforeman.org/ plugins {{ page.version }}
+<div class="upgrade_os upgrade_os_debian10">
+{% highlight bash %}
+deb http://deb.theforeman.org/ buster {{ page.version }}
+deb http://deb.theforeman.org/ plugins {{ page.version }}
+{% endhighlight %}
+</div>
+<div class="upgrade_os upgrade_os_ubuntu1804">
+{% highlight bash %}
+deb http://deb.theforeman.org/ bionic {{ page.version }}
+deb http://deb.theforeman.org/ plugins {{ page.version }}
+{% endhighlight %}
+</div>
 
 Next upgrade all Foreman packages:
 
-    apt-get update
-    apt-get --only-upgrade install ruby\* foreman\*
-
-You can skip to Step 3.
+{% highlight bash %}
+apt-get update
+apt-get --only-upgrade install ruby\* foreman\*
+{% endhighlight %}
+</div>
 
 #### Step 3 - Post-upgrade steps
 
 ##### Step 3 (A) - Database migration and cleanup
 
-The database should be migrated already, but you can make sure by executing the
-migration script again, it should produce no errors or output:
+Make sure by executing database is migrated. It should produce no errors or
+output:
 
     foreman-rake db:migrate
     foreman-rake db:seed
@@ -105,7 +172,13 @@ You should clear the cache and the existing sessions:
     foreman-rake tmp:cache:clear
     foreman-rake db:sessions:clear
 
-##### Optional Step 3 (B) - Run foreman-installer
+##### Optional Step 3 (B) - Reclaim database space
+
+After database migrations, some space can sometimes be reclaimed. It's a good idea to perform a *full* database vacuum for PostgreSQL rather than relying on the autovacuum feature to claim maximum space possible.
+
+    su - postgres -c 'vacuumdb --full --dbname=foreman'
+
+##### Optional Step 3 (C) - Run foreman-installer
 
 If you used foreman-installer to set up your existing Foreman instance we
 recommend running it again after upgrading. Note that the installer can
@@ -114,7 +187,7 @@ the installer in noop mode so you can see what would be changed.
 
 To see what would happen
 
-    foreman-installer --noop --dont-save-answers --verbose
+    foreman-installer --noop --verbose
 
 You may see ERRORS such as `/Stage[main]/Foreman_proxy::Register/Foreman_smartproxy[foreman-hostname.domain]:` `Could not evaluate: Connection refused - connect(2)` due to httpd / apache2 service being stopped.  These can be safely ignored.
 
@@ -122,33 +195,39 @@ To apply these changes, run the installer again without options
 
     foreman-installer
 
-#### Step 4 - Restart
+##### Optional Step 3 (D) - Update config files
+<div class="upgrade_os upgrade_os_none">
+  <i>*No operating system selected.*</i>
+</div>
+<div class="upgrade_os upgrade_os_el7">
+In order to catch all configuration changes and manage them properly you should install and run
+rpmconf from the EPEL repository along with vim-enhanced (for vimdiff).
 
-Restart the application server (e.g. mongrel, thin, passenger).
+{% highlight bash %}
+rpmconf -a --frontend=vimdiff
+{% endhighlight %}
+</div>
+<div class="upgrade_os upgrade_os_el8 upgrade_os_debian10 upgrade_os_ubuntu1804">
+This step is irrelevant for the chosen operating system.
+</div>
 
-On RPM installations, run:
+##### Step 4 - Restart
 
-    systemctl start httpd foreman.service foreman.socket
+Start the application server. This is redundant if you previously ran `foreman-installer` in step 3B.
 
-And on Debian/Ubuntu installations, run:
-
-    systemctl start apache foreman.service foreman.socket
-
-#### Optional Step 5 - Reclaim database space
-
-After database migrations, some space can sometimes be reclaimed. It's a good idea to perform a *full* database vacuum for PostgreSQL rather than relying on the autovacuum feature to claim maximum space possible. For PostgreSQL do the following:
-
-    foreman-maintain service stop --exclude postgresql
-    su - postgres -c 'vacuumdb --full --dbname=foreman'
-    foreman-maintain service start
-
-On platforms where foreman-maintain is not available, stop all Foreman-related services except PostgreSQL.
-
-#### Optional Step 6 - Cleanup of RPMs and repositories
-
-On EL7, consider removing unused SCL packages:
-
-    yum erase rh-ruby22\* rh-ruby24\* rh-ror42\* tfm-ror52\*
+<div class="upgrade_os upgrade_os_none">
+  <i>*No operating system selected.*</i>
+</div>
+<div class="upgrade_os upgrade_os_el7 upgrade_os_el8">
+{% highlight bash %}
+systemctl start httpd foreman.service foreman.socket
+{% endhighlight %}
+</div>
+<div class="upgrade_os upgrade_os_debian10 upgrade_os_ubuntu1804">
+{% highlight bash %}
+systemctl start apache foreman.service foreman.socket
+{% endhighlight %}
+</div>
 
 #### Common issues
 

--- a/_includes/manuals/2.4/3.6_upgrade.md
+++ b/_includes/manuals/2.4/3.6_upgrade.md
@@ -1,6 +1,3 @@
-
-### Upgrading to Foreman {{page.version}}
-
 #### Scope
 
 **These instructions apply to environments not using Katello**

--- a/_includes/manuals/2.4/3.6_upgrade.md
+++ b/_includes/manuals/2.4/3.6_upgrade.md
@@ -59,12 +59,12 @@ Before proceeding, it is necessary to shutdown the Foreman instance.
 </div>
 <div class="upgrade_os upgrade_os_el7 upgrade_os_el8">
 {% highlight bash %}
-systemctl stop httpd foreman.service foreman.socket
+systemctl stop httpd foreman.service foreman.socket dynflow\*
 {% endhighlight %}
 </div>
 <div class="upgrade_os upgrade_os_debian10 upgrade_os_ubuntu1804">
 {% highlight bash %}
-systemctl stop apache foreman.service foreman.socket
+systemctl stop apache foreman.service foreman.socket dynflow\*
 {% endhighlight %}
 </div>
 

--- a/_includes/manuals/2.4/3.6_upgrade.md
+++ b/_includes/manuals/2.4/3.6_upgrade.md
@@ -93,45 +93,6 @@ Next upgrade all Foreman packages:
 
 You can skip to Step 3.
 
-##### Step 2 (C) - Downloaded release (tar.bz2)
-
-- Uncompress the new program archive in a *new directory*.
-- Copy your database settings-file `config/database.yml` into the new `config` directory.
-
-VERY IMPORTANT: do NOT overwrite `config/settings.yml` with the old one.
-
-##### Step 2 (D) - git checkouts only
-
-*Please note* that there can be significant differences between stable and
-development branches.  You MUST take care to select a branch and make sure you
-get the correct one.
-
-1. Go to the Foreman root directory and run the following command:
-
-For staying on the stable branch:
-
-- git checkout {{page.version}}-stable
-- git pull
-
-There may have been changes to the ruby gem or node module versions, to update
-run the following commands:
-
-    bundle update
-    npm update
-
-The following step is the one that could change the contents of your database.
-Go to your new Foreman directory (or the git dir), then migrate and update the
-contents of your database:
-
-    foreman-rake db:migrate
-    foreman-rake db:seed
-
-You should compile i18n strings and precompile assets now:
-
-    foreman-rake locale:pack
-    foreman-rake assets:precompile RAILS_ENV=production
-    foreman-rake webpack:compile RAILS_ENV=production
-
 #### Step 3 - Post-upgrade steps
 
 ##### Step 3 (A) - Database migration and cleanup

--- a/_includes/manuals/2.4/3.6_upgrade.md
+++ b/_includes/manuals/2.4/3.6_upgrade.md
@@ -126,6 +126,27 @@ Next upgrade all Foreman packages:
 {% highlight bash %}
 dnf upgrade ruby\* foreman\*
 {% endhighlight %}
+
+Foreman runs best on PostgreSQL 12 but the default version on EL8 is 10. It is recommended to upgrade by [switching module streams](https://docs.fedoraproject.org/en-US/modularity/using-modules-switching-streams/).
+
+First check which version of PostgreSQL is currently installed:
+
+{% highlight bash %}
+rpm -qv postgresql-server
+{% endhighlight %}
+
+If you're already on 12 or don't have the PostgreSQL server installed, you can continue with step 3. Otherwise upgrade:
+
+{% highlight bash %}
+systemctl stop postgresql.service
+# https://bugzilla.redhat.com/1935301
+sed -i '/^data_directory =/d' /var/lib/pgsql/data/postgresql.conf
+dnf module reset postgresql
+dnf module install postgresql:12
+dnf install postgresql-upgrade
+postgresql-setup --upgrade
+systemctl start postgresql.service
+{% endhighlight %}
 </div>
 
 <div class="upgrade_os upgrade_os_debian10 upgrade_os_ubuntu1804">

--- a/_includes/manuals/nightly/3.6_upgrade.md
+++ b/_includes/manuals/nightly/3.6_upgrade.md
@@ -17,6 +17,30 @@ when planning to upgrade, as these change between releases. If your OS is no
 longer supported by Foreman, migrate or upgrade the OS (if supported) using a
 release of Foreman supported by both OS versions before upgrading Foreman.
 
+<script type="text/javascript">
+function update_upgrade_os(select) {
+  var os = select.value;
+  $(".upgrade_os").hide();
+  if (os) {
+    $(".upgrade_os_"+os).show();
+  } else {
+    $(".upgrade_os_none").show();
+  }
+}
+$(document).ready(function() {
+        $('#upgrade_os').trigger('change');
+});
+</script>
+
+To provide specific installation instructions, please select your operating system:
+<select id="upgrade_os" onChange="update_upgrade_os(this);">
+  <option value="none">-- select operating system --</option>
+  <option value="el7">CentOS 7 / Red Hat Enterprise Linux 7</option>
+  <option value="el8">CentOS 8 / Red Hat Enterprise Linux 8</option>
+  <option value="debian10">Debian 10 (Buster)</option>
+  <option value="ubuntu1804">Ubuntu 18.04 (Bionic)</option>
+</select>
+
 #### Step 1 - Backup
 
 It is recommended that you backup your database and modifications to Foreman
@@ -28,74 +52,117 @@ For more information about how to backup your instance head over to
 
 #### Step 2 - Perform the upgrade
 
-Before proceeding, it is necessary to shutdown the Foreman instance (e.g.
-`systemctl stop httpd foreman.service foreman.socket` or
-`systemctl stop apache foreman.service foreman.socket` usually).
+Before proceeding, it is necessary to shutdown the Foreman instance.
 
-Now it's time to perform the actual upgrade.  This process if different
-depending on how you downloaded Foreman.  You only need to perform *one* of
-the following options.
+<div class="upgrade_os upgrade_os_none">
+  <i>No operating system selected.</i>
+</div>
+<div class="upgrade_os upgrade_os_el7 upgrade_os_el8">
+{% highlight bash %}
+systemctl stop httpd foreman.service foreman.socket
+{% endhighlight %}
+</div>
+<div class="upgrade_os upgrade_os_debian10 upgrade_os_ubuntu1804">
+{% highlight bash %}
+systemctl stop apache foreman.service foreman.socket
+{% endhighlight %}
+</div>
 
-##### Step 2 (A) - RHEL package (RPM) and installer setups
+Now it's time to perform the actual upgrade.
 
+<div class="upgrade_os upgrade_os_none">
+  <i>No operating system selected.</i>
+</div>
+
+<div class="upgrade_os upgrade_os_el7">
 To upgrade an existing Foreman installation, first update with the
-appropriate foreman-release package for your operating system:
+appropriate foreman-release package:
 
-    yum upgrade https://yum.theforeman.org/releases/{{page.version}}/el7/x86_64/foreman-release.rpm
+{% highlight bash %}
+yum upgrade https://yum.theforeman.org/releases/{{page.version}}/el7/x86_64/foreman-release.rpm
+{% endhighlight %}
+
+Also make sure centos-release-scl-rh is up to date:
+
+{% highlight bash %}
+yum upgrade centos-release-scl-rh
+{% endhighlight %}
 
 Clean up the yum metadata cache:
 
-    yum clean metadata
-
-First install or upgrade the SCL release packages to add the RHSCL repository:
-
-    yum install centos-release-scl-rh
-
-or:
-
-    yum upgrade centos-release-scl-rh
-
-Clean up the yum metadata cache once more, to ensure the new repositories are used:
-
-    yum clean metadata
+{% highlight bash %}
+yum clean metadata
+{% endhighlight %}
 
 Next upgrade all Foreman packages:
 
-    yum upgrade tfm\* ruby\* foreman\*
+{% highlight bash %}
+yum upgrade tfm\* ruby\* foreman\*
+{% endhighlight %}
 
+Optionally, consider removing unused SCL packages:
 
-In order to catch all configuration changes and manage them properly you should install and run
-rpmconf from the EPEL repository along with vim-enhanced (for vimdiff):
+{% highlight bash %}
+yum erase rh-ruby22\* rh-ruby24\* rh-ror42\* tfm-ror52\*
+{% endhighlight %}
+</div>
 
-    rpmconf -a --frontend=vimdiff
+<div class="upgrade_os upgrade_os_el8">
+To upgrade an existing Foreman installation, first update with the
+appropriate foreman-release package:
 
-You can skip to Step 3.
+{% highlight bash %}
+dnf upgrade https://yum.theforeman.org/releases/{{page.version}}/el8/x86_64/foreman-release.rpm
+{% endhighlight %}
 
-##### Step 2 (B) - Debian or Ubuntu package (deb) and installer setups
+Clean up the yum metadata cache:
 
-Upgrading from the last release to {{page.version}} has been tested on both
-Debian and Ubuntu. Updating the packages will upgrade the application and
-automatically migrate the database.
+{% highlight bash %}
+dnf clean metadata
+{% endhighlight %}
+
+Next upgrade all Foreman packages:
+
+{% highlight bash %}
+dnf upgrade ruby\* foreman\*
+{% endhighlight %}
+</div>
+
+<div class="upgrade_os upgrade_os_debian10 upgrade_os_ubuntu1804">
+Upgrading from the last release to {{page.version}} has been tested. Updating
+the packages will upgrade the application and automatically migrate the
+database.
 
 First edit `/etc/apt/sources.list.d/foreman.list` and change the release
-number from the previous release or "stable" to `{{ page.version }}`:
+number from the previous release to `{{ page.version }}`:
 
-    deb http://deb.theforeman.org/ buster {{ page.version }}
-    deb http://deb.theforeman.org/ plugins {{ page.version }}
+<div class="upgrade_os upgrade_os_debian10">
+{% highlight bash %}
+deb http://deb.theforeman.org/ buster {{ page.version }}
+deb http://deb.theforeman.org/ plugins {{ page.version }}
+{% endhighlight %}
+</div>
+<div class="upgrade_os upgrade_os_ubuntu1804">
+{% highlight bash %}
+deb http://deb.theforeman.org/ bionic {{ page.version }}
+deb http://deb.theforeman.org/ plugins {{ page.version }}
+{% endhighlight %}
+</div>
 
 Next upgrade all Foreman packages:
 
-    apt-get update
-    apt-get --only-upgrade install ruby\* foreman\*
-
-You can skip to Step 3.
+{% highlight bash %}
+apt-get update
+apt-get --only-upgrade install ruby\* foreman\*
+{% endhighlight %}
+</div>
 
 #### Step 3 - Post-upgrade steps
 
 ##### Step 3 (A) - Database migration and cleanup
 
-The database should be migrated already, but you can make sure by executing the
-migration script again, it should produce no errors or output:
+Make sure by executing database is migrated. It should produce no errors or
+output:
 
     foreman-rake db:migrate
     foreman-rake db:seed
@@ -105,7 +172,13 @@ You should clear the cache and the existing sessions:
     foreman-rake tmp:cache:clear
     foreman-rake db:sessions:clear
 
-##### Optional Step 3 (B) - Run foreman-installer
+##### Optional Step 3 (B) - Reclaim database space
+
+After database migrations, some space can sometimes be reclaimed. It's a good idea to perform a *full* database vacuum for PostgreSQL rather than relying on the autovacuum feature to claim maximum space possible.
+
+    su - postgres -c 'vacuumdb --full --dbname=foreman'
+
+##### Optional Step 3 (C) - Run foreman-installer
 
 If you used foreman-installer to set up your existing Foreman instance we
 recommend running it again after upgrading. Note that the installer can
@@ -114,7 +187,7 @@ the installer in noop mode so you can see what would be changed.
 
 To see what would happen
 
-    foreman-installer --noop --dont-save-answers --verbose
+    foreman-installer --noop --verbose
 
 You may see ERRORS such as `/Stage[main]/Foreman_proxy::Register/Foreman_smartproxy[foreman-hostname.domain]:` `Could not evaluate: Connection refused - connect(2)` due to httpd / apache2 service being stopped.  These can be safely ignored.
 
@@ -122,33 +195,39 @@ To apply these changes, run the installer again without options
 
     foreman-installer
 
-#### Step 4 - Restart
+##### Optional Step 3 (D) - Update config files
+<div class="upgrade_os upgrade_os_none">
+  <i>*No operating system selected.*</i>
+</div>
+<div class="upgrade_os upgrade_os_el7">
+In order to catch all configuration changes and manage them properly you should install and run
+rpmconf from the EPEL repository along with vim-enhanced (for vimdiff).
 
-Restart the application server (e.g. mongrel, thin, passenger).
+{% highlight bash %}
+rpmconf -a --frontend=vimdiff
+{% endhighlight %}
+</div>
+<div class="upgrade_os upgrade_os_el8 upgrade_os_debian10 upgrade_os_ubuntu1804">
+This step is irrelevant for the chosen operating system.
+</div>
 
-On RPM installations, run:
+##### Step 4 - Restart
 
-    systemctl start httpd foreman.service foreman.socket
+Start the application server. This is redundant if you previously ran `foreman-installer` in step 3B.
 
-And on Debian/Ubuntu installations, run:
-
-    systemctl start apache foreman.service foreman.socket
-
-#### Optional Step 5 - Reclaim database space
-
-After database migrations, some space can sometimes be reclaimed. It's a good idea to perform a *full* database vacuum for PostgreSQL rather than relying on the autovacuum feature to claim maximum space possible. For PostgreSQL do the following:
-
-    foreman-maintain service stop --exclude postgresql
-    su - postgres -c 'vacuumdb --full --dbname=foreman'
-    foreman-maintain service start
-
-On platforms where foreman-maintain is not available, stop all Foreman-related services except PostgreSQL.
-
-#### Optional Step 6 - Cleanup of RPMs and repositories
-
-On EL7, consider removing unused SCL packages:
-
-    yum erase rh-ruby22\* rh-ruby24\* rh-ror42\* tfm-ror52\*
+<div class="upgrade_os upgrade_os_none">
+  <i>*No operating system selected.*</i>
+</div>
+<div class="upgrade_os upgrade_os_el7 upgrade_os_el8">
+{% highlight bash %}
+systemctl start httpd foreman.service foreman.socket
+{% endhighlight %}
+</div>
+<div class="upgrade_os upgrade_os_debian10 upgrade_os_ubuntu1804">
+{% highlight bash %}
+systemctl start apache foreman.service foreman.socket
+{% endhighlight %}
+</div>
 
 #### Common issues
 

--- a/_includes/manuals/nightly/3.6_upgrade.md
+++ b/_includes/manuals/nightly/3.6_upgrade.md
@@ -1,6 +1,3 @@
-
-### Upgrading to Foreman {{page.version}}
-
 #### Scope
 
 **These instructions apply to environments not using Katello**

--- a/_includes/manuals/nightly/3.6_upgrade.md
+++ b/_includes/manuals/nightly/3.6_upgrade.md
@@ -59,12 +59,12 @@ Before proceeding, it is necessary to shutdown the Foreman instance.
 </div>
 <div class="upgrade_os upgrade_os_el7 upgrade_os_el8">
 {% highlight bash %}
-systemctl stop httpd foreman.service foreman.socket
+systemctl stop httpd foreman.service foreman.socket dynflow\*
 {% endhighlight %}
 </div>
 <div class="upgrade_os upgrade_os_debian10 upgrade_os_ubuntu1804">
 {% highlight bash %}
-systemctl stop apache foreman.service foreman.socket
+systemctl stop apache foreman.service foreman.socket dynflow\*
 {% endhighlight %}
 </div>
 

--- a/_includes/manuals/nightly/3.6_upgrade.md
+++ b/_includes/manuals/nightly/3.6_upgrade.md
@@ -93,45 +93,6 @@ Next upgrade all Foreman packages:
 
 You can skip to Step 3.
 
-##### Step 2 (C) - Downloaded release (tar.bz2)
-
-- Uncompress the new program archive in a *new directory*.
-- Copy your database settings-file `config/database.yml` into the new `config` directory.
-
-VERY IMPORTANT: do NOT overwrite `config/settings.yml` with the old one.
-
-##### Step 2 (D) - git checkouts only
-
-*Please note* that there can be significant differences between stable and
-development branches.  You MUST take care to select a branch and make sure you
-get the correct one.
-
-1. Go to the Foreman root directory and run the following command:
-
-For staying on the stable branch:
-
-- git checkout {{page.version}}-stable
-- git pull
-
-There may have been changes to the ruby gem or node module versions, to update
-run the following commands:
-
-    bundle update
-    npm update
-
-The following step is the one that could change the contents of your database.
-Go to your new Foreman directory (or the git dir), then migrate and update the
-contents of your database:
-
-    foreman-rake db:migrate
-    foreman-rake db:seed
-
-You should compile i18n strings and precompile assets now:
-
-    foreman-rake locale:pack
-    foreman-rake assets:precompile RAILS_ENV=production
-    foreman-rake webpack:compile RAILS_ENV=production
-
 #### Step 3 - Post-upgrade steps
 
 ##### Step 3 (A) - Database migration and cleanup

--- a/manuals/2.4/index.md
+++ b/manuals/2.4/index.md
@@ -62,7 +62,7 @@ previous_version: "2.3"
 {%include manuals/{{ page.version }}/3.5.5_facts_and_the_enc.md %}
 ### 3.5.6 CLI
 {%include manuals/{{ page.version }}/3.5.6_cli.md %}
-## 3.6 Upgrade
+## 3.6 Upgrade to {{ page.version }}
 {%include manuals/{{ page.version }}/3.6_upgrade.md %}
 
 # 4. General Foreman

--- a/manuals/nightly/index.md
+++ b/manuals/nightly/index.md
@@ -62,7 +62,7 @@ previous_version: "2.4"
 {%include manuals/{{ page.version }}/3.5.5_facts_and_the_enc.md %}
 ### 3.5.6 CLI
 {%include manuals/{{ page.version }}/3.5.6_cli.md %}
-## 3.6 Upgrade
+## 3.6 Upgrade to {{ page.version }}
 {%include manuals/{{ page.version }}/3.6_upgrade.md %}
 
 # 4. General Foreman


### PR DESCRIPTION
This limits the manual to RPM/deb packages since that's what most users use. Those who use git or tarballs are expected to handle it themselves.

In the next commit it copies the OS selector from the quickstart. This makes the upgrade instructions shorter since you don't need to skip over irrelevant OSes. For users this is less confusing.

It also removes the foreman-maintain reference. This can be done by moving the cleanup step to a point where the services should be stopped anyway.  Avoiding a start-stop cycle makes the overall process shorter. The noop command removes the redundant --dont-save-answers. --noop already implies that.

With all of this in place it's easy to add PostgreSQL upgrade instructions only on EL8. In the previous structure it would have been too confusing.