### PR TITLE
Rephrase unattended deprecation message

### DIFF
--- a/_includes/manuals/3.1/1.2_release_notes.md
+++ b/_includes/manuals/3.1/1.2_release_notes.md
@@ -46,7 +46,10 @@ Note that this is only support to run Foreman and Foreman Proxy themselves on Ub
 
 ### Deprecations
 
-#### The `:unattended => false` Setting has been deprecated
+#### The `:unattended` Setting has been deprecated
+
+Historically Foreman has supported the `:unattended` setting in `settings.yaml`. Setting it to `false` is barely tested and has seen various regressions because of that. This setting will be removed in the future and Foreman will behave as if it's set to `true`.
+
 The host registration feature can be used to register hosts on Foreman for the sole purpose of an inventory. Refer to [the removal RFC](https://community.theforeman.org/t/rfc-remove-unattended-setting/10035) for more information.
 
 #### Running Foreman on EL7
@@ -375,6 +378,6 @@ Note that this is only support to run Foreman and Foreman Proxy themselves on EL
 
 We'd like to thank the following people who contributed to the Foreman {{page.version}} release:
 
-Adam Cecile, Adam Ruzicka, Adi Abramovich, Alexander Olofsson, Amir Fefer, Amit Upadhye, Andrew Teixeira, Anna Vitova, Antoine Beaupré, Avi Sharvit, Bernhard Suttner, Birkir Freyr, Chris Roberts, Dave Thomas, Dominik Matoulek, Eric D. Helms, Evgeni Golov, Ewoud Kohl van Wijngaarden, Gordon Bleux, Jeremy Lenz, John Mitsch, Jonathon Turel, Justin Sherrill, Kamil Szubrycht, Leos Stejskal, Lukáš Zapletal, Magnus Toneby, Marcel Kühlhorn, Marek Hulán, Maria Agaphontzev, Melanie Corr, Nacho Barrientos, Nadja Heitmann, Oleh Fedorenko, Ondřej Ezr, Ondřej Pražák, Patrick Creech, Rahul Bajaj, Romuald Conty, Ron Lavi, Samir Jha, Shimon Shtein, Shira Maximov, Stejskal Leos, Tim Meusel, Tomer Brisker, Trent Anderson, William Clark, Yifat Makias, amtilghman, andrewgdewar, maccelf, rafaelguerra01
+Adam Cecile, Adam Ruzicka, Adi Abramovich, Alexander Olofsson, Amir Fefer, Amit Upadhye, Andrew Teixeira, Anna Vitova, Antoine Beaupré, Avi Sharvit, Bernhard Suttner, Birkir Freyr, Chris Roberts, Dave Thomas, Dominik Matoulek, Eric D. Helms, Evgeni Golov, Ewoud Kohl van Wijngaarden, Gordon Bleux, Jeremy Lenz, John Mitsch, Jonathon Turel, Justin Sherrill, Kamil Szubrycht, Leos Stejskal, Lukáš Zapletal, Magnus Toneby, Marcel Kühlhorn, Marek Hulán, Maria Agaphontzev, Melanie Corr, Nacho Barrientos, Nadja Heitmann, Oleh Fedorenko, Ondřej Ezr, Ondřej Pražák, Patrick Creech, Rahul Bajaj, Romuald Conty, Ron Lavi, Samir Jha, Shimon Shtein, Shira Maximov, Tim Meusel, Tomer Brisker, Trent Anderson, William Clark, Yifat Makias, amtilghman, andrewgdewar, maccelf, rafaelguerra01
 
 As well as all users who helped test releases, report bugs and provide feedback on the project.


### PR DESCRIPTION
This adds a bit of context to the deprecation which makes it easier to understand. It also removes the duplicate entry for Leos in a (Last + First) notation since there's already a (First + Last) notation.