### PR TITLE
Fixing links to puppet ENC and report scripts

### DIFF
--- a/_includes/manuals/1.10/3.5.4_puppet_reports.md
+++ b/_includes/manuals/1.10/3.5.4_puppet_reports.md
@@ -19,7 +19,7 @@ First identify the directory containing report processors, e.g.
 * Debian or Ubuntu: /usr/lib/ruby/vendor_ruby/puppet/reports/
 * other OSes, look for tagmail.rb in the Puppet installation (`locate tagmail.rb`)
 
-Copy [the report processor source](https://raw.githubusercontent.com/theforeman/puppet-foreman/master/files/foreman-report_v2.rb) to this report directory and name it `foreman.rb`.
+Copy [the report processor source](https://raw.githubusercontent.com/theforeman/puppet-puppetserver_foreman/master/files/report.rb) to this report directory and name it `foreman.rb`.
 
 Create a new configuration file at `/etc/puppet/foreman.yaml` containing:
 <pre>

--- a/_includes/manuals/1.11/3.5.4_puppet_reports.md
+++ b/_includes/manuals/1.11/3.5.4_puppet_reports.md
@@ -19,7 +19,7 @@ First identify the directory containing report processors, e.g.
 * Debian or Ubuntu: /usr/lib/ruby/vendor_ruby/puppet/reports/
 * other OSes, look for tagmail.rb in the Puppet installation (`locate tagmail.rb`)
 
-Copy [the report processor source](https://raw.githubusercontent.com/theforeman/puppet-foreman/master/files/foreman-report_v2.rb) to this report directory and name it `foreman.rb`.
+Copy [the report processor source](https://raw.githubusercontent.com/theforeman/puppet-puppetserver_foreman/master/files/report.rb) to this report directory and name it `foreman.rb`.
 
 Create a new configuration file at `/etc/puppet/foreman.yaml` containing:
 <pre>

--- a/_includes/manuals/1.12/3.5.4_puppet_reports.md
+++ b/_includes/manuals/1.12/3.5.4_puppet_reports.md
@@ -20,7 +20,7 @@ First identify the directory containing report processors, e.g.
 * Debian or Ubuntu: /usr/lib/ruby/vendor_ruby/puppet/reports/
 * other OSes, look for tagmail.rb in the Puppet installation (`locate tagmail.rb`)
 
-Copy [the report processor source](https://raw.githubusercontent.com/theforeman/puppet-foreman/master/files/foreman-report_v2.rb) to this report directory and name it `foreman.rb`.
+Copy [the report processor source](https://raw.githubusercontent.com/theforeman/puppet-puppetserver_foreman/master/files/report.rb) to this report directory and name it `foreman.rb`.
 
 Create a new configuration file at `/etc/puppetlabs/puppet/foreman.yaml` (Puppet 4 AIO) or `/etc/puppet/foreman.yaml` (non-AIO) containing:
 <pre>

--- a/_includes/manuals/1.12/3.5.5_facts_and_the_enc.md
+++ b/_includes/manuals/1.12/3.5.5_facts_and_the_enc.md
@@ -7,7 +7,7 @@ The external nodes script we supply also deals with uploading facts from hosts t
 
 ##### Puppet master
 
-Download [the ENC script](https://raw.githubusercontent.com/theforeman/puppet-foreman/master/files/external_node_v2.rb) to `/etc/puppetlabs/puppet/node.rb` (Puppet 4 AIO) or `/etc/puppet/node.rb` (non-AIO). The name is arbitrary, but must match configuration below, and ensure it's executable by "puppet" with `chmod +x /etc/puppet/node.rb`.
+Download [the ENC script](https://raw.githubusercontent.com/theforeman/puppet-puppetserver_foreman/master/files/enc.rb) to `/etc/puppetlabs/puppet/node.rb` (Puppet 4 AIO) or `/etc/puppet/node.rb` (non-AIO). The name is arbitrary, but must match configuration below, and ensure it's executable by "puppet" with `chmod +x /etc/puppet/node.rb`.
 
 Unless it already exists from setting up reporting, create a new configuration file at `/etc/puppetlabs/puppet/foreman.yaml` (Puppet 4 AIO) or `/etc/puppet/foreman.yaml` (non-AIO) containing
 
@@ -146,4 +146,4 @@ supplied. The 'facts' hash must be a flat hash, not nested with other arrays or 
 See _link-to-API-when-its-updated-here_ for more details.
 
 This body can be POSTed to '/api/hosts/facts' using Foreman API v2. See the
-[node.rb template](https://github.com/theforeman/puppet-foreman/blob/master/files/external_node_v2.rb) for an example of constructing and sending data in Ruby.
+[node.rb template](https://raw.githubusercontent.com/theforeman/puppet-puppetserver_foreman/master/files/enc.rb) for an example of constructing and sending data in Ruby.

--- a/_includes/manuals/1.13/3.5.4_puppet_reports.md
+++ b/_includes/manuals/1.13/3.5.4_puppet_reports.md
@@ -20,7 +20,7 @@ First identify the directory containing report processors, e.g.
 * Debian or Ubuntu: /usr/lib/ruby/vendor_ruby/puppet/reports/
 * other OSes, look for tagmail.rb in the Puppet installation (`locate tagmail.rb`)
 
-Copy [the report processor source](https://raw.githubusercontent.com/theforeman/puppet-foreman/master/files/foreman-report_v2.rb) to this report directory and name it `foreman.rb`.
+Copy [the report processor source](https://raw.githubusercontent.com/theforeman/puppet-puppetserver_foreman/master/files/report.rb) to this report directory and name it `foreman.rb`.
 
 Create a new configuration file at `/etc/puppetlabs/puppet/foreman.yaml` (Puppet 4 AIO) or `/etc/puppet/foreman.yaml` (non-AIO) containing:
 <pre>

--- a/_includes/manuals/1.13/3.5.5_facts_and_the_enc.md
+++ b/_includes/manuals/1.13/3.5.5_facts_and_the_enc.md
@@ -7,7 +7,7 @@ The external nodes script we supply also deals with uploading facts from hosts t
 
 ##### Puppet master
 
-Download [the ENC script](https://raw.githubusercontent.com/theforeman/puppet-foreman/master/files/external_node_v2.rb) to `/etc/puppetlabs/puppet/node.rb` (Puppet 4 AIO) or `/etc/puppet/node.rb` (non-AIO). The name is arbitrary, but must match configuration below, and ensure it's executable by "puppet" with `chmod +x /etc/puppet/node.rb`.
+Download [the ENC script](https://raw.githubusercontent.com/theforeman/puppet-puppetserver_foreman/master/files/enc.rb) to `/etc/puppetlabs/puppet/node.rb` (Puppet 4 AIO) or `/etc/puppet/node.rb` (non-AIO). The name is arbitrary, but must match configuration below, and ensure it's executable by "puppet" with `chmod +x /etc/puppet/node.rb`.
 
 Unless it already exists from setting up reporting, create a new configuration file at `/etc/puppetlabs/puppet/foreman.yaml` (Puppet 4 AIO) or `/etc/puppet/foreman.yaml` (non-AIO) containing
 
@@ -146,4 +146,4 @@ supplied. The 'facts' hash must be a flat hash, not nested with other arrays or 
 See _link-to-API-when-its-updated-here_ for more details.
 
 This body can be POSTed to '/api/hosts/facts' using Foreman API v2. See the
-[node.rb template](https://github.com/theforeman/puppet-foreman/blob/master/files/external_node_v2.rb) for an example of constructing and sending data in Ruby.
+[node.rb template](https://raw.githubusercontent.com/theforeman/puppet-puppetserver_foreman/master/files/enc.rb) for an example of constructing and sending data in Ruby.

--- a/_includes/manuals/1.14/3.5.4_puppet_reports.md
+++ b/_includes/manuals/1.14/3.5.4_puppet_reports.md
@@ -20,7 +20,7 @@ First identify the directory containing report processors, e.g.
 * Debian or Ubuntu: /usr/lib/ruby/vendor_ruby/puppet/reports/
 * other OSes, look for tagmail.rb in the Puppet installation (`locate tagmail.rb`)
 
-Copy [the report processor source](https://raw.githubusercontent.com/theforeman/puppet-foreman/master/files/foreman-report_v2.rb) to this report directory and name it `foreman.rb`.
+Copy [the report processor source](https://raw.githubusercontent.com/theforeman/puppet-puppetserver_foreman/master/files/report.rb) to this report directory and name it `foreman.rb`.
 
 Create a new configuration file at `/etc/puppetlabs/puppet/foreman.yaml` (Puppet 4 AIO) or `/etc/puppet/foreman.yaml` (non-AIO) containing:
 <pre>

--- a/_includes/manuals/1.14/3.5.5_facts_and_the_enc.md
+++ b/_includes/manuals/1.14/3.5.5_facts_and_the_enc.md
@@ -7,7 +7,7 @@ The external nodes script we supply also deals with uploading facts from hosts t
 
 ##### Puppet master
 
-Download [the ENC script](https://raw.githubusercontent.com/theforeman/puppet-foreman/master/files/external_node_v2.rb) to `/etc/puppetlabs/puppet/node.rb` (Puppet 4 AIO) or `/etc/puppet/node.rb` (non-AIO). The name is arbitrary, but must match configuration below, and ensure it's executable by "puppet" with `chmod +x /etc/puppet/node.rb`.
+Download [the ENC script](https://raw.githubusercontent.com/theforeman/puppet-puppetserver_foreman/master/files/enc.rb) to `/etc/puppetlabs/puppet/node.rb` (Puppet 4 AIO) or `/etc/puppet/node.rb` (non-AIO). The name is arbitrary, but must match configuration below, and ensure it's executable by "puppet" with `chmod +x /etc/puppet/node.rb`.
 
 Unless it already exists from setting up reporting, create a new configuration file at `/etc/puppetlabs/puppet/foreman.yaml` (Puppet 4 AIO) or `/etc/puppet/foreman.yaml` (non-AIO) containing
 
@@ -146,4 +146,4 @@ supplied. The 'facts' hash must be a flat hash, not nested with other arrays or 
 See _link-to-API-when-its-updated-here_ for more details.
 
 This body can be POSTed to '/api/hosts/facts' using Foreman API v2. See the
-[node.rb template](https://github.com/theforeman/puppet-foreman/blob/master/files/external_node_v2.rb) for an example of constructing and sending data in Ruby.
+[node.rb template](https://raw.githubusercontent.com/theforeman/puppet-puppetserver_foreman/master/files/enc.rb) for an example of constructing and sending data in Ruby.

--- a/_includes/manuals/1.15/3.5.4_puppet_reports.md
+++ b/_includes/manuals/1.15/3.5.4_puppet_reports.md
@@ -20,7 +20,7 @@ First identify the directory containing report processors, e.g.
 * Debian or Ubuntu: /usr/lib/ruby/vendor_ruby/puppet/reports/
 * other OSes, look for tagmail.rb in the Puppet installation (`locate tagmail.rb`)
 
-Copy [the report processor source](https://raw.githubusercontent.com/theforeman/puppet-foreman/master/files/foreman-report_v2.rb) to this report directory and name it `foreman.rb`.
+Copy [the report processor source](https://raw.githubusercontent.com/theforeman/puppet-puppetserver_foreman/master/files/report.rb) to this report directory and name it `foreman.rb`.
 
 Create a new configuration file at `/etc/puppetlabs/puppet/foreman.yaml` (Puppet 4 AIO) or `/etc/puppet/foreman.yaml` (non-AIO) containing:
 <pre>

--- a/_includes/manuals/1.15/3.5.5_facts_and_the_enc.md
+++ b/_includes/manuals/1.15/3.5.5_facts_and_the_enc.md
@@ -7,7 +7,7 @@ The external nodes script we supply also deals with uploading facts from hosts t
 
 ##### Puppet master
 
-Download [the ENC script](https://raw.githubusercontent.com/theforeman/puppet-foreman/master/files/external_node_v2.rb) to `/etc/puppetlabs/puppet/node.rb` (Puppet 4 AIO) or `/etc/puppet/node.rb` (non-AIO). The name is arbitrary, but must match configuration below, and ensure it's executable by "puppet" with `chmod +x /etc/puppet/node.rb`.
+Download [the ENC script](https://raw.githubusercontent.com/theforeman/puppet-puppetserver_foreman/master/files/enc.rb) to `/etc/puppetlabs/puppet/node.rb` (Puppet 4 AIO) or `/etc/puppet/node.rb` (non-AIO). The name is arbitrary, but must match configuration below, and ensure it's executable by "puppet" with `chmod +x /etc/puppet/node.rb`.
 
 Unless it already exists from setting up reporting, create a new configuration file at `/etc/puppetlabs/puppet/foreman.yaml` (Puppet 4 AIO) or `/etc/puppet/foreman.yaml` (non-AIO) containing
 
@@ -146,4 +146,4 @@ supplied. The 'facts' hash must be a flat hash, not nested with other arrays or 
 See _link-to-API-when-its-updated-here_ for more details.
 
 This body can be POSTed to '/api/hosts/facts' using Foreman API v2. See the
-[node.rb template](https://github.com/theforeman/puppet-foreman/blob/master/files/external_node_v2.rb) for an example of constructing and sending data in Ruby.
+[node.rb template](https://raw.githubusercontent.com/theforeman/puppet-puppetserver_foreman/master/files/enc.rb) for an example of constructing and sending data in Ruby.

--- a/_includes/manuals/1.16/3.5.4_puppet_reports.md
+++ b/_includes/manuals/1.16/3.5.4_puppet_reports.md
@@ -20,7 +20,7 @@ First identify the directory containing report processors, e.g.
 * Debian or Ubuntu: /usr/lib/ruby/vendor_ruby/puppet/reports/
 * other OSes, look for tagmail.rb in the Puppet installation (`locate tagmail.rb`)
 
-Copy [the report processor source](https://raw.githubusercontent.com/theforeman/puppet-foreman/master/files/foreman-report_v2.rb) to this report directory and name it `foreman.rb`.
+Copy [the report processor source](https://raw.githubusercontent.com/theforeman/puppet-puppetserver_foreman/master/files/report.rb) to this report directory and name it `foreman.rb`.
 
 Create a new configuration file at `/etc/puppetlabs/puppet/foreman.yaml` (Puppet 4 AIO) or `/etc/puppet/foreman.yaml` (non-AIO) containing:
 <pre>

--- a/_includes/manuals/1.16/3.5.5_facts_and_the_enc.md
+++ b/_includes/manuals/1.16/3.5.5_facts_and_the_enc.md
@@ -7,7 +7,7 @@ The external nodes script we supply also deals with uploading facts from hosts t
 
 ##### Puppet master
 
-Download [the ENC script](https://raw.githubusercontent.com/theforeman/puppet-foreman/master/files/external_node_v2.rb) to `/etc/puppetlabs/puppet/node.rb` (Puppet 4 AIO) or `/etc/puppet/node.rb` (non-AIO). The name is arbitrary, but must match configuration below, and ensure it's executable by "puppet" with `chmod +x /etc/puppet/node.rb`.
+Download [the ENC script](https://raw.githubusercontent.com/theforeman/puppet-puppetserver_foreman/master/files/enc.rb) to `/etc/puppetlabs/puppet/node.rb` (Puppet 4 AIO) or `/etc/puppet/node.rb` (non-AIO). The name is arbitrary, but must match configuration below, and ensure it's executable by "puppet" with `chmod +x /etc/puppet/node.rb`.
 
 Unless it already exists from setting up reporting, create a new configuration file at `/etc/puppetlabs/puppet/foreman.yaml` (Puppet 4 AIO) or `/etc/puppet/foreman.yaml` (non-AIO) containing
 
@@ -146,4 +146,4 @@ supplied. The 'facts' hash must be a flat hash, not nested with other arrays or 
 See _link-to-API-when-its-updated-here_ for more details.
 
 This body can be POSTed to '/api/hosts/facts' using Foreman API v2. See the
-[node.rb template](https://github.com/theforeman/puppet-foreman/blob/master/files/external_node_v2.rb) for an example of constructing and sending data in Ruby.
+[node.rb template](https://raw.githubusercontent.com/theforeman/puppet-puppetserver_foreman/master/files/enc.rb) for an example of constructing and sending data in Ruby.

--- a/_includes/manuals/1.17/3.5.4_puppet_reports.md
+++ b/_includes/manuals/1.17/3.5.4_puppet_reports.md
@@ -20,7 +20,7 @@ First identify the directory containing report processors, e.g.
 * Debian or Ubuntu: /usr/lib/ruby/vendor_ruby/puppet/reports/
 * other OSes, look for tagmail.rb in the Puppet installation (`locate tagmail.rb`)
 
-Copy [the report processor source](https://raw.githubusercontent.com/theforeman/puppet-foreman/master/files/foreman-report_v2.rb) to this report directory and name it `foreman.rb`.
+Copy [the report processor source](https://raw.githubusercontent.com/theforeman/puppet-puppetserver_foreman/master/files/report.rb) to this report directory and name it `foreman.rb`.
 
 Create a new configuration file at `/etc/puppetlabs/puppet/foreman.yaml` (Puppet 4 AIO) or `/etc/puppet/foreman.yaml` (non-AIO) containing:
 <pre>

--- a/_includes/manuals/1.17/3.5.5_facts_and_the_enc.md
+++ b/_includes/manuals/1.17/3.5.5_facts_and_the_enc.md
@@ -7,7 +7,7 @@ The external nodes script we supply also deals with uploading facts from hosts t
 
 ##### Puppet master
 
-Download [the ENC script](https://raw.githubusercontent.com/theforeman/puppet-foreman/master/files/external_node_v2.rb) to `/etc/puppetlabs/puppet/node.rb` (Puppet 4 AIO) or `/etc/puppet/node.rb` (non-AIO). The name is arbitrary, but must match configuration below, and ensure it's executable by "puppet" with `chmod +x /etc/puppet/node.rb`.
+Download [the ENC script](https://raw.githubusercontent.com/theforeman/puppet-puppetserver_foreman/master/files/enc.rb) to `/etc/puppetlabs/puppet/node.rb` (Puppet 4 AIO) or `/etc/puppet/node.rb` (non-AIO). The name is arbitrary, but must match configuration below, and ensure it's executable by "puppet" with `chmod +x /etc/puppet/node.rb`.
 
 Unless it already exists from setting up reporting, create a new configuration file at `/etc/puppetlabs/puppet/foreman.yaml` (Puppet 4 AIO) or `/etc/puppet/foreman.yaml` (non-AIO) containing
 
@@ -146,4 +146,4 @@ supplied. The 'facts' hash must be a flat hash, not nested with other arrays or 
 See _link-to-API-when-its-updated-here_ for more details.
 
 This body can be POSTed to '/api/hosts/facts' using Foreman API v2. See the
-[node.rb template](https://github.com/theforeman/puppet-foreman/blob/master/files/external_node_v2.rb) for an example of constructing and sending data in Ruby.
+[node.rb template](https://raw.githubusercontent.com/theforeman/puppet-puppetserver_foreman/master/files/enc.rb) for an example of constructing and sending data in Ruby.

--- a/_includes/manuals/1.18/3.5.4_puppet_reports.md
+++ b/_includes/manuals/1.18/3.5.4_puppet_reports.md
@@ -20,7 +20,7 @@ First identify the directory containing report processors, e.g.
 * Debian or Ubuntu: /usr/lib/ruby/vendor_ruby/puppet/reports/
 * other OSes, look for tagmail.rb in the Puppet installation (`locate tagmail.rb`)
 
-Copy [the report processor source](https://raw.githubusercontent.com/theforeman/puppet-foreman/master/files/foreman-report_v2.rb) to this report directory and name it `foreman.rb`.
+Copy [the report processor source](https://raw.githubusercontent.com/theforeman/puppet-puppetserver_foreman/master/files/report.rb) to this report directory and name it `foreman.rb`.
 
 Create a new configuration file at `/etc/puppetlabs/puppet/foreman.yaml` (Puppet 4 AIO) or `/etc/puppet/foreman.yaml` (non-AIO) containing:
 <pre>

--- a/_includes/manuals/1.18/3.5.5_facts_and_the_enc.md
+++ b/_includes/manuals/1.18/3.5.5_facts_and_the_enc.md
@@ -7,7 +7,7 @@ The external nodes script we supply also deals with uploading facts from hosts t
 
 ##### Puppet master
 
-Download [the ENC script](https://raw.githubusercontent.com/theforeman/puppet-foreman/master/files/external_node_v2.rb) to `/etc/puppetlabs/puppet/node.rb` (Puppet 4 AIO) or `/etc/puppet/node.rb` (non-AIO). The name is arbitrary, but must match configuration below, and ensure it's executable by "puppet" with `chmod +x /etc/puppet/node.rb`.
+Download [the ENC script](https://raw.githubusercontent.com/theforeman/puppet-puppetserver_foreman/master/files/enc.rb) to `/etc/puppetlabs/puppet/node.rb` (Puppet 4 AIO) or `/etc/puppet/node.rb` (non-AIO). The name is arbitrary, but must match configuration below, and ensure it's executable by "puppet" with `chmod +x /etc/puppet/node.rb`.
 
 Unless it already exists from setting up reporting, create a new configuration file at `/etc/puppetlabs/puppet/foreman.yaml` (Puppet 4 AIO) or `/etc/puppet/foreman.yaml` (non-AIO) containing
 
@@ -154,4 +154,4 @@ supplied. The 'facts' hash must be a flat hash, not nested with other arrays or 
 See _link-to-API-when-its-updated-here_ for more details.
 
 This body can be POSTed to '/api/hosts/facts' using Foreman API v2. See the
-[node.rb template](https://github.com/theforeman/puppet-foreman/blob/master/files/external_node_v2.rb) for an example of constructing and sending data in Ruby.
+[node.rb template](https://raw.githubusercontent.com/theforeman/puppet-puppetserver_foreman/master/files/enc.rb) for an example of constructing and sending data in Ruby.

--- a/_includes/manuals/1.19/3.5.4_puppet_reports.md
+++ b/_includes/manuals/1.19/3.5.4_puppet_reports.md
@@ -19,7 +19,7 @@ First identify the directory containing report processors, e.g.
 * Debian or Ubuntu: /usr/lib/ruby/vendor_ruby/puppet/reports/
 * other OSes, look for tagmail.rb in the Puppet installation (`locate tagmail.rb`)
 
-Copy [the report processor source](https://raw.githubusercontent.com/theforeman/puppet-foreman/master/files/foreman-report_v2.rb) to this report directory and name it `foreman.rb`.
+Copy [the report processor source](https://raw.githubusercontent.com/theforeman/puppet-puppetserver_foreman/master/files/report.rb) to this report directory and name it `foreman.rb`.
 
 Create a new configuration file at `/etc/puppetlabs/puppet/foreman.yaml` (Puppet 4 AIO) or `/etc/puppet/foreman.yaml` (non-AIO) containing:
 <pre>

--- a/_includes/manuals/1.19/3.5.5_facts_and_the_enc.md
+++ b/_includes/manuals/1.19/3.5.5_facts_and_the_enc.md
@@ -7,7 +7,7 @@ The external nodes script we supply also deals with uploading facts from hosts t
 
 ##### Puppet master
 
-Download [the ENC script](https://raw.githubusercontent.com/theforeman/puppet-foreman/master/files/external_node_v2.rb) to `/etc/puppetlabs/puppet/node.rb` (Puppet 4 AIO) or `/etc/puppet/node.rb` (non-AIO). The name is arbitrary, but must match configuration below, and ensure it's executable by "puppet" with `chmod +x /etc/puppet/node.rb`.
+Download [the ENC script](https://raw.githubusercontent.com/theforeman/puppet-puppetserver_foreman/master/files/enc.rb) to `/etc/puppetlabs/puppet/node.rb` (Puppet 4 AIO) or `/etc/puppet/node.rb` (non-AIO). The name is arbitrary, but must match configuration below, and ensure it's executable by "puppet" with `chmod +x /etc/puppet/node.rb`.
 
 Unless it already exists from setting up reporting, create a new configuration file at `/etc/puppetlabs/puppet/foreman.yaml` (Puppet 4 AIO) or `/etc/puppet/foreman.yaml` (non-AIO) containing
 
@@ -146,4 +146,4 @@ supplied. The 'facts' hash must be a flat hash, not nested with other arrays or 
 See _link-to-API-when-its-updated-here_ for more details.
 
 This body can be POSTed to '/api/hosts/facts' using Foreman API v2. See the
-[node.rb template](https://github.com/theforeman/puppet-foreman/blob/master/files/external_node_v2.rb) for an example of constructing and sending data in Ruby.
+[node.rb template](https://raw.githubusercontent.com/theforeman/puppet-puppetserver_foreman/master/files/enc.rb) for an example of constructing and sending data in Ruby.

--- a/_includes/manuals/1.20/3.5.4_puppet_reports.md
+++ b/_includes/manuals/1.20/3.5.4_puppet_reports.md
@@ -19,7 +19,7 @@ First identify the directory containing report processors, e.g.
 * Debian or Ubuntu: /usr/lib/ruby/vendor_ruby/puppet/reports/
 * other OSes, look for tagmail.rb in the Puppet installation (`locate tagmail.rb`)
 
-Copy [the report processor source](https://raw.githubusercontent.com/theforeman/puppet-foreman/master/files/foreman-report_v2.rb) to this report directory and name it `foreman.rb`.
+Copy [the report processor source](https://raw.githubusercontent.com/theforeman/puppet-puppetserver_foreman/master/files/report.rb) to this report directory and name it `foreman.rb`.
 
 Create a new configuration file at `/etc/puppetlabs/puppet/foreman.yaml` (Puppet 4 AIO) or `/etc/puppet/foreman.yaml` (non-AIO) containing:
 <pre>

--- a/_includes/manuals/1.20/3.5.5_facts_and_the_enc.md
+++ b/_includes/manuals/1.20/3.5.5_facts_and_the_enc.md
@@ -7,7 +7,7 @@ The external nodes script we supply also deals with uploading facts from hosts t
 
 ##### Puppet master
 
-Download [the ENC script](https://raw.githubusercontent.com/theforeman/puppet-foreman/master/files/external_node_v2.rb) to `/etc/puppetlabs/puppet/node.rb` (Puppet 4 AIO) or `/etc/puppet/node.rb` (non-AIO). The name is arbitrary, but must match configuration below, and ensure it's executable by "puppet" with `chmod +x /etc/puppet/node.rb`.
+Download [the ENC script](https://raw.githubusercontent.com/theforeman/puppet-puppetserver_foreman/master/files/enc.rb) to `/etc/puppetlabs/puppet/node.rb` (Puppet 4 AIO) or `/etc/puppet/node.rb` (non-AIO). The name is arbitrary, but must match configuration below, and ensure it's executable by "puppet" with `chmod +x /etc/puppet/node.rb`.
 
 Unless it already exists from setting up reporting, create a new configuration file at `/etc/puppetlabs/puppet/foreman.yaml` (Puppet 4 AIO) or `/etc/puppet/foreman.yaml` (non-AIO) containing
 
@@ -146,4 +146,4 @@ supplied. The 'facts' hash must be a flat hash, not nested with other arrays or 
 See _link-to-API-when-its-updated-here_ for more details.
 
 This body can be POSTed to '/api/hosts/facts' using Foreman API v2. See the
-[node.rb template](https://github.com/theforeman/puppet-foreman/blob/master/files/external_node_v2.rb) for an example of constructing and sending data in Ruby.
+[node.rb template](https://raw.githubusercontent.com/theforeman/puppet-puppetserver_foreman/master/files/enc.rb) for an example of constructing and sending data in Ruby.

--- a/_includes/manuals/1.21/3.5.4_puppet_reports.md
+++ b/_includes/manuals/1.21/3.5.4_puppet_reports.md
@@ -19,7 +19,7 @@ First identify the directory containing report processors, e.g.
 * Debian or Ubuntu: /usr/lib/ruby/vendor_ruby/puppet/reports/
 * other OSes, look for tagmail.rb in the Puppet installation (`locate tagmail.rb`)
 
-Copy [the report processor source](https://raw.githubusercontent.com/theforeman/puppet-foreman/master/files/foreman-report_v2.rb) to this report directory and name it `foreman.rb`.
+Copy [the report processor source](https://raw.githubusercontent.com/theforeman/puppet-puppetserver_foreman/master/files/report.rb) to this report directory and name it `foreman.rb`.
 
 Create a new configuration file at `/etc/puppetlabs/puppet/foreman.yaml` (Puppet 4 AIO) or `/etc/puppet/foreman.yaml` (non-AIO) containing:
 <pre>

--- a/_includes/manuals/1.21/3.5.5_facts_and_the_enc.md
+++ b/_includes/manuals/1.21/3.5.5_facts_and_the_enc.md
@@ -7,7 +7,7 @@ The external nodes script we supply also deals with uploading facts from hosts t
 
 ##### Puppet master
 
-Download [the ENC script](https://raw.githubusercontent.com/theforeman/puppet-foreman/master/files/external_node_v2.rb) to `/etc/puppetlabs/puppet/node.rb` (Puppet 4 AIO) or `/etc/puppet/node.rb` (non-AIO). The name is arbitrary, but must match configuration below, and ensure it's executable by "puppet" with `chmod +x /etc/puppet/node.rb`.
+Download [the ENC script](https://raw.githubusercontent.com/theforeman/puppet-puppetserver_foreman/master/files/enc.rb) to `/etc/puppetlabs/puppet/node.rb` (Puppet 4 AIO) or `/etc/puppet/node.rb` (non-AIO). The name is arbitrary, but must match configuration below, and ensure it's executable by "puppet" with `chmod +x /etc/puppet/node.rb`.
 
 Unless it already exists from setting up reporting, create a new configuration file at `/etc/puppetlabs/puppet/foreman.yaml` (Puppet 4 AIO) or `/etc/puppet/foreman.yaml` (non-AIO) containing
 
@@ -146,4 +146,4 @@ supplied. The 'facts' hash must be a flat hash, not nested with other arrays or 
 See _link-to-API-when-its-updated-here_ for more details.
 
 This body can be POSTed to '/api/hosts/facts' using Foreman API v2. See the
-[node.rb template](https://github.com/theforeman/puppet-foreman/blob/master/files/external_node_v2.rb) for an example of constructing and sending data in Ruby.
+[node.rb template](https://raw.githubusercontent.com/theforeman/puppet-puppetserver_foreman/master/files/enc.rb) for an example of constructing and sending data in Ruby.

--- a/_includes/manuals/1.22/3.5.4_puppet_reports.md
+++ b/_includes/manuals/1.22/3.5.4_puppet_reports.md
@@ -19,7 +19,7 @@ First identify the directory containing report processors, e.g.
 * Debian or Ubuntu: /usr/lib/ruby/vendor_ruby/puppet/reports/
 * other OSes, look for tagmail.rb in the Puppet installation (`locate tagmail.rb`)
 
-Copy [the report processor source](https://raw.githubusercontent.com/theforeman/puppet-foreman/master/files/foreman-report_v2.rb) to this report directory and name it `foreman.rb`.
+Copy [the report processor source](https://raw.githubusercontent.com/theforeman/puppet-puppetserver_foreman/master/files/report.rb) to this report directory and name it `foreman.rb`.
 
 Create a new configuration file at `/etc/puppetlabs/puppet/foreman.yaml` (Puppet 4 AIO) or `/etc/puppet/foreman.yaml` (non-AIO) containing:
 <pre>

--- a/_includes/manuals/1.22/3.5.5_facts_and_the_enc.md
+++ b/_includes/manuals/1.22/3.5.5_facts_and_the_enc.md
@@ -7,7 +7,7 @@ The external nodes script we supply also deals with uploading facts from hosts t
 
 ##### Puppet master
 
-Download [the ENC script](https://raw.githubusercontent.com/theforeman/puppet-foreman/master/files/external_node_v2.rb) to `/etc/puppetlabs/puppet/node.rb` (Puppet 4 AIO) or `/etc/puppet/node.rb` (non-AIO). The name is arbitrary, but must match configuration below, and ensure it's executable by "puppet" with `chmod +x /etc/puppet/node.rb`.
+Download [the ENC script](https://raw.githubusercontent.com/theforeman/puppet-puppetserver_foreman/master/files/enc.rb) to `/etc/puppetlabs/puppet/node.rb` (Puppet 4 AIO) or `/etc/puppet/node.rb` (non-AIO). The name is arbitrary, but must match configuration below, and ensure it's executable by "puppet" with `chmod +x /etc/puppet/node.rb`.
 
 Unless it already exists from setting up reporting, create a new configuration file at `/etc/puppetlabs/puppet/foreman.yaml` (Puppet 4 AIO) or `/etc/puppet/foreman.yaml` (non-AIO) containing
 
@@ -146,4 +146,4 @@ supplied. The 'facts' hash must be a flat hash, not nested with other arrays or 
 See _link-to-API-when-its-updated-here_ for more details.
 
 This body can be POSTed to '/api/hosts/facts' using Foreman API v2. See the
-[node.rb template](https://github.com/theforeman/puppet-foreman/blob/master/files/external_node_v2.rb) for an example of constructing and sending data in Ruby.
+[node.rb template](https://raw.githubusercontent.com/theforeman/puppet-puppetserver_foreman/master/files/enc.rb) for an example of constructing and sending data in Ruby.

--- a/_includes/manuals/1.23/3.5.4_puppet_reports.md
+++ b/_includes/manuals/1.23/3.5.4_puppet_reports.md
@@ -19,7 +19,7 @@ First identify the directory containing report processors, e.g.
 * Debian or Ubuntu: /usr/lib/ruby/vendor_ruby/puppet/reports/
 * other OSes, look for tagmail.rb in the Puppet installation (`locate tagmail.rb`)
 
-Copy [the report processor source](https://raw.githubusercontent.com/theforeman/puppet-foreman/master/files/foreman-report_v2.rb) to this report directory and name it `foreman.rb`.
+Copy [the report processor source](https://raw.githubusercontent.com/theforeman/puppet-puppetserver_foreman/master/files/report.rb) to this report directory and name it `foreman.rb`.
 
 Create a new configuration file at `/etc/puppetlabs/puppet/foreman.yaml` (Puppet 4 AIO) or `/etc/puppet/foreman.yaml` (non-AIO) containing:
 <pre>

--- a/_includes/manuals/1.23/3.5.5_facts_and_the_enc.md
+++ b/_includes/manuals/1.23/3.5.5_facts_and_the_enc.md
@@ -7,7 +7,7 @@ The external nodes script we supply also deals with uploading facts from hosts t
 
 ##### Puppet master
 
-Download [the ENC script](https://raw.githubusercontent.com/theforeman/puppet-foreman/master/files/external_node_v2.rb) to `/etc/puppetlabs/puppet/node.rb` (Puppet 4 AIO) or `/etc/puppet/node.rb` (non-AIO). The name is arbitrary, but must match configuration below, and ensure it's executable by "puppet" with `chmod +x /etc/puppet/node.rb`.
+Download [the ENC script](https://raw.githubusercontent.com/theforeman/puppet-puppetserver_foreman/master/files/enc.rb) to `/etc/puppetlabs/puppet/node.rb` (Puppet 4 AIO) or `/etc/puppet/node.rb` (non-AIO). The name is arbitrary, but must match configuration below, and ensure it's executable by "puppet" with `chmod +x /etc/puppet/node.rb`.
 
 Unless it already exists from setting up reporting, create a new configuration file at `/etc/puppetlabs/puppet/foreman.yaml` (Puppet 4 AIO) or `/etc/puppet/foreman.yaml` (non-AIO) containing
 
@@ -146,4 +146,4 @@ supplied. The 'facts' hash must be a flat hash, not nested with other arrays or 
 See _link-to-API-when-its-updated-here_ for more details.
 
 This body can be POSTed to '/api/hosts/facts' using Foreman API v2. See the
-[node.rb template](https://github.com/theforeman/puppet-foreman/blob/master/files/external_node_v2.rb) for an example of constructing and sending data in Ruby.
+[node.rb template](https://raw.githubusercontent.com/theforeman/puppet-puppetserver_foreman/master/files/enc.rb) for an example of constructing and sending data in Ruby.

--- a/_includes/manuals/1.24/3.5.4_puppet_reports.md
+++ b/_includes/manuals/1.24/3.5.4_puppet_reports.md
@@ -19,7 +19,7 @@ First identify the directory containing report processors, e.g.
 * Debian or Ubuntu: /usr/lib/ruby/vendor_ruby/puppet/reports/
 * other OSes, look for tagmail.rb in the Puppet installation (`locate tagmail.rb`)
 
-Copy [the report processor source](https://raw.githubusercontent.com/theforeman/puppet-foreman/master/files/foreman-report_v2.rb) to this report directory and name it `foreman.rb`.
+Copy [the report processor source](https://raw.githubusercontent.com/theforeman/puppet-puppetserver_foreman/master/files/report.rb) to this report directory and name it `foreman.rb`.
 
 Create a new configuration file at `/etc/puppetlabs/puppet/foreman.yaml` (Puppet 4 AIO) or `/etc/puppet/foreman.yaml` (non-AIO) containing:
 <pre>

--- a/_includes/manuals/1.24/3.5.5_facts_and_the_enc.md
+++ b/_includes/manuals/1.24/3.5.5_facts_and_the_enc.md
@@ -7,7 +7,7 @@ The external nodes script we supply also deals with uploading facts from hosts t
 
 ##### Puppet master
 
-Download [the ENC script](https://raw.githubusercontent.com/theforeman/puppet-foreman/master/files/external_node_v2.rb) to `/etc/puppetlabs/puppet/node.rb` (Puppet AIO) or `/etc/puppet/node.rb` (non-AIO). The name is arbitrary, but must match configuration below, and ensure it's executable by "puppet" with `chmod +x /etc/puppet/node.rb`.
+Download [the ENC script](https://raw.githubusercontent.com/theforeman/puppet-puppetserver_foreman/master/files/enc.rb) to `/etc/puppetlabs/puppet/node.rb` (Puppet AIO) or `/etc/puppet/node.rb` (non-AIO). The name is arbitrary, but must match configuration below, and ensure it's executable by "puppet" with `chmod +x /etc/puppet/node.rb`.
 
 Unless it already exists from setting up reporting, create a new configuration file at `/etc/puppetlabs/puppet/foreman.yaml` (Puppet AIO) or `/etc/puppet/foreman.yaml` (non-AIO) containing
 
@@ -145,4 +145,4 @@ The 'certname' is optional but will be used to locate the Host in Foreman when
 supplied. See [the API documentation](/api/{{page.version}}/apidoc/v2/hosts/facts.html) for more details.
 
 This body can be POSTed to '/api/hosts/facts' using Foreman API v2. See the
-[node.rb template](https://github.com/theforeman/puppet-foreman/blob/master/files/external_node_v2.rb) for an example of constructing and sending data in Ruby.
+[node.rb template](https://raw.githubusercontent.com/theforeman/puppet-puppetserver_foreman/master/files/enc.rb) for an example of constructing and sending data in Ruby.

--- a/_includes/manuals/1.6/3.5.4_puppet_reports.md
+++ b/_includes/manuals/1.6/3.5.4_puppet_reports.md
@@ -19,7 +19,7 @@ First identify the directory containing report processors, e.g.
 * Debian or Ubuntu: /usr/lib/ruby/vendor_ruby/puppet/reports/
 * other OSes, look for tagmail.rb in the Puppet installation (`locate tagmail.rb`)
 
-Copy [the report processor source](https://raw.githubusercontent.com/theforeman/puppet-foreman/master/files/foreman-report_v2.rb) to this report directory and name it `foreman.rb`.
+Copy [the report processor source](https://raw.githubusercontent.com/theforeman/puppet-puppetserver_foreman/master/files/report.rb) to this report directory and name it `foreman.rb`.
 
 Create a new configuration file at `/etc/puppet/foreman.yaml` containing:
 <pre>

--- a/_includes/manuals/1.7/3.5.4_puppet_reports.md
+++ b/_includes/manuals/1.7/3.5.4_puppet_reports.md
@@ -19,7 +19,7 @@ First identify the directory containing report processors, e.g.
 * Debian or Ubuntu: /usr/lib/ruby/vendor_ruby/puppet/reports/
 * other OSes, look for tagmail.rb in the Puppet installation (`locate tagmail.rb`)
 
-Copy [the report processor source](https://raw.githubusercontent.com/theforeman/puppet-foreman/master/files/foreman-report_v2.rb) to this report directory and name it `foreman.rb`.
+Copy [the report processor source](https://raw.githubusercontent.com/theforeman/puppet-puppetserver_foreman/master/files/report.rb) to this report directory and name it `foreman.rb`.
 
 Create a new configuration file at `/etc/puppet/foreman.yaml` containing:
 <pre>

--- a/_includes/manuals/1.8/3.5.4_puppet_reports.md
+++ b/_includes/manuals/1.8/3.5.4_puppet_reports.md
@@ -19,7 +19,7 @@ First identify the directory containing report processors, e.g.
 * Debian or Ubuntu: /usr/lib/ruby/vendor_ruby/puppet/reports/
 * other OSes, look for tagmail.rb in the Puppet installation (`locate tagmail.rb`)
 
-Copy [the report processor source](https://raw.githubusercontent.com/theforeman/puppet-foreman/master/files/foreman-report_v2.rb) to this report directory and name it `foreman.rb`.
+Copy [the report processor source](https://raw.githubusercontent.com/theforeman/puppet-puppetserver_foreman/master/files/report.rb) to this report directory and name it `foreman.rb`.
 
 Create a new configuration file at `/etc/puppet/foreman.yaml` containing:
 <pre>

--- a/_includes/manuals/1.9/3.5.4_puppet_reports.md
+++ b/_includes/manuals/1.9/3.5.4_puppet_reports.md
@@ -19,7 +19,7 @@ First identify the directory containing report processors, e.g.
 * Debian or Ubuntu: /usr/lib/ruby/vendor_ruby/puppet/reports/
 * other OSes, look for tagmail.rb in the Puppet installation (`locate tagmail.rb`)
 
-Copy [the report processor source](https://raw.githubusercontent.com/theforeman/puppet-foreman/master/files/foreman-report_v2.rb) to this report directory and name it `foreman.rb`.
+Copy [the report processor source](https://raw.githubusercontent.com/theforeman/puppet-puppetserver_foreman/master/files/report.rb) to this report directory and name it `foreman.rb`.
 
 Create a new configuration file at `/etc/puppet/foreman.yaml` containing:
 <pre>

--- a/_includes/manuals/2.0/3.5.4_puppet_reports.md
+++ b/_includes/manuals/2.0/3.5.4_puppet_reports.md
@@ -19,7 +19,7 @@ First identify the directory containing report processors, e.g.
 * Debian or Ubuntu: /usr/lib/ruby/vendor_ruby/puppet/reports/
 * other OSes, look for tagmail.rb in the Puppet installation (`locate tagmail.rb`)
 
-Copy [the report processor source](https://raw.githubusercontent.com/theforeman/puppet-foreman/master/files/foreman-report_v2.rb) to this report directory and name it `foreman.rb`.
+Copy [the report processor source](https://raw.githubusercontent.com/theforeman/puppet-puppetserver_foreman/master/files/report.rb) to this report directory and name it `foreman.rb`.
 
 Create a new configuration file at `/etc/puppetlabs/puppet/foreman.yaml` (Puppet 4 AIO) or `/etc/puppet/foreman.yaml` (non-AIO) containing:
 <pre>

--- a/_includes/manuals/2.0/3.5.5_facts_and_the_enc.md
+++ b/_includes/manuals/2.0/3.5.5_facts_and_the_enc.md
@@ -7,7 +7,7 @@ The external nodes script we supply also deals with uploading facts from hosts t
 
 ##### Puppet master
 
-Download [the ENC script](https://raw.githubusercontent.com/theforeman/puppet-foreman/master/files/external_node_v2.rb) to `/etc/puppetlabs/puppet/node.rb` (Puppet AIO) or `/etc/puppet/node.rb` (non-AIO). The name is arbitrary, but must match configuration below, and ensure it's executable by "puppet" with `chmod +x /etc/puppet/node.rb`.
+Download [the ENC script](https://raw.githubusercontent.com/theforeman/puppet-puppetserver_foreman/master/files/enc.rb) to `/etc/puppetlabs/puppet/node.rb` (Puppet AIO) or `/etc/puppet/node.rb` (non-AIO). The name is arbitrary, but must match configuration below, and ensure it's executable by "puppet" with `chmod +x /etc/puppet/node.rb`.
 
 Unless it already exists from setting up reporting, create a new configuration file at `/etc/puppetlabs/puppet/foreman.yaml` (Puppet AIO) or `/etc/puppet/foreman.yaml` (non-AIO) containing
 
@@ -145,4 +145,4 @@ The 'certname' is optional but will be used to locate the Host in Foreman when
 supplied. See [the API documentation](/api/{{page.version}}/apidoc/v2/hosts/facts.html) for more details.
 
 This body can be POSTed to '/api/hosts/facts' using Foreman API v2. See the
-[node.rb template](https://github.com/theforeman/puppet-foreman/blob/master/files/external_node_v2.rb) for an example of constructing and sending data in Ruby.
+[node.rb template](https://raw.githubusercontent.com/theforeman/puppet-puppetserver_foreman/master/files/enc.rb) for an example of constructing and sending data in Ruby.

--- a/_includes/manuals/2.1/3.5.4_puppet_reports.md
+++ b/_includes/manuals/2.1/3.5.4_puppet_reports.md
@@ -19,7 +19,7 @@ First identify the directory containing report processors, e.g.
 * Debian or Ubuntu: /usr/lib/ruby/vendor_ruby/puppet/reports/
 * other OSes, look for tagmail.rb in the Puppet installation (`locate tagmail.rb`)
 
-Copy [the report processor source](https://raw.githubusercontent.com/theforeman/puppet-foreman/master/files/foreman-report_v2.rb) to this report directory and name it `foreman.rb`.
+Copy [the report processor source](https://raw.githubusercontent.com/theforeman/puppet-puppetserver_foreman/master/files/report.rb) to this report directory and name it `foreman.rb`.
 
 Create a new configuration file at `/etc/puppetlabs/puppet/foreman.yaml` (Puppet 4 AIO) or `/etc/puppet/foreman.yaml` (non-AIO) containing:
 <pre>

--- a/_includes/manuals/2.1/3.5.5_facts_and_the_enc.md
+++ b/_includes/manuals/2.1/3.5.5_facts_and_the_enc.md
@@ -7,7 +7,7 @@ The external nodes script we supply also deals with uploading facts from hosts t
 
 ##### Puppet master
 
-Download [the ENC script](https://raw.githubusercontent.com/theforeman/puppet-foreman/master/files/external_node_v2.rb) to `/etc/puppetlabs/puppet/node.rb` (Puppet AIO) or `/etc/puppet/node.rb` (non-AIO). The name is arbitrary, but must match configuration below, and ensure it's executable by "puppet" with `chmod +x /etc/puppet/node.rb`.
+Download [the ENC script](https://raw.githubusercontent.com/theforeman/puppet-puppetserver_foreman/master/files/enc.rb) to `/etc/puppetlabs/puppet/node.rb` (Puppet AIO) or `/etc/puppet/node.rb` (non-AIO). The name is arbitrary, but must match configuration below, and ensure it's executable by "puppet" with `chmod +x /etc/puppet/node.rb`.
 
 Unless it already exists from setting up reporting, create a new configuration file at `/etc/puppetlabs/puppet/foreman.yaml` (Puppet AIO) or `/etc/puppet/foreman.yaml` (non-AIO) containing
 
@@ -145,4 +145,4 @@ The 'certname' is optional but will be used to locate the Host in Foreman when
 supplied. See [the API documentation](/api/{{page.version}}/apidoc/v2/hosts/facts.html) for more details.
 
 This body can be POSTed to '/api/hosts/facts' using Foreman API v2. See the
-[node.rb template](https://github.com/theforeman/puppet-foreman/blob/master/files/external_node_v2.rb) for an example of constructing and sending data in Ruby.
+[node.rb template](https://raw.githubusercontent.com/theforeman/puppet-puppetserver_foreman/master/files/enc.rb) for an example of constructing and sending data in Ruby.

--- a/_includes/manuals/2.2/3.5.4_puppet_reports.md
+++ b/_includes/manuals/2.2/3.5.4_puppet_reports.md
@@ -19,7 +19,7 @@ First identify the directory containing report processors, e.g.
 * Debian or Ubuntu: /usr/lib/ruby/vendor_ruby/puppet/reports/
 * other OSes, look for tagmail.rb in the Puppet installation (`locate tagmail.rb`)
 
-Copy [the report processor source](https://raw.githubusercontent.com/theforeman/puppet-foreman/master/files/foreman-report_v2.rb) to this report directory and name it `foreman.rb`.
+Copy [the report processor source](https://raw.githubusercontent.com/theforeman/puppet-puppetserver_foreman/master/files/report.rb) to this report directory and name it `foreman.rb`.
 
 Create a new configuration file at `/etc/puppetlabs/puppet/foreman.yaml` (Puppet 4 AIO) or `/etc/puppet/foreman.yaml` (non-AIO) containing:
 <pre>

--- a/_includes/manuals/2.2/3.5.5_facts_and_the_enc.md
+++ b/_includes/manuals/2.2/3.5.5_facts_and_the_enc.md
@@ -7,7 +7,7 @@ The external nodes script we supply also deals with uploading facts from hosts t
 
 ##### Puppet master
 
-Download [the ENC script](https://raw.githubusercontent.com/theforeman/puppet-foreman/master/files/external_node_v2.rb) to `/etc/puppetlabs/puppet/node.rb` (Puppet AIO) or `/etc/puppet/node.rb` (non-AIO). The name is arbitrary, but must match configuration below, and ensure it's executable by "puppet" with `chmod +x /etc/puppet/node.rb`.
+Download [the ENC script](https://raw.githubusercontent.com/theforeman/puppet-puppetserver_foreman/master/files/enc.rb) to `/etc/puppetlabs/puppet/node.rb` (Puppet AIO) or `/etc/puppet/node.rb` (non-AIO). The name is arbitrary, but must match configuration below, and ensure it's executable by "puppet" with `chmod +x /etc/puppet/node.rb`.
 
 Unless it already exists from setting up reporting, create a new configuration file at `/etc/puppetlabs/puppet/foreman.yaml` (Puppet AIO) or `/etc/puppet/foreman.yaml` (non-AIO) containing
 
@@ -145,4 +145,4 @@ The 'certname' is optional but will be used to locate the Host in Foreman when
 supplied. See [the API documentation](/api/{{page.version}}/apidoc/v2/hosts/facts.html) for more details.
 
 This body can be POSTed to '/api/hosts/facts' using Foreman API v2. See the
-[node.rb template](https://github.com/theforeman/puppet-foreman/blob/master/files/external_node_v2.rb) for an example of constructing and sending data in Ruby.
+[node.rb template](https://raw.githubusercontent.com/theforeman/puppet-puppetserver_foreman/master/files/enc.rb) for an example of constructing and sending data in Ruby.

--- a/_includes/manuals/2.3/3.5.4_puppet_reports.md
+++ b/_includes/manuals/2.3/3.5.4_puppet_reports.md
@@ -19,7 +19,7 @@ First identify the directory containing report processors, e.g.
 * Debian or Ubuntu: /usr/lib/ruby/vendor_ruby/puppet/reports/
 * other OSes, look for tagmail.rb in the Puppet installation (`locate tagmail.rb`)
 
-Copy [the report processor source](https://raw.githubusercontent.com/theforeman/puppet-foreman/master/files/foreman-report_v2.rb) to this report directory and name it `foreman.rb`.
+Copy [the report processor source](https://raw.githubusercontent.com/theforeman/puppet-puppetserver_foreman/master/files/report.rb) to this report directory and name it `foreman.rb`.
 
 Create a new configuration file at `/etc/puppetlabs/puppet/foreman.yaml` (Puppet 4 AIO) or `/etc/puppet/foreman.yaml` (non-AIO) containing:
 <pre>

--- a/_includes/manuals/2.3/3.5.5_facts_and_the_enc.md
+++ b/_includes/manuals/2.3/3.5.5_facts_and_the_enc.md
@@ -7,7 +7,7 @@ The external nodes script we supply also deals with uploading facts from hosts t
 
 ##### Puppet server
 
-Download [the ENC script](https://raw.githubusercontent.com/theforeman/puppet-foreman/master/files/external_node_v2.rb) to `/etc/puppetlabs/puppet/node.rb` (Puppet AIO) or `/etc/puppet/node.rb` (non-AIO). The name is arbitrary, but must match configuration below, and ensure it's executable by "puppet" with `chmod +x /etc/puppet/node.rb`.
+Download [the ENC script](https://raw.githubusercontent.com/theforeman/puppet-puppetserver_foreman/master/files/enc.rb) to `/etc/puppetlabs/puppet/node.rb` (Puppet AIO) or `/etc/puppet/node.rb` (non-AIO). The name is arbitrary, but must match configuration below, and ensure it's executable by "puppet" with `chmod +x /etc/puppet/node.rb`.
 
 Unless it already exists from setting up reporting, create a new configuration file at `/etc/puppetlabs/puppet/foreman.yaml` (Puppet AIO) or `/etc/puppet/foreman.yaml` (non-AIO) containing
 
@@ -145,4 +145,4 @@ The 'certname' is optional but will be used to locate the Host in Foreman when
 supplied. See [the API documentation](/api/{{page.version}}/apidoc/v2/hosts/facts.html) for more details.
 
 This body can be POSTed to '/api/hosts/facts' using Foreman API v2. See the
-[node.rb template](https://github.com/theforeman/puppet-foreman/blob/master/files/external_node_v2.rb) for an example of constructing and sending data in Ruby.
+[node.rb template](https://raw.githubusercontent.com/theforeman/puppet-puppetserver_foreman/master/files/enc.rb) for an example of constructing and sending data in Ruby.

--- a/_includes/manuals/2.4/3.5.4_puppet_reports.md
+++ b/_includes/manuals/2.4/3.5.4_puppet_reports.md
@@ -19,7 +19,7 @@ First identify the directory containing report processors, e.g.
 * Debian or Ubuntu: /usr/lib/ruby/vendor_ruby/puppet/reports/
 * other OSes, look for tagmail.rb in the Puppet installation (`locate tagmail.rb`)
 
-Copy [the report processor source](https://raw.githubusercontent.com/theforeman/puppet-foreman/master/files/foreman-report_v2.rb) to this report directory and name it `foreman.rb`.
+Copy [the report processor source](https://raw.githubusercontent.com/theforeman/puppet-puppetserver_foreman/master/files/report.rb) to this report directory and name it `foreman.rb`.
 
 Create a new configuration file at `/etc/puppetlabs/puppet/foreman.yaml` (Puppet 4 AIO) or `/etc/puppet/foreman.yaml` (non-AIO) containing:
 <pre>

--- a/_includes/manuals/2.4/3.5.5_facts_and_the_enc.md
+++ b/_includes/manuals/2.4/3.5.5_facts_and_the_enc.md
@@ -7,7 +7,7 @@ The external nodes script we supply also deals with uploading facts from hosts t
 
 ##### Puppet server
 
-Download [the ENC script](https://raw.githubusercontent.com/theforeman/puppet-foreman/master/files/external_node_v2.rb) to `/etc/puppetlabs/puppet/node.rb` (Puppet AIO) or `/etc/puppet/node.rb` (non-AIO). The name is arbitrary, but must match configuration below, and ensure it's executable by "puppet" with `chmod +x /etc/puppet/node.rb`.
+Download [the ENC script](https://raw.githubusercontent.com/theforeman/puppet-puppetserver_foreman/master/files/enc.rb) to `/etc/puppetlabs/puppet/node.rb` (Puppet AIO) or `/etc/puppet/node.rb` (non-AIO). The name is arbitrary, but must match configuration below, and ensure it's executable by "puppet" with `chmod +x /etc/puppet/node.rb`.
 
 Unless it already exists from setting up reporting, create a new configuration file at `/etc/puppetlabs/puppet/foreman.yaml` (Puppet AIO) or `/etc/puppet/foreman.yaml` (non-AIO) containing
 
@@ -145,4 +145,4 @@ The 'certname' is optional but will be used to locate the Host in Foreman when
 supplied. See [the API documentation](/api/{{page.version}}/apidoc/v2/hosts/facts.html) for more details.
 
 This body can be POSTed to '/api/hosts/facts' using Foreman API v2. See the
-[node.rb template](https://github.com/theforeman/puppet-foreman/blob/master/files/external_node_v2.rb) for an example of constructing and sending data in Ruby.
+[node.rb template](https://raw.githubusercontent.com/theforeman/puppet-puppetserver_foreman/master/files/enc.rb) for an example of constructing and sending data in Ruby.

--- a/_includes/manuals/nightly/3.5.4_puppet_reports.md
+++ b/_includes/manuals/nightly/3.5.4_puppet_reports.md
@@ -19,7 +19,7 @@ First identify the directory containing report processors, e.g.
 * Debian or Ubuntu: /usr/lib/ruby/vendor_ruby/puppet/reports/
 * other OSes, look for tagmail.rb in the Puppet installation (`locate tagmail.rb`)
 
-Copy [the report processor source](https://raw.githubusercontent.com/theforeman/puppet-foreman/master/files/foreman-report_v2.rb) to this report directory and name it `foreman.rb`.
+Copy [the report processor source](https://raw.githubusercontent.com/theforeman/puppet-puppetserver_foreman/master/files/report.rb) to this report directory and name it `foreman.rb`.
 
 Create a new configuration file at `/etc/puppetlabs/puppet/foreman.yaml` (Puppet 4 AIO) or `/etc/puppet/foreman.yaml` (non-AIO) containing:
 <pre>

--- a/_includes/manuals/nightly/3.5.5_facts_and_the_enc.md
+++ b/_includes/manuals/nightly/3.5.5_facts_and_the_enc.md
@@ -7,7 +7,7 @@ The external nodes script we supply also deals with uploading facts from hosts t
 
 ##### Puppet server
 
-Download [the ENC script](https://raw.githubusercontent.com/theforeman/puppet-foreman/master/files/external_node_v2.rb) to `/etc/puppetlabs/puppet/node.rb` (Puppet AIO) or `/etc/puppet/node.rb` (non-AIO). The name is arbitrary, but must match configuration below, and ensure it's executable by "puppet" with `chmod +x /etc/puppet/node.rb`.
+Download [the ENC script](https://raw.githubusercontent.com/theforeman/puppet-puppetserver_foreman/master/files/enc.rb) to `/etc/puppetlabs/puppet/node.rb` (Puppet AIO) or `/etc/puppet/node.rb` (non-AIO). The name is arbitrary, but must match configuration below, and ensure it's executable by "puppet" with `chmod +x /etc/puppet/node.rb`.
 
 Unless it already exists from setting up reporting, create a new configuration file at `/etc/puppetlabs/puppet/foreman.yaml` (Puppet AIO) or `/etc/puppet/foreman.yaml` (non-AIO) containing
 
@@ -145,4 +145,4 @@ The 'certname' is optional but will be used to locate the Host in Foreman when
 supplied. See [the API documentation](/api/{{page.version}}/apidoc/v2/hosts/facts.html) for more details.
 
 This body can be POSTed to '/api/hosts/facts' using Foreman API v2. See the
-[node.rb template](https://github.com/theforeman/puppet-foreman/blob/master/files/external_node_v2.rb) for an example of constructing and sending data in Ruby.
+[node.rb template](https://raw.githubusercontent.com/theforeman/puppet-puppetserver_foreman/master/files/enc.rb) for an example of constructing and sending data in Ruby.


### PR DESCRIPTION
In https://github.com/theforeman/puppet-foreman/commit/0b3507b9286d966233fdf782ebb5d55eb90e4530 the ENC and report scripts were removed as those were split off to theforeman/puppetserver_foreman, causing all links in all docs to be dead.