### PR TITLE
Deprecate support for Puppet 5

### DIFF
--- a/_includes/manuals/2.4/1.2_release_notes.md
+++ b/_includes/manuals/2.4/1.2_release_notes.md
@@ -293,6 +293,10 @@ Features to be removed include:
 Endpoint `/enc` will continue to provide information about the Host, but without the removed information.
 Users who want to continue using these features are advised to [follow the Puppet plugin stabilization](https://projects.theforeman.org/issues/32182) and install it alongside the next Foreman version or report any issues holding them from doing so.
 
+#### Puppet 5
+
+Puppet 5 is officially End of Life. Foreman {{page.version}} still supports Puppet 5, but in a future release this will be removed.
+
 ### Upgrade warnings
 
 #### TLS 1.2+ by default

--- a/_includes/manuals/nightly/1.2_release_notes.md
+++ b/_includes/manuals/nightly/1.2_release_notes.md
@@ -8,6 +8,10 @@ This section will be updated prior to the next release.
 
 ### Deprecations
 
+#### Puppet 5
+
+Puppet 5 is officially End of Life. Foreman {{page.version}} still supports Puppet 5, but in a future release this will be removed.
+
 ### Upgrade warnings
 
 ### Contributors


### PR DESCRIPTION
Since Puppet 5 is EOL now, it's good to make a statement about it.