### PR TITLE
Use more markdown

### DIFF
--- a/_includes/manuals/nightly/3.3.3_debian_packages.md
+++ b/_includes/manuals/nightly/3.3.3_debian_packages.md
@@ -43,20 +43,26 @@ deb http://deb.theforeman.org/ plugins nightly
 The public key for [secure APT](https://wiki.debian.org/SecureApt) can be downloaded [here](https://deb.theforeman.org/pubkey.gpg)
 
 You can add this key with
-<pre>apt-key add pubkey.gpg</pre>
+```
+apt-key add pubkey.gpg
+```
 
 or combine downloading and registering:
-<pre>wget -q https://deb.theforeman.org/pubkey.gpg -O- | apt-key add -</pre>
+```
+wget -q https://deb.theforeman.org/pubkey.gpg -O- | apt-key add -
+```
 
 The key fingerprint is
-<pre>
+```
 AE0A F310 E2EA 96B6 B6F4 BD72 6F86 00B9 5632 78F6
 Foreman Automatic Signing Key (2016) <packages@theforeman.org>
-</pre>
+```
 
 Remember to update your package lists!
 
-<pre>apt-get update</pre>
+```
+apt-get update
+```
 
 #### Install packages
 

--- a/_includes/manuals/nightly/3.5.1_initial_setup.md
+++ b/_includes/manuals/nightly/3.5.1_initial_setup.md
@@ -16,8 +16,10 @@ The installer can set this up for you.
 In all cases, please use the *production* settings.
 
 to initialize the database schema and content, run:
-<pre>foreman-rake db:migrate
-foreman-rake db:seed</pre>
+```
+foreman-rake db:migrate
+foreman-rake db:seed
+```
 
 For more information please see the database configuration page
 [here](manuals/{{page.version}}/index.html#3.5.3DatabaseSetup)
@@ -29,7 +31,9 @@ At this point, you might want to go through the [[FAQ]] to see how can you impor
 #### Start The Web Server
 
 if you installed via rpm, just start the foreman service, or start the builtin web server by typing:
-<pre>RAILS_ENV=production rails server</pre>
+```
+RAILS_ENV=production rails server
+```
 
 and point your browser to `http://foreman:3000`
 

--- a/_includes/manuals/nightly/3.5.2_configuration_options.md
+++ b/_includes/manuals/nightly/3.5.2_configuration_options.md
@@ -9,41 +9,41 @@ The configuration file can also override those settings specified in the web int
 
 The first non-comment line of this file must be three dashes.
 
-<pre>
+```yaml
 ---
-</pre>
+```
 
 ##### require_ssl
 
 This boolean option configures whether Foreman insists on using only https/ssl encrypted communication channels in the web interface. This does not configure the channels used to contact the smart-proxies. Note that certain operations will still accept a http connection even if this is set, for example, the downloading of a finish script.
 
-<pre>
+```yaml
 :require_ssl: true
-</pre>
+```
 
 ##### unattended
 
 This boolean option configures whether Foreman will act as a simple node classifier for puppet, or support the full spectrum of operations required for managing a host's lifecycle. When set to _true_ then foreman will provide full host building facilities for various operating systems.
-<pre>
+```yaml
 :unattended: true
-</pre>
+```
 
 ##### support_jsonp
 
 This boolean options configures whether Foreman will provide support for the JavaScript object notation with padding. When set to _true_ then Foreman will allow to pass a callback parameter to the API calls.
 
-<pre>
+```yaml
 :support_jsonp: false
-</pre>
+```
 
 ##### logging
 
 This options contains a hash of parameters that override the current logging configuration.  It supports any of the options that are in `logging.yaml` (see below), but most usually it's used to change the log level for debugging.
 
-<pre>
+```yaml
 :logging:
   :level: debug
-</pre>
+```
 
 ##### loggers
 
@@ -59,7 +59,7 @@ Available loggers are:
 
 Uncomment or add a :loggers block to enable or disable loggers:
 
-<pre>
+```yaml
 :loggers:
   :app:
     :enabled: true
@@ -69,7 +69,7 @@ Uncomment or add a :loggers block to enable or disable loggers:
     :enabled: false
   :sql:
     :enabled: false
-</pre>
+```
 
 Some plugins may add their own loggers. See the configuration files in /etc/foreman/plugins/ which should list possibilities and enable them there.
 

--- a/_includes/manuals/nightly/3.5.3_database_setup.md
+++ b/_includes/manuals/nightly/3.5.3_database_setup.md
@@ -3,16 +3,16 @@ Foreman is a Rails application. While Rails supports different databases, Forema
 
 The database configuration file can be found at:
 
-<pre>/etc/foreman/database.yml</pre>
+`/etc/foreman/database.yml`
 
 <div class="alert alert-info">When using PostgreSQL, you should make sure that the foreman-postgresql package is installed. See <a href="manuals/{{page.version}}/index.html#3.3InstallFromPackages">3.3 Install From Packages</a>.</div>
 
 Edit your config/database.yml and modify:
-{% highlight yaml %}
+```yaml
 production:
   adapter: postgresql
   database: foreman
   username: foreman
   password: password
   host: localhost
-{% endhighlight %}
+```

--- a/_includes/manuals/nightly/3.5.4_puppet_reports.md
+++ b/_includes/manuals/nightly/3.5.4_puppet_reports.md
@@ -6,7 +6,9 @@ Foreman uses a custom puppet reports address (similar to tagmail or store) which
 ##### Client
 
 Ensure that the puppet clients has the following option in their puppet.conf:
-<pre>report = true</pre>
+```ini
+report = true
+```
 
 Without it, no reports will be sent.
 
@@ -22,7 +24,7 @@ First identify the directory containing report processors, e.g.
 Copy [the report processor source](https://raw.githubusercontent.com/theforeman/puppet-puppetserver_foreman/master/files/report.rb) to this report directory and name it `foreman.rb`.
 
 Create a new configuration file at `/etc/puppetlabs/puppet/foreman.yaml` (Puppet 4 AIO) or `/etc/puppet/foreman.yaml` (non-AIO) containing:
-<pre>
+```yaml
 ---
 # Update for your Foreman and Puppet server hostname(s)
 :url: "https://foreman.example.com"
@@ -36,13 +38,15 @@ Create a new configuration file at `/etc/puppetlabs/puppet/foreman.yaml` (Puppet
 :facts: true
 :timeout: 10
 :threads: null
-</pre>
+```
 
 Edit the URL field to point to your Foreman instance, and the SSL fields for the hostname of the Puppet server (which may be the same host). Paths to Puppet's SSL certificates will be under /var/lib/puppet/ssl/ when using Puppet with non-AIO.
 
 Lastly add this report processor to your Puppet server configuration.  In your server puppet.conf under the `[main]` section add:
 
-<pre>reports=log, foreman</pre>
+```ini
+reports=log, foreman
+```
 
 and restart your Puppet server.
 
@@ -65,11 +69,14 @@ Available conditions:
 * days => number of days to keep reports (defaults to 7)
 * status => status of the report (defaults to 0 --> "reports with no errors")
 
-Example:
+To expires all reports regardless of their status:
 
-1. Expires all reports regardless of their status
+```
+foreman-rake reports:expire days=7
+```
 
-    <pre>foreman-rake reports:expire days=7</pre>
-2. Expires all non interesting reports after one day
+To expire all non-interesting reports after one day:
 
-    <pre>foreman-rake reports:expire days=1 status=0</pre>
+```
+foreman-rake reports:expire days=1 status=0
+```

--- a/_includes/manuals/nightly/3.5.5_facts_and_the_enc.md
+++ b/_includes/manuals/nightly/3.5.5_facts_and_the_enc.md
@@ -11,7 +11,7 @@ Download [the ENC script](https://raw.githubusercontent.com/theforeman/puppet-pu
 
 Unless it already exists from setting up reporting, create a new configuration file at `/etc/puppetlabs/puppet/foreman.yaml` (Puppet AIO) or `/etc/puppet/foreman.yaml` (non-AIO) containing
 
-<pre>
+```yaml
 ---
 # Update for your Foreman and Puppet server hostname(s)
 :url: "https://foreman.example.com"
@@ -25,17 +25,17 @@ Unless it already exists from setting up reporting, create a new configuration f
 :facts: true
 :timeout: 10
 :threads: null
-</pre>
+```
 
 Edit the URL field to point to your Foreman instance, and the SSL fields for the hostname of the Puppet server (which may be the same host). Paths to Puppet's SSL certificates will be under /var/lib/puppet/ssl/ and puppetdir will be under /var/lib/puppet when using Puppet with non-AIO. More information on SSL certificates is at [Securing communications with SSL](/manuals/{{page.version}}/index.html#5.4SecuringCommunicationswithSSL).
 
 Add the following lines to the [master] section of puppet.conf:
 
-<pre>
+```ini
 [master]
   external_nodes = /etc/puppetlabs/puppet/node.rb
   node_terminus  = exec
-</pre>
+```
 
 Restart the Puppet server. When the next agent checks in, the script will upload
 fact data for this host to Foreman, and download the ENC data.
@@ -53,16 +53,20 @@ No agent configuration is necessary to use this functionality.
 
 Make sure that the puppet user can execute the ENC script and it works:
 
-    sudo -u puppet /etc/puppet/node.rb [the name of a node, eg agent.local]
+```
+sudo -u puppet /etc/puppet/node.rb [the name of a node, eg agent.local]
+```
 
 should output something like:
 
-    parameters:
-      puppetmaster: puppet
-      foreman_env: &id001 production
-    classes:
-      helloworld:
-    environment: *id001
+```yaml
+parameters:
+  puppetmaster: puppet
+  foreman_env: &id001 production
+classes:
+  helloworld:
+environment: *id001
+```
 
 This output should match the information displayed when you click on the YAML button
 on the Host page in Foreman.
@@ -79,7 +83,7 @@ For further information see the [Puppet Labs docs on external nodes](https://pup
 
 Foreman passes all associated parameters, classes,and class parameters, to the Host,
 including those inherited from host groups, domains, or global settings. See section
-<a href="manuals/{{page.version}}/index.html#4.2ManagingPuppet">Managing Puppet</a> for
+[Managing Puppet](/manuals/{{page.version}}/index.html#4.2ManagingPuppet) for
 more information on assigning configuration to hosts.
 
 #### Creating hosts in Foreman with facts
@@ -113,7 +117,9 @@ all of it to Foreman.
 
 Download and configure the node.rb script as above, and then call it like this:
 
-    sudo -u puppet /etc/puppetlabs/puppet/node.rb --push-facts
+```
+sudo -u puppet /etc/puppetlabs/puppet/node.rb --push-facts
+```
 
 The following options are available for node.rb's batch mode:
 
@@ -130,16 +136,18 @@ The following options are available for node.rb's batch mode:
 Foreman's fact-upload API endpoint accepts data in pure JSON. You can push data
 to Foreman as a hash containing:
 
-    {
-      "name": "fqdn-of-host.domain.com",
-      "certname": "optional-certname-of-host.domain.com",
-      "facts": {
-        "fact1": "string",
-        "fact2": "true",
-        "fact3": "1.2.3.4",
-        ...
-      }
-    }
+```json
+{
+  "name": "fqdn-of-host.domain.com",
+  "certname": "optional-certname-of-host.domain.com",
+  "facts": {
+    "fact1": "string",
+    "fact2": "true",
+    "fact3": "1.2.3.4",
+    ...
+  }
+}
+```
 
 The 'certname' is optional but will be used to locate the Host in Foreman when
 supplied. See [the API documentation](/api/{{page.version}}/apidoc/v2/hosts/facts.html) for more details.

--- a/_includes/manuals/nightly/4.1.4_auditing.md
+++ b/_includes/manuals/nightly/4.1.4_auditing.md
@@ -28,12 +28,15 @@ Examples:
 
 1. Expires all audits older then 90 days
 
-		<pre>foreman-rake audits:expire</pre>
+```
+foreman-rake audits:expire
+```
 
 2. Expires all audits older then 7 days
 
-		<pre>foreman-rake audits:expire days=7</pre>
-
+```
+foreman-rake audits:expire days=7
+```
 
 Note that you can also set a cronjob which will delete your audits periodically using this rake task.
 
@@ -48,7 +51,9 @@ Example:
 
 1. Anonymizes all audits older then 7 days
 
-		<pre>foreman-rake audits:anonymize days=7</pre>
+```
+foreman-rake audits:anonymize days=7
+```
 
 #### Organizations and Locations
 

--- a/_includes/manuals/nightly/4.3.10_smartproxy_ssl.md
+++ b/_includes/manuals/nightly/4.3.10_smartproxy_ssl.md
@@ -9,17 +9,17 @@ If the smart proxy host is not managed by Puppet, you will need to generate a ce
 
 When using Puppet's certificates, the following lines will be required in puppet.conf to relax permissions to the `puppet` group.  The `foreman` and/or `foreman-proxy` users should then be added to the `puppet` group.
 
-<pre>
+```ini
 [main]
 privatekeydir = $ssldir/private_keys { group = service }
 hostprivkey = $privatekeydir/$certname.pem { mode = 640 }
-</pre>
+```
 
 ##### Configuring the proxy
 
 Configure the locations to the SSL files in `/etc/foreman-proxy/settings.yml`, plus the list of trusted Foreman hosts:
 
-<pre>
+```yaml
 :ssl_certificate: /etc/puppetlabs/puppet/ssl/certs/FQDN.pem
 :ssl_ca_file: /etc/puppetlabs/puppet/ssl/certs/ca.pem
 :ssl_private_key: /etc/puppetlabs/puppet/ssl/private_keys/FQDN.pem
@@ -27,7 +27,7 @@ Configure the locations to the SSL files in `/etc/foreman-proxy/settings.yml`, p
 :trusted_hosts:
 - foreman.corp.com
 #- foreman.dev.domain
-</pre>
+```
 
 ##### SSL cipher suites
 
@@ -46,9 +46,9 @@ Please note, the smart proxy uses the OpenSSL suite naming scheme. For more info
 
 Certain users may require to disable certain cipher suites due to security policies or newly discovered weaknesses. This can be done by using the `:ssl_disabled_ciphers:` option in `/etc/foreman-proxy/settings.yml`.  For example:
 
-<pre>
+```yaml
 :ssl_disabled_ciphers: ['AES128-SHA','AES256-SHA']
-</pre>
+```
 
 ##### Generating a certificate
 

--- a/_includes/manuals/nightly/4.3.1_smartproxy_installation.md
+++ b/_includes/manuals/nightly/4.3.1_smartproxy_installation.md
@@ -15,9 +15,9 @@ RPM and Debian packages are available, see the [Install from Packages](manuals/{
 
 You can get the latest stable code from [GitHub](https://github.com/theforeman/smart-proxy) ([via git](git://github.com/theforeman/smart-proxy.git)).
 
-<pre>
+```
 git clone git://github.com/theforeman/smart-proxy.git -b {{page.version}}-stable
-</pre>
+```
 
 #### System requirements
 
@@ -48,7 +48,7 @@ The Microsoft smart-proxy installation procedure is very basic compared to the R
 1. Copy *settings.yml.example* inside *config* to *settings.yml*
 1. At very least, modify the settings for `:bind_host:` and `:log_file:` and SSL, for example:
 
-```
+```yaml
 :bind_host: '0.0.0.0'
 :log_file: 'C:\smart-proxy.log'
 
@@ -57,7 +57,6 @@ The Microsoft smart-proxy installation procedure is very basic compared to the R
 :ssl_certificate: <smart-proxy location>\ssl\host.example.com.pem
 :ssl_private_key: <smart-proxy location>\ssl\host.example.com.pem
 :ssl_ca_file:     <smart-proxy location>\ssl\ca.pem
-
 ```
 
 ##### Test and configure smart proxy features
@@ -70,7 +69,7 @@ __Caveats:__ There is an issue with DevKit not finding any ruby version installe
 
 __Puppet hint:__ If you have Puppet installed on the same host running smart-proxy, you can use Puppet's Ruby. You only need DevKit. In this case, just add directory containing `ruby.exe` to your path variable and add it to DevKit settings if necessary by editing DevKit's `config.yml`. Also, you might want to use Puppet's host certificates right away for smart proxy SSL connections. Usually, they can be found in `C:\ProgramData\PuppetLabs\puppet\etc\ssl`. For example:
 
-```
+```yaml
 :ssl_certificate: C:\ProgramData\PuppetLabs\puppet\etc\ssl\certs\host.example.com.pem
 :ssl_private_key: C:\ProgramData\PuppetLabs\puppet\etc\ssl\private_keys\host.example.com.pem
 :ssl_ca_file:     C:\ProgramData\PuppetLabs\puppet\etc\ssl\certs\ca.pem
@@ -85,15 +84,15 @@ Configuration of each subsystem is usually in /etc/foreman-proxy/settings.d/ or 
 
 #### Start the daemon
 
-<pre>
+```
 bundle exec bin/smart-proxy
-</pre>
+```
 
 Or if you installed it via a package simply start the foreman-proxy service.
 
-<pre>
+```
 service foreman-proxy start
-</pre>
+```
 
 #### Add the Smart Proxy to Foreman
 

--- a/_includes/manuals/nightly/4.3.2_smartproxy_settings.md
+++ b/_includes/manuals/nightly/4.3.2_smartproxy_settings.md
@@ -6,16 +6,18 @@ Each of the modules used in the Smart Proxy have their configuration in the */et
 
 The first non-comment line of all configuration files must be three dashes.
 
-<pre>---</pre>
+```yaml
+---
+```
 
 #### Daemon configuration (settings.yml)
 
 If daemon is present and true then the Smart Proxy will attempt to disconnect itself from the controlling terminal and daemonize itself on startup, writing its pid (process ID) into the specified file.
 
-<pre>
+```yaml
 :daemon: true
 :daemon_pid: /var/run/foreman-proxy/foreman-proxy.pid
-</pre>
+```
 
 #### Logging (settings.yml)
 
@@ -30,10 +32,10 @@ The proxy's output is captured to the **log_file** and may be filtered via the u
 
 See Ruby's [Logger class](http://www.ruby-doc.org/stdlib/libdoc/logger/rdoc/classes/Logger.html) for details.
 
-<pre>
+```yaml
 :log_file: /var/log/foreman-proxy/proxy.log
 :log_level: DEBUG
-</pre>
+```
 
 The log_file setting may be set to "STDOUT" which causes log messages to be logged to standard output, for capture by the running process (e.g. systemd with journal).  When log_file is set to "SYSLOG", all messages will be sent to syslog.
 
@@ -41,21 +43,21 @@ A limited number of recent log messages are kept in memory using a ring buffer, 
 
 The number of all log messages is controlled by the `log_buffer` setting, and a second buffer of error messages is controlled by the `log_buffer_errors` setting.  The total of the two will directly affect the maximum amount of memory used, which is approximately 500kB in the default configuration of 3,000 recent messages.
 
-<pre>
+```yaml
 :log_buffer: 2000
 :log_buffer_errors: 1000
-</pre>
+```
 
 #### Listening configuration (settings.yaml)
 
 By default the Smart Proxy listens on all interfaces, which can be changed to limit access to a network:
 
-<pre>
+```yaml
 # host to bind ports to (possible values: *, localhost, 0.0.0.0)
 :bind_host: ['*']
 :bind_host: private.example.com
 :bind_host: 192.168.1.10
-</pre>
+```
 
 On EL7, the default value for `bind_host` is `::`. Keep in mind that if IPv6 has been disabled at the kernel level, you will need to change it to `*` manually.
 
@@ -63,10 +65,10 @@ The Smart Proxy has a number of different modules which can be enabled either fo
 
 The two port options control which TCP port(s) the Smart Proxy will listen on.  At least one must be enabled for the proxy to start.  It is recommended to only set https_port unless an HTTP-only module is active, which also requires the three ssl_* settings to be set.
 
-<pre>
+```yaml
 :http_port: 8000
 :https_port: 8443
-</pre>
+```
 
 <div class="alert alert-info">Be careful when enabling http_port, ensure settings.d/ files are enabled only on HTTPS or trusted_hosts is set appropriately so modules are not exposed without security on HTTP.</div>
 
@@ -84,11 +86,11 @@ The existence of all the three ssl key entries below requires the use of an SSL 
 **NOTE** that both client certificates need to be signed by the same CA, which must be in the *ssl_ca_file*, in order for this to work
 see [**SSL**](manuals/{{page.version}}/index.html#4.3.10SSL) for more information
 
-<pre>
+```yaml
 :ssl_certificate: ssl/certs/fqdn.pem
 :ssl_ca_file: ssl/certs/ca.pem
 :ssl_private_key: ssl/private_keys/fqdn.key
-</pre>
+```
 
 Specific SSL cipher suites can be disabled by using the `:ssl_disabled_ciphers:` option. For more information on which cipher suites are enabled by default and how to correctly disable specific ones, please see [**SSL cipher suites**](manuals/{{page.version}}/index.html#ssl-cipher-suites).
 
@@ -96,11 +98,11 @@ The TLS versions can be disabled if requiring a specific version. So while insec
 
 This is the list of hosts from which the smart proxy will accept connections.  For HTTPS connections, the name must match the common name (CN) within the subject DN and for HTTP connections, it must match the hostname from reverse DNS.
 
-<pre>
+```yaml
 :trusted_hosts:
   - foreman.prod.domain
   - foreman.dev.domain
-</pre>
+```
 
 For HTTPS connections, the name must match the common name (CN) within the subject DN and for HTTP connections, it must match the hostname from reverse DNS.  When `:forward_verify` is enabled (default: true) then the reverse lookup is verified against the forward lookup of the hostname (aka forward-confirmed reverse DNS/FCrDNS).
 

--- a/_includes/manuals/nightly/4.3.3_smartproxy_bmc.md
+++ b/_includes/manuals/nightly/4.3.3_smartproxy_bmc.md
@@ -1,10 +1,10 @@
 
 Activate the BMC management module within the Smart Proxy instance.  This allows users to trigger power management commands through the proxy to controlled hosts using IPMI or similar.
 
-<pre>
+```yaml
 :enabled: https
 :bmc_default_provider: freeipmi
-</pre>
+```
 
 Available providers are:
 

--- a/_includes/manuals/nightly/4.3.4.2_isc_dhcp.md
+++ b/_includes/manuals/nightly/4.3.4.2_isc_dhcp.md
@@ -7,7 +7,7 @@ ISC implementation is based on the OMAPI interface, which means:
 
 * dhcpd configuration file:
 ensure you have the following line in your dhcpd.conf file (somewhere in the top first lines):
-<pre>omapi-port 7911;</pre>
+`omapi-port 7911;`
 * configure the settings file to point to your dhcpd.conf and dhcpd.leases files (make sure they are readable by the smart-proxy user)
 * make sure the omshell command (/usr/bin/omshell) can be executed by the smart-proxy user.
 * make sure that /etc/dhcp and /etc/dhcp/dhcpd.conf has group foreman-proxy
@@ -18,22 +18,22 @@ ensure you have the following line in your dhcpd.conf file (somewhere in the top
 The dhcpd api server will listen to any host. You might need to add a omapi_key to provide basic security.
 
 Example generating a key (on CentOS):
-<pre>
+```
 yum install bind
 dnssec-keygen -r /dev/urandom -a HMAC-MD5 -b 512 -n HOST omapi_key
 cat Komapi_key.+*.private |grep ^Key|cut -d ' ' -f2-
-</pre>
+```
 
 1. Edit your "/etc/dhcpd.conf":
 
-    <pre>
-    omapi-port 7911;
-    key omapi_key {
-    algorithm HMAC-MD5;
-    secret "XXXXXXXXX"; #<-The output from the generated key above.
-    };
-    omapi-key omapi_key;
-    </pre>
+```
+omapi-port 7911;
+key omapi_key {
+algorithm HMAC-MD5;
+  secret "XXXXXXXXX"; #<-The output from the generated key above.
+};
+omapi-key omapi_key;
+```
 
 2. Make sure you also add the omapi_key to your proxy's [dhcp_isc.yml](/manuals/{{page.version}}/index.html#4.3.4DHCP)
 
@@ -44,7 +44,7 @@ cat Komapi_key.+*.private |grep ^Key|cut -d ' ' -f2-
 The next step is to set up appropriate Subnets in Foreman from the settings menu.
 
 ##### Sample dhcpd.conf
-<pre>
+```
 ddns-update-style interim;
 ignore client-updates;
 authoritative;
@@ -74,4 +74,4 @@ subnet 10.1.1.0 netmask 255.255.255.0 {
   max-lease-time 43200;
 
 }
-</pre>
+```

--- a/_includes/manuals/nightly/4.3.5.2_bind.md
+++ b/_includes/manuals/nightly/4.3.5.2_bind.md
@@ -9,7 +9,7 @@ In order to communicate securely with your dns server, you would need a key whic
 
 execute 'ddns-confgen -k foreman -a hmac-md5' - this should output something like the following:
 
-<pre>
+```
 # To activate this key, place the following in named.conf, and
 # in a separate keyfile on the system or systems from which nsupdate
 # will be run:
@@ -29,7 +29,7 @@ update-policy {
 # After the keyfile has been placed, the following command will
 # execute nsupdate using this key:
 nsupdate -k /path/to/keyfile
-</pre>
+```
 
 You should create a new file (such as /etc/rndc.key or other) and store the key "foreman {...} in it.
 in the proxy Settings file you should point to this file location - make sure that the proxy have read permissions to this file.

--- a/_includes/manuals/nightly/4.3.6_smartproxy_puppet.md
+++ b/_includes/manuals/nightly/4.3.6_smartproxy_puppet.md
@@ -32,7 +32,7 @@ To get a list of environments, classes and their parameters, the proxy queries t
 
 The Puppetserver has to permit these API queries. The [HOCON-formatted auth.conf style](https://docs.puppet.com/puppetserver/latest/config_file_auth.html) is at /etc/puppetlabs/puppetserver/conf.d/auth.conf and requires these rules:
 
-<pre>
+```hocon
 {
     match-request: {
         path: "/puppet/v3/environments"
@@ -53,4 +53,4 @@ The Puppetserver has to permit these API queries. The [HOCON-formatted auth.conf
     sort-order: 500
     name: "puppetlabs environment classes"
 },
-</pre>
+```

--- a/_includes/manuals/nightly/4.3.8_smartproxy_realm.md
+++ b/_includes/manuals/nightly/4.3.8_smartproxy_realm.md
@@ -1,10 +1,10 @@
 
 Activate the realm management module within the Smart Proxy instance.  This manages Kerberos realms or domains, allowing Foreman to add and remove hosts to enable them to join the realm/domain automatically during provisioning.
 
-<pre>
+```yaml
 :enabled: https
 :use_provider: realm_freeipa
-</pre>
+```
 
 Builtin providers are:
 
@@ -14,8 +14,8 @@ The configuration for each provider should be in its respective file, i.e: `/etc
 
 The following settings control authentication of the proxy to the realm for management of hosts.
 In `realm_freeipa.yml`:
-<pre>
+```yaml
 # Authentication for Kerberos-based Realms
 :keytab_path: /etc/foreman-proxy/freeipa.keytab
 :principal: realm-proxy@EXAMPLE.COM
-</pre>
+```

--- a/_includes/manuals/nightly/4.3.9_smartproxy_tftp.md
+++ b/_includes/manuals/nightly/4.3.9_smartproxy_tftp.md
@@ -4,11 +4,11 @@
 Activate the TFTP management module within the Smart Proxy instance.  This is designed to manage files on a TFTP server, e.g. bootloaders for OS installation and PXE menu files.
 
 The *tftproot* value is directory into which TFTP files are copied and then served from. The TFTP daemon will also be expected to chroot to this location. This component is only supported in a Unix environment.
-<pre>
+```yaml
 :enabled: https
 :tftproot: /var/lib/tftpboot
 :tftp_servername: name of your tftp server (used for next server value in your dhcp reservation) - defaults to the host name of your proxy.
-</pre>
+```
 
 <div class="alert alert-info">The foreman-proxy user must have read/write access to the _tftpboot/pxelinux.cfg_ and _tftpboot/boot_ directories.</div>
 

--- a/_includes/manuals/nightly/4.5.2_cli_success.md
+++ b/_includes/manuals/nightly/4.5.2_cli_success.md
@@ -4,80 +4,80 @@ There was a set of common commands identified as necessary for basic Foreman man
 The goal is to provision bare metal host on a clean install of Foreman. The following steps are necessary:
 
 * create smart proxy
-<pre>
+```
 hammer proxy create --name myproxy --url https://proxy.my.net:8443
-</pre>
+```
 * create architecture
-<pre>
+```
 hammer architecture create --name x86_64
-</pre>
+```
 * create new subnet
-<pre>
+```
 hammer subnet create --name "My Net" --network "192.168.122.0" --mask "255.255.255.0" --gateway "192.168.122.1" --dns-primary "192.168.122.1"
-</pre>
+```
 * import existing subnet from a proxy
 
     missing, see [#3355](http://projects.theforeman.org/issues/3355)
 * create new domain
-<pre>
+```
 hammer domain create --name "my.net" --fullname "My network"
-</pre>
+```
 * associate domain with proxy
-<pre>
+```
 hammer domain update --id 1 --dns-id 1
-</pre>
+```
 * associate subnet with domain
-<pre>
+```
 hammer subnet update --id 1 --domain-ids 1
-</pre>
+```
 * associate subnet with proxy (DHCP, TFTP, DNS)
-<pre>
+```
 hammer subnet update --id 1 --dhcp-id 1 --tftp-id 1 --dns-id 1
-</pre>
+```
 * create new partition table
-<pre>
+```
 hammer partition_table create --name "Redhat test" --file /tmp/rh_test.txt
-</pre>
+```
 * create new OS
-<pre>
+```
 hammer os create --name RHEL --major 6 --minor 4
-</pre>
+```
 * create new template
-<pre>
+```
 hammer template create --name "kickstart mynet" --type provision --file /tmp/ks.txt
-</pre>
+```
 * edit existing pre-defined template
-<pre>
+```
 hammer template dump --id 4 > /tmp/ks.txt
     vim /tmp/ks.txt
 hammer template update --id 4 --file /tmp/ks.txt
-</pre>
+```
 * associate applicable OS with pre-defined template
-<pre>
+```
 hammer template update --id 1 --operatingsystem-ids 1
-</pre>
+```
 
    Listing associated OS's is still missing - see [#3360](http://projects.theforeman.org/issues/3360)
 
 * associate OS with architecture
-<pre>
+```
 hammer os update --id 1 --architecture-ids 1
-</pre>
+```
 * associate OS with part table
-<pre>
+```
 hammer os update --id 1 --ptable-ids 1
-</pre>
+```
 * associate OS with install media
-<pre>
+```
 hammer os update --id 1 --medium-ids 1
-</pre>
+```
 * associate OS with install provision and pxelinux templates
 
     Missing, needs investigation, may be related to [#3360](http://projects.theforeman.org/issues/3360)
 * create libvirt compute resource
-<pre>
+```
 hammer compute_resource create --name libvirt --url "qemu:///system" --provider Libvirt
-</pre>
+```
 * import puppet classes
 
     missing - see [#3035](http://projects.theforeman.org/issues/3035)

--- a/_includes/manuals/nightly/5.4.2_comms_proxy.md
+++ b/_includes/manuals/nightly/5.4.2_comms_proxy.md
@@ -7,7 +7,7 @@ In a simple setup, a single Puppet Certificate Authority (CA) can be used for au
 
 `/etc/foreman-proxy/settings.yml` contains the locations to the SSL certificates and keys:
 
-<pre>
+```yaml
 ---
 # SSL Setup
 
@@ -17,20 +17,19 @@ In a simple setup, a single Puppet Certificate Authority (CA) can be used for au
 :ssl_certificate: /etc/puppetlabs/puppet/ssl/certs/FQDN.pem
 :ssl_ca_file: /etc/puppetlabs/puppet/ssl/certs/ca.pem
 :ssl_private_key: /etc/puppetlabs/puppet/ssl/private_keys/FQDN.pem
-</pre>
+```
 
 In this example, the proxy is sharing Puppet's certificates, but it could equally use its own.
 
 In addition it contains a list of hosts that connections will be accepted from, which should be the host(s) running Foreman:
 
-<pre>
+```yaml
 # the hosts which the proxy accepts connections from
 # commenting the following lines would mean every verified SSL connection allowed
 :trusted_hosts:
 - foreman.corp.com
 #- foreman.dev.domain
-</pre>
-
+```
 
 ##### Configuring Foreman
 
@@ -45,10 +44,10 @@ Lastly, when adding the smart proxy in Foreman, ensure the URL begins with `http
 
 If using Puppet's certificates, the following lines will be required in puppet.conf to relax permissions to the `puppet` group.  The `foreman` and/or `foreman-proxy` users should then be added to the `puppet` group.
 
-<pre>
+```ini
 [main]
 privatekeydir = $ssldir/private_keys { group = service }
 hostprivkey = $privatekeydir/$certname.pem { mode = 640 }
-</pre>
+```
 
 Note that the "service" keyword will be interpreted by Puppet as the "puppet" service group.


### PR DESCRIPTION
This replaces various HTML tags and uses native markdown syntax. This also brings in more syntax highlighting.

In `3.5.5_facts_and_the_enc.md` the phrasing is changed a bit. Otherwise the numbering was off. It would have been `1. ... 1. ...` instead of `1. ... 2. ...`.