### PR TITLE
Add links to docs.theforeman.org where docs are better

### DIFF
--- a/_includes/manuals/nightly/4.1.6_user_management.md
+++ b/_includes/manuals/nightly/4.1.6_user_management.md
@@ -1,7 +1,12 @@
 
 Foreman is all about hosts and users interacting with these hosts.
 
+You can find comprehensive user management instructions over on our
+[next generation docs site](https://docs.theforeman.org/nightly/Administering_Red_Hat_Satellite/index-foreman-el.html#user-management_admin).
+
 #### SSH Keys
+
+You can find more comprehensive documentation on SSH Keys in our [next generation docs site](https://docs.theforeman.org/nightly/Administering_Red_Hat_Satellite/index-foreman-el.html#ssh-keys_admin)
 
 Each Foreman user can have multiple SSH keys assigned when editing a user. These keys alone do not serve any purpose, but are available for use in provisioning templates and can be accessed via ENC data. They provide an easy way to manage users and login ssh keys on hosts without the need for LDAP.
 If you want users to be able to login to a host using the data provided in Foreman, you need to include the `create_users` snippet in your provisioning template. There is a [puppet module](https://github.com/ekohl/puppet-foreman_simple_user) available to keep user data in sync with Foreman and your hosts.


### PR DESCRIPTION
I am working through https://community.theforeman.org/t/foreman-manual-reboot/22606
There are places where docs.theforeman.org links could really help a user today. 
If there are no objections, I would like to include links to docs.theforeman.org where the docs coverage is equal to or better than what we have in the Foreman manual. 

This first commit targets here: https://theforeman.org/manuals/2.3/index.html#4.1.6UserManagement

And tells the user about here: https://docs.theforeman.org/nightly/Administering_Red_Hat_Satellite/index-foreman-el.html#user-management_admin

I think this is a good example of when we can make an impact. 