### PR TITLE
Move Release Notes to after Upgrade warnings

### DIFF
--- a/_includes/manuals/nightly/1.2_release_notes.md
+++ b/_includes/manuals/nightly/1.2_release_notes.md
@@ -4,8 +4,6 @@ This section will be updated prior to the next release.
 
 ### Headline features
 
-### Release Notes
-
 ### Deprecations
 
 #### Puppet 5
@@ -13,6 +11,8 @@ This section will be updated prior to the next release.
 Puppet 5 is officially End of Life. Foreman {{page.version}} still supports Puppet 5, but in a future release this will be removed.
 
 ### Upgrade warnings
+
+### Release Notes
 
 ### Contributors
 


### PR DESCRIPTION
Releases notes can be long and cause users to miss the important bits. It is more important that users read Headline features, deprecations and upgrade warnings than the full release notes. This new order should make that easier.