### PR TITLE
Correct Debian package installation from packages & SP Ruby version

### DIFF
--- a/_includes/manuals/3.0/3.3.3_debian_packages.md
+++ b/_includes/manuals/3.0/3.3.3_debian_packages.md
@@ -5,6 +5,7 @@ The Foreman packages should work on the following Debian-based Linux distributio
 
 * Debian Linux 10 (Buster), amd64
 * Ubuntu Linux 18.04 LTS (Bionic Beaver), amd64
+* Ubuntu Linux 20.04 LTS (Focal Fossa), amd64
 
 If you encounter any errors during the installation, [please file a bug report!](/contribute.html#Bugreporting)
 
@@ -12,55 +13,42 @@ If you encounter any errors during the installation, [please file a bug report!]
 
 Add one of the following lines to your */etc/apt/sources.list* (alternatively in a separate file in */etc/apt/sources.list.d/foreman.list*):
 
-{% highlight bash %}
-# Stable packages
-
+```
 # Debian Buster
 deb http://deb.theforeman.org/ buster {{page.version}}
 # Ubuntu 18.04 Bionic
 deb http://deb.theforeman.org/ bionic {{page.version}}
 # Ubuntu 20.04 Focal
 deb http://deb.theforeman.org/ focal {{page.version}}
-
-# Nightly builds. Beware: HERE BE DRAGONS
-
-# Debian Buster
-deb http://deb.theforeman.org/ buster nightly
-# Ubuntu 18.04 Bionic
-deb http://deb.theforeman.org/ bionic nightly
-# Ubuntu 20.04 Focal
-deb http://deb.theforeman.org/ focal nightly
-{% endhighlight %}
+```
 
 You may also want some plugins from the plugin repo (required for the Foreman Installer):
-{% highlight bash %}
-# Plugins compatible with Stable
+```
 deb http://deb.theforeman.org/ plugins {{page.version}}
-# Plugins compatible with Nightly
-deb http://deb.theforeman.org/ plugins nightly
-{% endhighlight %}
+```
 
 The public key for [secure APT](https://wiki.debian.org/SecureApt) can be downloaded [here](https://deb.theforeman.org/pubkey.gpg)
 
-You can add this key with
-<pre>apt-key add pubkey.gpg</pre>
-
-or combine downloading and registering:
-<pre>wget -q https://deb.theforeman.org/pubkey.gpg -O- | apt-key add -</pre>
+You can add this key with:
+```
+wget https://deb.theforeman.org/foreman.asc -O /etc/apt/trusted.gpg.d/foreman.asc
+```
 
 The key fingerprint is
-<pre>
-AE0A F310 E2EA 96B6 B6F4 BD72 6F86 00B9 5632 78F6
-Foreman Automatic Signing Key (2016) <packages@theforeman.org>
-</pre>
+```
+5B7C 3E5A 735B CB4D 6158 29DC 0BDD A991 FD7A AC8A
+Foreman Automatic Signing Key (2021) <packages@theforeman.org>
+```
 
 Remember to update your package lists!
 
-<pre>apt-get update</pre>
+```
+apt-get update
+```
 
 #### Install packages
 
-The packages are now split by gem dependencies - there are 11 packages to choose from. These are:
+The packages are split by gem dependencies - there are 15 packages to choose from. These are:
 
 Main package:
 
@@ -68,18 +56,22 @@ Main package:
 
 Database gems:
 
-* foreman-pgsql
+* foreman-postgresql
 
 Optional functionality:
 
 * foreman-console
 * foreman-debug
+* foreman-dynflow-sidekiq
 * foreman-ec2
 * foreman-gce
+* foreman-journald
 * foreman-libvirt
 * foreman-openstack
 * foreman-ovirt
-* foreman-test
+* foreman-redis
+* foreman-service
+* foreman-telemetry
 * foreman-vmware
 
 Command line interface:
@@ -89,9 +81,9 @@ Command line interface:
 
 Installation instructions are:
 
-{% highlight bash %}
+```bash
 # Install packages  (adjust additional packages as needed)
-apt-get install foreman foreman-pgsql foreman-libvirt
+apt-get install foreman foreman-postgresql foreman-libvirt
 
 # Copy sample db config to /etc
 cp /usr/share/foreman/config/database.yml.example /etc/foreman/database.yml
@@ -102,7 +94,7 @@ vi /etc/foreman/settings.yaml /etc/foreman/database.yml
 # Perform initial DB setup
 foreman-rake db:migrate
 foreman-rake db:seed
-{% endhighlight %}
+```
 
 The packages should auto-run db:migrate and db:seed if */etc/foreman/database.yml* exists. So the initial DB setup is only needed during first install, upgrades should just work.
 

--- a/_includes/manuals/3.0/4.3.1_smartproxy_installation.md
+++ b/_includes/manuals/3.0/4.3.1_smartproxy_installation.md
@@ -23,7 +23,7 @@ git clone git://github.com/theforeman/smart-proxy.git -b {{page.version}}-stable
 
 The smart proxy will run with the following requirements (aside from rubygem dependencies):
 
-* Ruby 2.5 or 2.6
+* Ruby 2.5, 2.6 or 2.7
 
 #### Windows
 The Microsoft smart-proxy installation procedure is very basic compared to the RPM or APT based solution. You need to run smart-proxy from the source as well as install Ruby and Ruby DevKit.

--- a/_includes/manuals/3.1/3.3.3_debian_packages.md
+++ b/_includes/manuals/3.1/3.3.3_debian_packages.md
@@ -4,7 +4,7 @@ The Foreman packages should work on the following Debian-based Linux distributio
 #### Distributions
 
 * Debian Linux 10 (Buster), amd64
-* Ubuntu Linux 18.04 LTS (Bionic Beaver), amd64
+* Ubuntu Linux 20.04 LTS (Focal Fossa), amd64
 
 If you encounter any errors during the installation, [please file a bug report!](/contribute.html#Bugreporting)
 
@@ -12,55 +12,40 @@ If you encounter any errors during the installation, [please file a bug report!]
 
 Add one of the following lines to your */etc/apt/sources.list* (alternatively in a separate file in */etc/apt/sources.list.d/foreman.list*):
 
-{% highlight bash %}
-# Stable packages
-
+```
 # Debian Buster
 deb http://deb.theforeman.org/ buster {{page.version}}
-# Ubuntu 18.04 Bionic
-deb http://deb.theforeman.org/ bionic {{page.version}}
 # Ubuntu 20.04 Focal
 deb http://deb.theforeman.org/ focal {{page.version}}
-
-# Nightly builds. Beware: HERE BE DRAGONS
-
-# Debian Buster
-deb http://deb.theforeman.org/ buster nightly
-# Ubuntu 18.04 Bionic
-deb http://deb.theforeman.org/ bionic nightly
-# Ubuntu 20.04 Focal
-deb http://deb.theforeman.org/ focal nightly
-{% endhighlight %}
+```
 
 You may also want some plugins from the plugin repo (required for the Foreman Installer):
-{% highlight bash %}
-# Plugins compatible with Stable
+```
 deb http://deb.theforeman.org/ plugins {{page.version}}
-# Plugins compatible with Nightly
-deb http://deb.theforeman.org/ plugins nightly
-{% endhighlight %}
+```
 
 The public key for [secure APT](https://wiki.debian.org/SecureApt) can be downloaded [here](https://deb.theforeman.org/pubkey.gpg)
 
-You can add this key with
-<pre>apt-key add pubkey.gpg</pre>
-
-or combine downloading and registering:
-<pre>wget -q https://deb.theforeman.org/pubkey.gpg -O- | apt-key add -</pre>
+You can add this key with:
+```
+wget https://deb.theforeman.org/foreman.asc -O /etc/apt/trusted.gpg.d/foreman.asc
+```
 
 The key fingerprint is
-<pre>
-AE0A F310 E2EA 96B6 B6F4 BD72 6F86 00B9 5632 78F6
-Foreman Automatic Signing Key (2016) <packages@theforeman.org>
-</pre>
+```
+5B7C 3E5A 735B CB4D 6158 29DC 0BDD A991 FD7A AC8A
+Foreman Automatic Signing Key (2021) <packages@theforeman.org>
+```
 
 Remember to update your package lists!
 
-<pre>apt-get update</pre>
+```
+apt-get update
+```
 
 #### Install packages
 
-The packages are now split by gem dependencies - there are 11 packages to choose from. These are:
+The packages are split by gem dependencies - there are 15 packages to choose from. These are:
 
 Main package:
 
@@ -68,18 +53,22 @@ Main package:
 
 Database gems:
 
-* foreman-pgsql
+* foreman-postgresql
 
 Optional functionality:
 
 * foreman-console
 * foreman-debug
+* foreman-dynflow-sidekiq
 * foreman-ec2
 * foreman-gce
+* foreman-journald
 * foreman-libvirt
 * foreman-openstack
 * foreman-ovirt
-* foreman-test
+* foreman-redis
+* foreman-service
+* foreman-telemetry
 * foreman-vmware
 
 Command line interface:
@@ -89,9 +78,9 @@ Command line interface:
 
 Installation instructions are:
 
-{% highlight bash %}
+```bash
 # Install packages  (adjust additional packages as needed)
-apt-get install foreman foreman-pgsql foreman-libvirt
+apt-get install foreman foreman-postgresql foreman-libvirt
 
 # Copy sample db config to /etc
 cp /usr/share/foreman/config/database.yml.example /etc/foreman/database.yml
@@ -102,7 +91,7 @@ vi /etc/foreman/settings.yaml /etc/foreman/database.yml
 # Perform initial DB setup
 foreman-rake db:migrate
 foreman-rake db:seed
-{% endhighlight %}
+```
 
 The packages should auto-run db:migrate and db:seed if */etc/foreman/database.yml* exists. So the initial DB setup is only needed during first install, upgrades should just work.
 

--- a/_includes/manuals/3.1/4.3.1_smartproxy_installation.md
+++ b/_includes/manuals/3.1/4.3.1_smartproxy_installation.md
@@ -23,7 +23,7 @@ git clone git://github.com/theforeman/smart-proxy.git -b {{page.version}}-stable
 
 The smart proxy will run with the following requirements (aside from rubygem dependencies):
 
-* Ruby 2.5 or 2.6
+* Ruby 2.5, 2.6 or 2.7
 
 #### Windows
 The Microsoft smart-proxy installation procedure is very basic compared to the RPM or APT based solution. You need to run smart-proxy from the source as well as install Ruby and Ruby DevKit.

--- a/_includes/manuals/nightly/3.3.3_debian_packages.md
+++ b/_includes/manuals/nightly/3.3.3_debian_packages.md
@@ -4,7 +4,7 @@ The Foreman packages should work on the following Debian-based Linux distributio
 #### Distributions
 
 * Debian Linux 10 (Buster), amd64
-* Ubuntu Linux 18.04 LTS (Bionic Beaver), amd64
+* Ubuntu Linux 20.04 LTS (Focal Fossa), amd64
 
 If you encounter any errors during the installation, [please file a bug report!](/contribute.html#Bugreporting)
 
@@ -12,50 +12,29 @@ If you encounter any errors during the installation, [please file a bug report!]
 
 Add one of the following lines to your */etc/apt/sources.list* (alternatively in a separate file in */etc/apt/sources.list.d/foreman.list*):
 
-{% highlight bash %}
-# Stable packages
-
+```
 # Debian Buster
 deb http://deb.theforeman.org/ buster {{page.version}}
-# Ubuntu 18.04 Bionic
-deb http://deb.theforeman.org/ bionic {{page.version}}
 # Ubuntu 20.04 Focal
 deb http://deb.theforeman.org/ focal {{page.version}}
-
-# Nightly builds. Beware: HERE BE DRAGONS
-
-# Debian Buster
-deb http://deb.theforeman.org/ buster nightly
-# Ubuntu 18.04 Bionic
-deb http://deb.theforeman.org/ bionic nightly
-# Ubuntu 20.04 Focal
-deb http://deb.theforeman.org/ focal nightly
-{% endhighlight %}
+```
 
 You may also want some plugins from the plugin repo (required for the Foreman Installer):
-{% highlight bash %}
-# Plugins compatible with Stable
+```
 deb http://deb.theforeman.org/ plugins {{page.version}}
-# Plugins compatible with Nightly
-deb http://deb.theforeman.org/ plugins nightly
-{% endhighlight %}
+```
 
 The public key for [secure APT](https://wiki.debian.org/SecureApt) can be downloaded [here](https://deb.theforeman.org/pubkey.gpg)
 
-You can add this key with
+You can add this key with:
 ```
-apt-key add pubkey.gpg
-```
-
-or combine downloading and registering:
-```
-wget -q https://deb.theforeman.org/pubkey.gpg -O- | apt-key add -
+wget https://deb.theforeman.org/foreman.asc -O /etc/apt/trusted.gpg.d/foreman.asc
 ```
 
 The key fingerprint is
 ```
-AE0A F310 E2EA 96B6 B6F4 BD72 6F86 00B9 5632 78F6
-Foreman Automatic Signing Key (2016) <packages@theforeman.org>
+5B7C 3E5A 735B CB4D 6158 29DC 0BDD A991 FD7A AC8A
+Foreman Automatic Signing Key (2021) <packages@theforeman.org>
 ```
 
 Remember to update your package lists!
@@ -66,7 +45,7 @@ apt-get update
 
 #### Install packages
 
-The packages are now split by gem dependencies - there are 11 packages to choose from. These are:
+The packages are split by gem dependencies - there are 15 packages to choose from. These are:
 
 Main package:
 
@@ -74,18 +53,22 @@ Main package:
 
 Database gems:
 
-* foreman-pgsql
+* foreman-postgresql
 
 Optional functionality:
 
 * foreman-console
 * foreman-debug
+* foreman-dynflow-sidekiq
 * foreman-ec2
 * foreman-gce
+* foreman-journald
 * foreman-libvirt
 * foreman-openstack
 * foreman-ovirt
-* foreman-test
+* foreman-redis
+* foreman-service
+* foreman-telemetry
 * foreman-vmware
 
 Command line interface:
@@ -95,9 +78,9 @@ Command line interface:
 
 Installation instructions are:
 
-{% highlight bash %}
+```bash
 # Install packages  (adjust additional packages as needed)
-apt-get install foreman foreman-pgsql foreman-libvirt
+apt-get install foreman foreman-postgresql foreman-libvirt
 
 # Copy sample db config to /etc
 cp /usr/share/foreman/config/database.yml.example /etc/foreman/database.yml
@@ -108,7 +91,7 @@ vi /etc/foreman/settings.yaml /etc/foreman/database.yml
 # Perform initial DB setup
 foreman-rake db:migrate
 foreman-rake db:seed
-{% endhighlight %}
+```
 
 The packages should auto-run db:migrate and db:seed if */etc/foreman/database.yml* exists. So the initial DB setup is only needed during first install, upgrades should just work.
 

--- a/_includes/manuals/nightly/4.3.1_smartproxy_installation.md
+++ b/_includes/manuals/nightly/4.3.1_smartproxy_installation.md
@@ -23,7 +23,7 @@ git clone git://github.com/theforeman/smart-proxy.git -b {{page.version}}-stable
 
 The smart proxy will run with the following requirements (aside from rubygem dependencies):
 
-* Ruby 2.5 or 2.6
+* Ruby 2.5, 2.6 or 2.7
 
 #### Windows
 The Microsoft smart-proxy installation procedure is very basic compared to the RPM or APT based solution. You need to run smart-proxy from the source as well as install Ruby and Ruby DevKit.


### PR DESCRIPTION
This lists the correct versions for 3.0, 3.1 and nightly.

It also removes the instructions for both nightly and stable releases. We have different manuals for each.

The GPG key and list of pacakge are also updated to be current.