### PR TITLE
Drop Ubuntu 18.04 from the manuals

### DIFF
--- a/_includes/manuals/3.1/2.1_quickstart_installation.md
+++ b/_includes/manuals/3.1/2.1_quickstart_installation.md
@@ -31,7 +31,6 @@ To provide specific installation instructions, please select your operating syst
   <option value="debian10">Debian 10 (Buster)</option>
   <option value="rhel7">Red Hat Enterprise Linux 7</option>
   <option value="rhel8">Red Hat Enterprise Linux 8</option>
-  <option value="ubuntu1804">Ubuntu 18.04 (Bionic)</option>
   <option value="ubuntu2004">Ubuntu 20.04 (Focal)</option>
 </select>
 
@@ -150,29 +149,6 @@ wget -q https://deb.theforeman.org/pubkey.gpg -O- | sudo apt-key add -
 {% endhighlight %}
 </div>
 
-<div class="quickstart_os quickstart_os_ubuntu1804">
-  <p>
-    Using Puppet 6.x is recommended, which is available from the Puppet Labs repository.
-
-    To use Puppet 6.x with Puppet Agent and Puppet server:
-  </p>
-
-{% highlight bash %}
-sudo apt-get -y install ca-certificates
-cd /tmp && wget https://apt.puppet.com/puppet6-release-bionic.deb
-sudo dpkg -i /tmp/puppet6-release-bionic.deb
-{% endhighlight %}
-
-  <p>Enable the Foreman repo:</p>
-
-{% highlight bash %}
-echo "deb http://deb.theforeman.org/ bionic {{page.version}}" | sudo tee /etc/apt/sources.list.d/foreman.list
-echo "deb http://deb.theforeman.org/ plugins {{page.version}}" | sudo tee -a /etc/apt/sources.list.d/foreman.list
-sudo apt-get -y install ca-certificates
-wget -q https://deb.theforeman.org/pubkey.gpg -O- | sudo apt-key add -
-{% endhighlight %}
-</div>
-
 <div class="quickstart_os quickstart_os_ubuntu2004">
   <p>
     Using Puppet 6.x is recommended, which is available from the Puppet Labs repository.
@@ -208,7 +184,7 @@ sudo yum -y install foreman-installer
 {% endhighlight %}
 </div>
 
-<div class="quickstart_os quickstart_os_debian10 quickstart_os_ubuntu1804 quickstart_os_ubuntu2004">
+<div class="quickstart_os quickstart_os_debian10 quickstart_os_ubuntu2004">
 {% highlight bash %}
 sudo apt-get update && sudo apt-get -y install foreman-installer
 {% endhighlight %}
@@ -216,13 +192,13 @@ sudo apt-get update && sudo apt-get -y install foreman-installer
 
 #### Running the installer
 
-<div class="quickstart_os quickstart_os_debian10 quickstart_os_ubuntu1804 quickstart_os_ubuntu2004 alert alert-info">
+<div class="quickstart_os quickstart_os_debian10 quickstart_os_ubuntu2004 alert alert-info">
   Ensure that <code>ping $(hostname -f)</code> shows the real IP address, not 127.0.1.1.  Change or remove this entry from /etc/hosts if present.
 </div>
 
 The installation run is non-interactive, but the configuration can be customized by supplying any of the options listed in `foreman-installer --help`, or by running `foreman-installer -i` for interactive mode.  More examples are given in the [Installation Options](/manuals/{{page.version}}/index.html#3.2.2InstallerOptions) section.  Adding `-v` will disable the progress bar and display all changes.  To run the installer, execute:
 
-<div class="quickstart_os quickstart_os_none quickstart_os_el7 quickstart_os_rhel7 quickstart_os_debian10 quickstart_os_ubuntu1804 quickstart_os_ubuntu2004 quickstart_os_el8 quickstart_os_rhel8">
+<div class="quickstart_os quickstart_os_none quickstart_os_el7 quickstart_os_rhel7 quickstart_os_debian10 quickstart_os_ubuntu2004 quickstart_os_el8 quickstart_os_rhel8">
 {% highlight bash %}
 sudo foreman-installer
 {% endhighlight %}

--- a/_includes/manuals/3.1/2_quickstart_guide.md
+++ b/_includes/manuals/3.1/2_quickstart_guide.md
@@ -10,7 +10,6 @@ Components include the Foreman web UI, Smart Proxy, a Puppet server, and optiona
 * Debian 10 (Buster), amd64
 * Red Hat Enterprise Linux 7, x86_64
 * Red Hat Enterprise Linux 8, x86_64
-* Ubuntu 18.04 (Bionic), amd64
 * Ubuntu 20.04 (Focal), amd64
 
 #### Untested platforms (packages may not work on these)

--- a/_includes/manuals/3.1/3.1.1_supported_platforms.md
+++ b/_includes/manuals/3.1/3.1.1_supported_platforms.md
@@ -19,8 +19,6 @@ The following operating systems are supported by the installer, have packages an
 * CentOS 8 Stream
   * Architectures: x86_64 only
   * **Note:** The RPM packages are built on CentOS Linux 8, but tested to work also on CentOS 8 Stream
-* Ubuntu 18.04 (Bionic)
-  * Architectures: amd64
 * Ubuntu 20.04 (Bionic)
   * Architectures: amd64
 * Debian 10 (Buster)

--- a/_includes/manuals/3.1/3.6_upgrade.md
+++ b/_includes/manuals/3.1/3.6_upgrade.md
@@ -38,7 +38,6 @@ To provide specific installation instructions, please select your operating syst
   <option value="el7">CentOS 7 / Red Hat Enterprise Linux 7</option>
   <option value="el8">CentOS 8 / CentOS 8 Stream / Red Hat Enterprise Linux 8</option>
   <option value="debian10">Debian 10 (Buster)</option>
-  <option value="ubuntu1804">Ubuntu 18.04 (Bionic)</option>
   <option value="ubuntu2004">Ubuntu 20.04 (Focal)</option>
 </select>
 
@@ -63,7 +62,7 @@ Before proceeding, it is necessary to shutdown the Foreman instance.
 systemctl stop httpd foreman.service foreman.socket dynflow\*
 {% endhighlight %}
 </div>
-<div class="upgrade_os upgrade_os_debian10 upgrade_os_ubuntu1804 upgrade_os_ubuntu2004">
+<div class="upgrade_os upgrade_os_debian10 upgrade_os_ubuntu2004">
 {% highlight bash %}
 systemctl stop apache foreman.service foreman.socket dynflow\*
 {% endhighlight %}
@@ -136,7 +135,7 @@ dnf upgrade ruby\* foreman\*
 {% endhighlight %}
 </div>
 
-<div class="upgrade_os upgrade_os_debian10 upgrade_os_ubuntu1804 upgrade_os_ubuntu2004">
+<div class="upgrade_os upgrade_os_debian10 upgrade_os_ubuntu2004">
 Upgrading from the last release to {{page.version}} has been tested. Updating
 the packages will upgrade the application and automatically migrate the
 database.
@@ -147,12 +146,6 @@ number from the previous release to `{{ page.version }}`:
 <div class="upgrade_os upgrade_os_debian10">
 {% highlight bash %}
 deb http://deb.theforeman.org/ buster {{ page.version }}
-deb http://deb.theforeman.org/ plugins {{ page.version }}
-{% endhighlight %}
-</div>
-<div class="upgrade_os upgrade_os_ubuntu1804">
-{% highlight bash %}
-deb http://deb.theforeman.org/ bionic {{ page.version }}
 deb http://deb.theforeman.org/ plugins {{ page.version }}
 {% endhighlight %}
 </div>
@@ -221,7 +214,7 @@ rpmconf from the EPEL repository along with vim-enhanced (for vimdiff).
 rpmconf -a --frontend=vimdiff
 {% endhighlight %}
 </div>
-<div class="upgrade_os upgrade_os_el8 upgrade_os_debian10 upgrade_os_ubuntu1804 upgrade_os_ubuntu2004">
+<div class="upgrade_os upgrade_os_el8 upgrade_os_debian10 upgrade_os_ubuntu2004">
 This step is irrelevant for the chosen operating system.
 </div>
 
@@ -237,7 +230,7 @@ Start the application server. This is redundant if you previously ran `foreman-i
 systemctl start httpd foreman.service foreman.socket
 {% endhighlight %}
 </div>
-<div class="upgrade_os upgrade_os_debian10 upgrade_os_ubuntu1804 upgrade_os_ubuntu2004">
+<div class="upgrade_os upgrade_os_debian10 upgrade_os_ubuntu2004">
 {% highlight bash %}
 systemctl start apache foreman.service foreman.socket
 {% endhighlight %}

--- a/_includes/manuals/nightly/2.1_quickstart_installation.md
+++ b/_includes/manuals/nightly/2.1_quickstart_installation.md
@@ -31,7 +31,6 @@ To provide specific installation instructions, please select your operating syst
   <option value="debian10">Debian 10 (Buster)</option>
   <option value="rhel7">Red Hat Enterprise Linux 7</option>
   <option value="rhel8">Red Hat Enterprise Linux 8</option>
-  <option value="ubuntu1804">Ubuntu 18.04 (Bionic)</option>
   <option value="ubuntu2004">Ubuntu 20.04 (Focal)</option>
 </select>
 
@@ -150,29 +149,6 @@ wget -q https://deb.theforeman.org/pubkey.gpg -O- | sudo apt-key add -
 {% endhighlight %}
 </div>
 
-<div class="quickstart_os quickstart_os_ubuntu1804">
-  <p>
-    Using Puppet 6.x is recommended, which is available from the Puppet Labs repository.
-
-    To use Puppet 6.x with Puppet Agent and Puppet server:
-  </p>
-
-{% highlight bash %}
-sudo apt-get -y install ca-certificates
-cd /tmp && wget https://apt.puppet.com/puppet6-release-bionic.deb
-sudo dpkg -i /tmp/puppet6-release-bionic.deb
-{% endhighlight %}
-
-  <p>Enable the Foreman repo:</p>
-
-{% highlight bash %}
-echo "deb http://deb.theforeman.org/ bionic {{page.version}}" | sudo tee /etc/apt/sources.list.d/foreman.list
-echo "deb http://deb.theforeman.org/ plugins {{page.version}}" | sudo tee -a /etc/apt/sources.list.d/foreman.list
-sudo apt-get -y install ca-certificates
-wget -q https://deb.theforeman.org/pubkey.gpg -O- | sudo apt-key add -
-{% endhighlight %}
-</div>
-
 <div class="quickstart_os quickstart_os_ubuntu2004">
   <p>
     Using Puppet 6.x is recommended, which is available from the Puppet Labs repository.
@@ -208,7 +184,7 @@ sudo yum -y install foreman-installer
 {% endhighlight %}
 </div>
 
-<div class="quickstart_os quickstart_os_debian10 quickstart_os_ubuntu1804 quickstart_os_ubuntu2004">
+<div class="quickstart_os quickstart_os_debian10 quickstart_os_ubuntu2004">
 {% highlight bash %}
 sudo apt-get update && sudo apt-get -y install foreman-installer
 {% endhighlight %}
@@ -216,13 +192,13 @@ sudo apt-get update && sudo apt-get -y install foreman-installer
 
 #### Running the installer
 
-<div class="quickstart_os quickstart_os_debian10 quickstart_os_ubuntu1804 quickstart_os_ubuntu2004 alert alert-info">
+<div class="quickstart_os quickstart_os_debian10 quickstart_os_ubuntu2004 alert alert-info">
   Ensure that <code>ping $(hostname -f)</code> shows the real IP address, not 127.0.1.1.  Change or remove this entry from /etc/hosts if present.
 </div>
 
 The installation run is non-interactive, but the configuration can be customized by supplying any of the options listed in `foreman-installer --help`, or by running `foreman-installer -i` for interactive mode.  More examples are given in the [Installation Options](/manuals/{{page.version}}/index.html#3.2.2InstallerOptions) section.  Adding `-v` will disable the progress bar and display all changes.  To run the installer, execute:
 
-<div class="quickstart_os quickstart_os_none quickstart_os_el7 quickstart_os_rhel7 quickstart_os_debian10 quickstart_os_ubuntu1804 quickstart_os_ubuntu2004 quickstart_os_el8 quickstart_os_rhel8">
+<div class="quickstart_os quickstart_os_none quickstart_os_el7 quickstart_os_rhel7 quickstart_os_debian10 quickstart_os_ubuntu2004 quickstart_os_el8 quickstart_os_rhel8">
 {% highlight bash %}
 sudo foreman-installer
 {% endhighlight %}

--- a/_includes/manuals/nightly/2_quickstart_guide.md
+++ b/_includes/manuals/nightly/2_quickstart_guide.md
@@ -10,7 +10,6 @@ Components include the Foreman web UI, Smart Proxy, a Puppet server, and optiona
 * Debian 10 (Buster), amd64
 * Red Hat Enterprise Linux 7, x86_64
 * Red Hat Enterprise Linux 8, x86_64
-* Ubuntu 18.04 (Bionic), amd64
 * Ubuntu 20.04 (Focal), amd64
 
 #### Untested platforms (packages may not work on these)

--- a/_includes/manuals/nightly/3.1.1_supported_platforms.md
+++ b/_includes/manuals/nightly/3.1.1_supported_platforms.md
@@ -19,8 +19,6 @@ The following operating systems are supported by the installer, have packages an
 * CentOS 8 Stream
   * Architectures: x86_64 only
   * **Note:** The RPM packages are built on CentOS Linux 8, but tested to work also on CentOS 8 Stream
-* Ubuntu 18.04 (Bionic)
-  * Architectures: amd64
 * Ubuntu 20.04 (Bionic)
   * Architectures: amd64
 * Debian 10 (Buster)

--- a/_includes/manuals/nightly/3.6_upgrade.md
+++ b/_includes/manuals/nightly/3.6_upgrade.md
@@ -38,7 +38,6 @@ To provide specific installation instructions, please select your operating syst
   <option value="el7">CentOS 7 / Red Hat Enterprise Linux 7</option>
   <option value="el8">CentOS 8 / CentOS 8 Stream / Red Hat Enterprise Linux 8</option>
   <option value="debian10">Debian 10 (Buster)</option>
-  <option value="ubuntu1804">Ubuntu 18.04 (Bionic)</option>
   <option value="ubuntu2004">Ubuntu 20.04 (Focal)</option>
 </select>
 
@@ -63,7 +62,7 @@ Before proceeding, it is necessary to shutdown the Foreman instance.
 systemctl stop httpd foreman.service foreman.socket dynflow\*
 {% endhighlight %}
 </div>
-<div class="upgrade_os upgrade_os_debian10 upgrade_os_ubuntu1804 upgrade_os_ubuntu2004">
+<div class="upgrade_os upgrade_os_debian10 upgrade_os_ubuntu2004">
 {% highlight bash %}
 systemctl stop apache foreman.service foreman.socket dynflow\*
 {% endhighlight %}
@@ -136,7 +135,7 @@ dnf upgrade ruby\* foreman\*
 {% endhighlight %}
 </div>
 
-<div class="upgrade_os upgrade_os_debian10 upgrade_os_ubuntu1804 upgrade_os_ubuntu2004">
+<div class="upgrade_os upgrade_os_debian10 upgrade_os_ubuntu2004">
 Upgrading from the last release to {{page.version}} has been tested. Updating
 the packages will upgrade the application and automatically migrate the
 database.
@@ -147,12 +146,6 @@ number from the previous release to `{{ page.version }}`:
 <div class="upgrade_os upgrade_os_debian10">
 {% highlight bash %}
 deb http://deb.theforeman.org/ buster {{ page.version }}
-deb http://deb.theforeman.org/ plugins {{ page.version }}
-{% endhighlight %}
-</div>
-<div class="upgrade_os upgrade_os_ubuntu1804">
-{% highlight bash %}
-deb http://deb.theforeman.org/ bionic {{ page.version }}
 deb http://deb.theforeman.org/ plugins {{ page.version }}
 {% endhighlight %}
 </div>
@@ -221,7 +214,7 @@ rpmconf from the EPEL repository along with vim-enhanced (for vimdiff).
 rpmconf -a --frontend=vimdiff
 {% endhighlight %}
 </div>
-<div class="upgrade_os upgrade_os_el8 upgrade_os_debian10 upgrade_os_ubuntu1804 upgrade_os_ubuntu2004">
+<div class="upgrade_os upgrade_os_el8 upgrade_os_debian10 upgrade_os_ubuntu2004">
 This step is irrelevant for the chosen operating system.
 </div>
 
@@ -237,7 +230,7 @@ Start the application server. This is redundant if you previously ran `foreman-i
 systemctl start httpd foreman.service foreman.socket
 {% endhighlight %}
 </div>
-<div class="upgrade_os upgrade_os_debian10 upgrade_os_ubuntu1804 upgrade_os_ubuntu2004">
+<div class="upgrade_os upgrade_os_debian10 upgrade_os_ubuntu2004">
 {% highlight bash %}
 systemctl start apache foreman.service foreman.socket
 {% endhighlight %}


### PR DESCRIPTION
Foreman 3.1 dropped Ubuntu 18.04 and I forgot to drop it from the manual itself. This drops it from 3.1 and nightly.