### PR TITLE
Add an upgrade warning about mod_passenger removal

### DIFF
--- a/_includes/manuals/nightly/1.2_release_notes.md
+++ b/_includes/manuals/nightly/1.2_release_notes.md
@@ -10,6 +10,10 @@ Packages for Foreman and its various plug-ins are now being built for Ubuntu 20.
 
 ### Upgrade warnings
 
+#### Removal of mod_passenger support
+
+After defaulting to Puma in Foreman 2.1 and deprecation in Foreman 2.4, support for [mod_passenger is dropped](https://community.theforeman.org/t/drop-passenger-support/22787). The packages have been dropped and the installer can no longer configure it. Users who upgrade using the installer will be migrated automatically but users who upgrade without the installer must take care of this themselves.
+
 ### Deprecations
 
 #### Puppet host methods in templates

--- a/_includes/manuals/nightly/1.2_release_notes.md
+++ b/_includes/manuals/nightly/1.2_release_notes.md
@@ -8,6 +8,8 @@ This section will be updated prior to the next release.
 
 Packages for Foreman and its various plug-ins are now being built for Ubuntu 20.04 (Focal) as well.
 
+### Upgrade warnings
+
 ### Deprecations
 
 #### Puppet host methods in templates
@@ -22,8 +24,6 @@ This is the list of deprecated methods and their successor:
 #### Puppet 5
 
 Puppet 5 is officially End of Life. Foreman {{page.version}} still supports Puppet 5, but in a future release this will be removed.
-
-### Upgrade warnings
 
 ### Release Notes
 


### PR DESCRIPTION
This doesn't feel like something that is a headline feature but certainly something users must know.

Similar to 102b1b4f3de42a976790fc46ca66994adcf766c5, Upgrade warnings are more important than deprecations and should be read first. That's also included in a separate commit.