### PR TITLE
Add puppet ENC deprecation warning

### DIFF
--- a/_includes/manuals/2.4/1.2_release_notes.md
+++ b/_includes/manuals/2.4/1.2_release_notes.md
@@ -254,6 +254,20 @@ See the upgrade warnings for more information.
 
 Foreman 2.1 started to default to Puma while still allowing to fall back to Passenger. This support was kept in for users who ran into problems. Now that it has been the default for a few releases, this release deprecates Passenger support which [will be removed in the future](https://community.theforeman.org/t/drop-passenger-support/22787). Users are strongly encouraged to switch to Puma or reach out if there's something holding them back.
 
+#### Puppet ENC
+
+Puppet specific ENC functionality is deprecated and [will be moved to a plugin in the future](https://community.theforeman.org/t/puppet-plugin-release-and-its-future/22335).
+
+Features to be removed include:
+* Environment
+* Puppetclass
+* ConfigGroup
+* SmartClassParameter
+
+Endpoint `/enc` will continue to provide information about the Host, but without the removed information.
+Users who want to continue using these features are advised to [follow the Puppet plugin stabilization](https://projects.theforeman.org/issues/32182) and install it alongside the next Foreman version or report any issues holding them from doing so.
+
+
 ### Upgrade warnings
 
 #### TLS 1.2+ by default


### PR DESCRIPTION
We have introduced deprecation warning in https://projects.theforeman.org/issues/30215
This adds the deprecation warning to the deprecation notes.