### PR TITLE
Fix "Populate users and attributes" section to use correct lookup_identity.conf

### DIFF
--- a/_includes/manuals/2.2/5.7.5_populate_users_attributes_groups.md
+++ b/_includes/manuals/2.2/5.7.5_populate_users_attributes_groups.md
@@ -33,10 +33,18 @@ Configure Apache to retrieve these attributes, for example in `/etc/httpd/conf.d
 {% highlight text %}
 LoadModule lookup_identity_module modules/mod_lookup_identity.so
 <LocationMatch ^/users/(ext)?login$>
-  LookupUserAttr email REMOTE_USER_EMAIL " "
+  LookupUserAttr email REMOTE_USER_EMAIL
   LookupUserAttr firstname REMOTE_USER_FIRSTNAME
   LookupUserAttr lastname REMOTE_USER_LASTNAME
+  LookupUserGroups REMOTE_USER_GROUPS :
   LookupUserGroupsIter REMOTE_USER_GROUP
+
+  # Set headers for proxy requests
+  RequestHeader set REMOTE_USER %{REMOTE_USER}e
+  RequestHeader set REMOTE_USER_EMAIL %{REMOTE_USER_EMAIL}e
+  RequestHeader set REMOTE_USER_FIRSTNAME %{REMOTE_USER_FIRSTNAME}e
+  RequestHeader set REMOTE_USER_LASTNAME %{REMOTE_USER_LASTNAME}e
+  RequestHeader set REMOTE_USER_GROUPS %{REMOTE_USER_GROUPS}e
 </LocationMatch>
 {% endhighlight %}
 

--- a/_includes/manuals/2.3/5.7.5_populate_users_attributes_groups.md
+++ b/_includes/manuals/2.3/5.7.5_populate_users_attributes_groups.md
@@ -33,10 +33,18 @@ Configure Apache to retrieve these attributes, for example in `/etc/httpd/conf.d
 {% highlight text %}
 LoadModule lookup_identity_module modules/mod_lookup_identity.so
 <LocationMatch ^/users/(ext)?login$>
-  LookupUserAttr email REMOTE_USER_EMAIL " "
+  LookupUserAttr email REMOTE_USER_EMAIL
   LookupUserAttr firstname REMOTE_USER_FIRSTNAME
   LookupUserAttr lastname REMOTE_USER_LASTNAME
+  LookupUserGroups REMOTE_USER_GROUPS :
   LookupUserGroupsIter REMOTE_USER_GROUP
+
+  # Set headers for proxy requests
+  RequestHeader set REMOTE_USER %{REMOTE_USER}e
+  RequestHeader set REMOTE_USER_EMAIL %{REMOTE_USER_EMAIL}e
+  RequestHeader set REMOTE_USER_FIRSTNAME %{REMOTE_USER_FIRSTNAME}e
+  RequestHeader set REMOTE_USER_LASTNAME %{REMOTE_USER_LASTNAME}e
+  RequestHeader set REMOTE_USER_GROUPS %{REMOTE_USER_GROUPS}e
 </LocationMatch>
 {% endhighlight %}
 

--- a/_includes/manuals/2.4/5.7.5_populate_users_attributes_groups.md
+++ b/_includes/manuals/2.4/5.7.5_populate_users_attributes_groups.md
@@ -33,10 +33,18 @@ Configure Apache to retrieve these attributes, for example in `/etc/httpd/conf.d
 {% highlight text %}
 LoadModule lookup_identity_module modules/mod_lookup_identity.so
 <LocationMatch ^/users/(ext)?login$>
-  LookupUserAttr email REMOTE_USER_EMAIL " "
+  LookupUserAttr email REMOTE_USER_EMAIL
   LookupUserAttr firstname REMOTE_USER_FIRSTNAME
   LookupUserAttr lastname REMOTE_USER_LASTNAME
+  LookupUserGroups REMOTE_USER_GROUPS :
   LookupUserGroupsIter REMOTE_USER_GROUP
+
+  # Set headers for proxy requests
+  RequestHeader set REMOTE_USER %{REMOTE_USER}e
+  RequestHeader set REMOTE_USER_EMAIL %{REMOTE_USER_EMAIL}e
+  RequestHeader set REMOTE_USER_FIRSTNAME %{REMOTE_USER_FIRSTNAME}e
+  RequestHeader set REMOTE_USER_LASTNAME %{REMOTE_USER_LASTNAME}e
+  RequestHeader set REMOTE_USER_GROUPS %{REMOTE_USER_GROUPS}e
 </LocationMatch>
 {% endhighlight %}
 

--- a/_includes/manuals/2.5/5.7.5_populate_users_attributes_groups.md
+++ b/_includes/manuals/2.5/5.7.5_populate_users_attributes_groups.md
@@ -33,10 +33,18 @@ Configure Apache to retrieve these attributes, for example in `/etc/httpd/conf.d
 {% highlight text %}
 LoadModule lookup_identity_module modules/mod_lookup_identity.so
 <LocationMatch ^/users/(ext)?login$>
-  LookupUserAttr email REMOTE_USER_EMAIL " "
+  LookupUserAttr email REMOTE_USER_EMAIL
   LookupUserAttr firstname REMOTE_USER_FIRSTNAME
   LookupUserAttr lastname REMOTE_USER_LASTNAME
+  LookupUserGroups REMOTE_USER_GROUPS :
   LookupUserGroupsIter REMOTE_USER_GROUP
+
+  # Set headers for proxy requests
+  RequestHeader set REMOTE_USER %{REMOTE_USER}e
+  RequestHeader set REMOTE_USER_EMAIL %{REMOTE_USER_EMAIL}e
+  RequestHeader set REMOTE_USER_FIRSTNAME %{REMOTE_USER_FIRSTNAME}e
+  RequestHeader set REMOTE_USER_LASTNAME %{REMOTE_USER_LASTNAME}e
+  RequestHeader set REMOTE_USER_GROUPS %{REMOTE_USER_GROUPS}e
 </LocationMatch>
 {% endhighlight %}
 


### PR DESCRIPTION
With the changes made to HTTP headers in [PR 7909](https://github.com/theforeman/foreman/pull/7909), a different lookup_identity.conf must be used as shown in puppet-foreman's [PR 872](https://github.com/theforeman/puppet-foreman/pull/872). 

As it stands, what is currently in the manual does not work (tested with Foreman 2.4). This new lookup_identity.conf does work as intended.