### PR TITLE
Fixing small typo in MySQL to PostgreSQL migration

### DIFF
--- a/_includes/manuals/1.24/3.7_migration.md
+++ b/_includes/manuals/1.24/3.7_migration.md
@@ -127,7 +127,7 @@ production:
 In the next step, call a rake task which will create new database:
 
 ```sh
-forman-rake db:create RAILS_ENV=development
+foreman-rake db:create RAILS_ENV=development
 ```
 
 The new database needs to be set up with all the tables required for Foreman to


### PR DESCRIPTION
While migrating our (old) Foreman install from MySQL to PostgreSQL I ran into this small typo, which made me look twice before I realised it missed a character.