### PR TITLE
Add Foreman 3.0 upgrade instructions

### DIFF
--- a/_includes/manuals/3.0/3.6_upgrade.md
+++ b/_includes/manuals/3.0/3.6_upgrade.md
@@ -101,6 +101,12 @@ Next upgrade all Foreman packages:
 yum upgrade tfm\* ruby\* foreman\*
 {% endhighlight %}
 
+If you wish to continue using Puppet:
+
+{% highlight bash %}
+yum install foreman-plugin-puppet
+{% endhighlight %}
+
 Optionally, consider removing unused SCL packages:
 
 {% highlight bash %}
@@ -134,6 +140,12 @@ Next upgrade all Foreman packages:
 {% highlight bash %}
 dnf upgrade ruby\* foreman\*
 {% endhighlight %}
+
+If you wish to continue using Puppet:
+
+{% highlight bash %}
+dnf install foreman-plugin-puppet
+{% endhighlight %}
 </div>
 
 <div class="upgrade_os upgrade_os_debian10 upgrade_os_ubuntu1804 upgrade_os_ubuntu2004">
@@ -163,11 +175,23 @@ deb http://deb.theforeman.org/ plugins {{ page.version }}
 {% endhighlight %}
 </div>
 
+Then import the new release GPG key ([5B7C3E5A735BCB4D615829DC0BDDA991FD7AAC8A](https://theforeman.org/static/keys/5B7C3E5A735BCB4D615829DC0BDDA991FD7AAC8A.pub)):
+
+{% highlight bash %}
+wget https://deb.theforeman.org/foreman.asc -O /etc/apt/trusted.gpg.d/foreman.asc
+{% endhighlight %}
+
 Next upgrade all Foreman packages:
 
 {% highlight bash %}
 apt-get update
 apt-get --only-upgrade install ruby\* foreman\*
+{% endhighlight %}
+
+If you wish to continue using Puppet:
+
+{% highlight bash %}
+apt-get install ruby-foreman-puppet
 {% endhighlight %}
 </div>
 


### PR DESCRIPTION
Previously it was assumed the installer was used, but that's marked as an optional step. It also makes the GPG key update explicit so users can simply copy-paste.