### PR TITLE
Fixes #20977 - Document that rubygem-rubyipmi might cause issues

### DIFF
--- a/_includes/manuals/nightly/4.3.3.2_smartproxy_bmc_ipmitool.md
+++ b/_includes/manuals/nightly/4.3.3.2_smartproxy_bmc_ipmitool.md
@@ -1,0 +1,14 @@
+
+If you select `ipmitool` as your default provider, there's an issue
+that might bite you. The Gem that's used to interact with `ipmitool`
+has a bug for which there's a fix but no stable release has been
+released for years now containing it.
+
+When Foreman calls `/bmc/X.X.X.X/lan/foo` (typically when a host with
+BMC interface is browsed), the proxy might enter an infinite loop if
+the BMC is not working, provoking a huge process creation/destruction
+rate, high system CPU use and high system load as consequence.
+
+See Foreman issue
+[#20977](https://projects.theforeman.org/issues/20977) for more
+details.

--- a/manuals/nightly/index.md
+++ b/manuals/nightly/index.md
@@ -106,6 +106,8 @@ previous_version: "3.0"
 {%include manuals/{{ page.version }}/4.3.3_smartproxy_bmc.md %}
 #### 4.3.3.1 SSH BMC
 {%include manuals/{{ page.version }}/4.3.3.1_smartproxy_bmc_ssh.md %}
+#### 4.3.3.2 SSH BMC
+{%include manuals/{{ page.version }}/4.3.3.2_smartproxy_bmc_ipmitool.md %}
 
 ### 4.3.4 DHCP
 


### PR DESCRIPTION
Unfortunately, there isn't still any version of rubyipmi containing a fix for what's described in #20977 [0]. We've hit this issue in production and having this described in the documentation would have saved us some time debugging.

I think that given there hasn't been a release upstream since 2015 and that the bug is still present in the wild (for instance, the version of rubyipmi shipped in the Foreman repositories is affected) it's now
time to add something to the manual.

Not sure if I'm adding the new entry to the documentation to the correct place.

[0] https://projects.theforeman.org/issues/20977