### PR TITLE
Fix noVNC Link in 7.1_novnc.md

### DIFF
--- a/_includes/manuals/1.4/7.1_novnc.md
+++ b/_includes/manuals/1.4/7.1_novnc.md
@@ -1,4 +1,4 @@
-Foreman uses the excellent javascript VNC library [noVNC](http://kanaka.github.com/noVNC/noVNC/vnc.html), which allows clientless VNC within a web browser. When a console is opened by the user's web browser, Foreman opens a connection to TCP Port 5910 (and up) on the hypervisor and redirects that itself.
+Foreman uses the excellent javascript VNC library [noVNC](https://novnc.com/info.html), which allows clientless VNC within a web browser. When a console is opened by the user's web browser, Foreman opens a connection to TCP Port 5910 (and up) on the hypervisor and redirects that itself.
 
 ### Requirements
 


### PR DESCRIPTION
- http://kanaka.github.com/noVNC/noVNC/vnc.html throws 404
- replacing with https://novnc.com/info.html