### PR TITLE
Add --no-enable-foreman-(cli-)puppet argument

### DIFF
--- a/_includes/manuals/3.0/3.2.3_installation_scenarios.md
+++ b/_includes/manuals/3.0/3.2.3_installation_scenarios.md
@@ -58,7 +58,9 @@ Command line arguments:
 {% highlight bash %}
 foreman-installer \
   --no-enable-foreman \
+  --no-enable-foreman-puppet \
   --no-enable-foreman-cli \
+  --no-enable-foreman-cli-puppet \
   --enable-puppet \
   --puppet-server-ca=false \
   --puppet-server-foreman-url=https://foreman.example.com \
@@ -110,7 +112,9 @@ Command line arguments for a basic smart proxy installation:
 {% highlight bash %}
 foreman-installer \
   --no-enable-foreman \
+  --no-enable-foreman-puppet \
   --no-enable-foreman-cli \
+  --no-enable-foreman-cli-puppet \
   --no-enable-puppet \
   --enable-foreman-proxy \
   --foreman-proxy-foreman-base-url=https://foreman.example.com \
@@ -126,7 +130,9 @@ Command line arguments for a smart proxy configured with just TFTP, BIND, settin
 {% highlight bash %}
 foreman-installer \
   --no-enable-foreman \
+  --no-enable-foreman-puppet \
   --no-enable-foreman-cli \
+  --no-enable-foreman-cli-puppet \
   --no-enable-puppet \
   --enable-foreman-proxy \
   --foreman-proxy-tftp=true \
@@ -154,7 +160,9 @@ Command line arguments for a smart proxy configured with just ISC DHCP and a sin
 {% highlight bash %}
 foreman-installer \
   --no-enable-foreman \
+  --no-enable-foreman-puppet \
   --no-enable-foreman-cli \
+  --no-enable-foreman-cli-puppet \
   --no-enable-puppet \
   --enable-foreman-proxy \
   --foreman-proxy-puppet=false \

--- a/_includes/manuals/nightly/3.2.3_installation_scenarios.md
+++ b/_includes/manuals/nightly/3.2.3_installation_scenarios.md
@@ -58,7 +58,9 @@ Command line arguments:
 {% highlight bash %}
 foreman-installer \
   --no-enable-foreman \
+  --no-enable-foreman-puppet \
   --no-enable-foreman-cli \
+  --no-enable-foreman-cli-puppet \
   --enable-puppet \
   --puppet-server-ca=false \
   --puppet-server-foreman-url=https://foreman.example.com \
@@ -110,7 +112,9 @@ Command line arguments for a basic smart proxy installation:
 {% highlight bash %}
 foreman-installer \
   --no-enable-foreman \
+  --no-enable-foreman-puppet \
   --no-enable-foreman-cli \
+  --no-enable-foreman-cli-puppet \
   --no-enable-puppet \
   --enable-foreman-proxy \
   --foreman-proxy-foreman-base-url=https://foreman.example.com \
@@ -126,7 +130,9 @@ Command line arguments for a smart proxy configured with just TFTP, BIND, settin
 {% highlight bash %}
 foreman-installer \
   --no-enable-foreman \
+  --no-enable-foreman-puppet \
   --no-enable-foreman-cli \
+  --no-enable-foreman-cli-puppet \
   --no-enable-puppet \
   --enable-foreman-proxy \
   --foreman-proxy-tftp=true \
@@ -154,7 +160,9 @@ Command line arguments for a smart proxy configured with just ISC DHCP and a sin
 {% highlight bash %}
 foreman-installer \
   --no-enable-foreman \
+  --no-enable-foreman-puppet \
   --no-enable-foreman-cli \
+  --no-enable-foreman-cli-puppet \
   --no-enable-puppet \
   --enable-foreman-proxy \
   --foreman-proxy-puppet=false \


### PR DESCRIPTION
Since Foreman 3.0 the Foreman and Foreman CLI Puppet plugins are installed by default. This updates the instructions to disable those where appropriate.