### PR TITLE
Puppet fixes and add Debian 11 support to the manual

### DIFF
--- a/_includes/manuals/3.0/1.2_release_notes.md
+++ b/_includes/manuals/3.0/1.2_release_notes.md
@@ -29,6 +29,7 @@ Fact parsers for Ansible, Chef, Salt and Subscription Manager were moved to the 
 * The `host_param_true?` and `host_param_false?` macros changed the meaning of the `default_value` parameter. The value is now used for the comparison if the parameter is not set on the host, instead of returing the value directly. Please update your templates accordingly.
 * The Debian packages are signed with a new key ([5B7C3E5A735BCB4D615829DC0BDDA991FD7AAC8A](/static/keys/5B7C3E5A735BCB4D615829DC0BDDA991FD7AAC8A.pub)). Please import it to verify the packages.
 * Foreman 2.5 for Debian/Ubuntu had briefly wrong versioned Ansible and Remote Execution plugins published, please read our [blog post how to properly upgrade these](/2021/08/please-manually-upgrade-ansible-and-remote-execution-plugins-on-25.html).
+* The installer now requires Puppet 6.15 or higher. The Smart Proxy can still work with older versions, but Puppet 5 is no longer supported by Puppet so users are recommended to upgrade.
 
 ### Deprecations
 

--- a/_includes/manuals/3.0/3.1.1_supported_platforms.md
+++ b/_includes/manuals/3.0/3.1.1_supported_platforms.md
@@ -30,7 +30,7 @@ PostgreSQL version 10 or newer. For EL 7 this is available from Software Collect
 
 It is recommended to apply all OS updates if possible.
 
-All platforms will require Puppet 5 or higher, which may be installed from OS or the Puppet Labs repositories.
+All platforms will require Puppet 6 or higher, which may be installed from Puppet's repositories.
 
 Other operating systems will need to use alternative installation methods, such as from source.
 

--- a/_includes/manuals/3.1/3.1.1_supported_platforms.md
+++ b/_includes/manuals/3.1/3.1.1_supported_platforms.md
@@ -28,7 +28,7 @@ PostgreSQL version 10 or newer. For EL 7 this is available from Software Collect
 
 It is recommended to apply all OS updates if possible.
 
-All platforms will require Puppet 5 or higher, which may be installed from OS or the Puppet Labs repositories.
+All platforms will require Puppet 6 or higher, which may be installed from Puppet's repositories.
 
 Other operating systems will need to use alternative installation methods, such as from source.
 

--- a/_includes/manuals/nightly/1.2_release_notes.md
+++ b/_includes/manuals/nightly/1.2_release_notes.md
@@ -4,6 +4,10 @@ This section will be updated prior to the next release.
 
 ### Headline features
 
+#### Foreman on Debian 11 (Bullseye)
+
+It is now possible to run Foreman on Debian 11. Users are encouraged to upgrade.
+
 ### Upgrade warnings
 
 #### `require_ssl_smart_proxies` setting dropped
@@ -22,6 +26,12 @@ For fresh installations, EL8 should considered the preferred target.
 Existing installations should start thinking about a migration plan.
 
 Note that this is only support to run Foreman and Foreman Proxy themselves on EL7. Managing EL7 systems remains supported. See [the RFC](https://community.theforeman.org/t/deprecation-plans-for-foreman-on-el7-debian-10-and-ubuntu-18-04/25008) for more information.
+
+#### Running Foreman on Debian 10
+
+Now that Debian 11 is supported, Debian 10 support is deprecated and will be dropped with Foreman 3.4
+
+Note that this is only support to run Foreman and Foreman Proxy themselves on Debian 10. Managing Debia 10 systems remains supported. See [the RFC](https://community.theforeman.org/t/deprecation-plans-for-foreman-on-el7-debian-10-and-ubuntu-18-04/25008) for more information.
 
 ### Release Notes
 

--- a/_includes/manuals/nightly/2.1_quickstart_installation.md
+++ b/_includes/manuals/nightly/2.1_quickstart_installation.md
@@ -58,23 +58,21 @@ sudo yum-config-manager --enable rhel-7-server-optional-rpms rhel-server-rhscl-7
   </p>
 
   <p>
-    Using a recent version of Puppet is recommended, which is available from the Puppet Labs repository.
-    To use Puppet 6.x with Puppet Agent and Puppet server:
+    Enable Puppet's 7.x repository:
   </p>
 
 {% highlight bash %}
-sudo yum -y install https://yum.puppet.com/puppet6-release-el-7.noarch.rpm
+sudo yum -y install https://yum.puppet.com/puppet7-release-el-7.noarch.rpm
 {% endhighlight %}
 </div>
 
 <div class="quickstart_os quickstart_os_rhel8 quickstart_os_el8">
   <p>
-    Using a recent version of Puppet is recommended, which is available from the Puppet Labs repository.
-    To use Puppet 6.x with Puppet Agent and Puppet server:
+    Enable Puppet's 7.x repository:
   </p>
 
 {% highlight bash %}
-sudo yum -y install https://yum.puppet.com/puppet6-release-el-8.noarch.rpm
+sudo yum -y install https://yum.puppet.com/puppet7-release-el-8.noarch.rpm
 {% endhighlight %}
 </div>
 
@@ -128,15 +126,13 @@ sudo yum -y install https://yum.theforeman.org/releases/{{page.version}}/el8/x86
 
 <div class="quickstart_os quickstart_os_debian10">
   <p>
-    Using Puppet 6.x is recommended, which is available from the Puppet Labs repository.
-
-    To use Puppet 6.x with Puppet Agent and Puppet server:
+    Enable Puppet's 7.x repository:
   </p>
 
 {% highlight bash %}
 sudo apt-get -y install ca-certificates
-cd /tmp && wget https://apt.puppet.com/puppet6-release-buster.deb
-sudo dpkg -i /tmp/puppet6-release-buster.deb
+cd /tmp && wget https://apt.puppet.com/puppet7-release-buster.deb
+sudo dpkg -i /tmp/puppet7-release-buster.deb
 {% endhighlight %}
 
   <p>Enable the Foreman repo:</p>
@@ -151,15 +147,13 @@ wget -q https://deb.theforeman.org/pubkey.gpg -O- | sudo apt-key add -
 
 <div class="quickstart_os quickstart_os_ubuntu2004">
   <p>
-    Using Puppet 6.x is recommended, which is available from the Puppet Labs repository.
-
-    To use Puppet 6.x with Puppet Agent and Puppet server:
+    Enable Puppet's 7.x repository:
   </p>
 
 {% highlight bash %}
 sudo apt-get -y install ca-certificates
-cd /tmp && wget https://apt.puppet.com/puppet6-release-focal.deb
-sudo dpkg -i /tmp/puppet6-release-focal.deb
+cd /tmp && wget https://apt.puppet.com/puppet7-release-focal.deb
+sudo dpkg -i /tmp/puppet7-release-focal.deb
 {% endhighlight %}
 
   <p>Enable the Foreman repo:</p>

--- a/_includes/manuals/nightly/2.1_quickstart_installation.md
+++ b/_includes/manuals/nightly/2.1_quickstart_installation.md
@@ -132,7 +132,7 @@ sudo yum -y install https://yum.theforeman.org/releases/{{page.version}}/el8/x86
 {% highlight bash %}
 sudo apt-get -y install ca-certificates
 cd /tmp && wget https://apt.puppet.com/puppet7-release-buster.deb
-sudo dpkg -i /tmp/puppet7-release-buster.deb
+sudo apt-get install /tmp/puppet7-release-buster.deb
 {% endhighlight %}
 
   <p>Enable the Foreman repositories:</p>
@@ -152,7 +152,7 @@ echo "deb http://deb.theforeman.org/ plugins {{page.version}}" | sudo tee -a /et
 {% highlight bash %}
 sudo apt-get -y install ca-certificates
 cd /tmp && wget https://apt.puppet.com/puppet7-release-focal.deb
-sudo dpkg -i /tmp/puppet7-release-focal.deb
+sudo apt-get install /tmp/puppet7-release-focal.deb
 {% endhighlight %}
 
   <p>Enable the Foreman repositories:</p>

--- a/_includes/manuals/nightly/2.1_quickstart_installation.md
+++ b/_includes/manuals/nightly/2.1_quickstart_installation.md
@@ -138,10 +138,9 @@ sudo dpkg -i /tmp/puppet7-release-buster.deb
   <p>Enable the Foreman repositories:</p>
 
 {% highlight bash %}
+sudo wget https://deb.theforeman.org/foreman.asc -O /etc/apt/trusted.gpg.d/foreman.asc
 echo "deb http://deb.theforeman.org/ buster {{page.version}}" | sudo tee /etc/apt/sources.list.d/foreman.list
 echo "deb http://deb.theforeman.org/ plugins {{page.version}}" | sudo tee -a /etc/apt/sources.list.d/foreman.list
-sudo apt-get -y install ca-certificates gpg
-wget -q https://deb.theforeman.org/pubkey.gpg -O- | sudo apt-key add -
 {% endhighlight %}
 </div>
 
@@ -159,10 +158,9 @@ sudo dpkg -i /tmp/puppet7-release-focal.deb
   <p>Enable the Foreman repositories:</p>
 
 {% highlight bash %}
+sudo wget https://deb.theforeman.org/foreman.asc -O /etc/apt/trusted.gpg.d/foreman.asc
 echo "deb http://deb.theforeman.org/ focal {{page.version}}" | sudo tee /etc/apt/sources.list.d/foreman.list
 echo "deb http://deb.theforeman.org/ plugins {{page.version}}" | sudo tee -a /etc/apt/sources.list.d/foreman.list
-sudo apt-get -y install ca-certificates
-wget -q https://deb.theforeman.org/pubkey.gpg -O- | sudo apt-key add -
 {% endhighlight %}
 </div>
 

--- a/_includes/manuals/nightly/2.1_quickstart_installation.md
+++ b/_includes/manuals/nightly/2.1_quickstart_installation.md
@@ -135,7 +135,7 @@ cd /tmp && wget https://apt.puppet.com/puppet7-release-buster.deb
 sudo dpkg -i /tmp/puppet7-release-buster.deb
 {% endhighlight %}
 
-  <p>Enable the Foreman repo:</p>
+  <p>Enable the Foreman repositories:</p>
 
 {% highlight bash %}
 echo "deb http://deb.theforeman.org/ buster {{page.version}}" | sudo tee /etc/apt/sources.list.d/foreman.list
@@ -156,7 +156,7 @@ cd /tmp && wget https://apt.puppet.com/puppet7-release-focal.deb
 sudo dpkg -i /tmp/puppet7-release-focal.deb
 {% endhighlight %}
 
-  <p>Enable the Foreman repo:</p>
+  <p>Enable the Foreman repositories:</p>
 
 {% highlight bash %}
 echo "deb http://deb.theforeman.org/ focal {{page.version}}" | sudo tee /etc/apt/sources.list.d/foreman.list

--- a/_includes/manuals/nightly/2.1_quickstart_installation.md
+++ b/_includes/manuals/nightly/2.1_quickstart_installation.md
@@ -29,6 +29,7 @@ To provide specific installation instructions, please select your operating syst
   <option value="el8">CentOS 8 Stream</option>
   <option value="other_el7">Scientific Linux or Oracle Linux 7</option>
   <option value="debian10">Debian 10 (Buster)</option>
+  <option value="debian11">Debian 11 (Bullseye)</option>
   <option value="rhel7">Red Hat Enterprise Linux 7</option>
   <option value="rhel8">Red Hat Enterprise Linux 8</option>
   <option value="ubuntu2004">Ubuntu 20.04 (Focal)</option>
@@ -144,6 +145,26 @@ echo "deb http://deb.theforeman.org/ plugins {{page.version}}" | sudo tee -a /et
 {% endhighlight %}
 </div>
 
+<div class="quickstart_os quickstart_os_debian11">
+  <p>
+    Enable Puppet's 7.x repository:
+  </p>
+
+{% highlight bash %}
+sudo apt-get -y install ca-certificates
+cd /tmp && wget https://apt.puppet.com/puppet7-release-bullseye.deb
+sudo apt-get install /tmp/puppet7-release-bullseye.deb
+{% endhighlight %}
+
+  <p>Enable the Foreman repositories:</p>
+
+{% highlight bash %}
+sudo wget https://deb.theforeman.org/foreman.asc -O /etc/apt/trusted.gpg.d/foreman.asc
+echo "deb http://deb.theforeman.org/ bullseye {{page.version}}" | sudo tee /etc/apt/sources.list.d/foreman.list
+echo "deb http://deb.theforeman.org/ plugins {{page.version}}" | sudo tee -a /etc/apt/sources.list.d/foreman.list
+{% endhighlight %}
+</div>
+
 <div class="quickstart_os quickstart_os_ubuntu2004">
   <p>
     Enable Puppet's 7.x repository:
@@ -176,7 +197,7 @@ sudo yum -y install foreman-installer
 {% endhighlight %}
 </div>
 
-<div class="quickstart_os quickstart_os_debian10 quickstart_os_ubuntu2004">
+<div class="quickstart_os quickstart_os_debian10 quickstart_os_debian11 quickstart_os_ubuntu2004">
 {% highlight bash %}
 sudo apt-get update && sudo apt-get -y install foreman-installer
 {% endhighlight %}
@@ -184,13 +205,13 @@ sudo apt-get update && sudo apt-get -y install foreman-installer
 
 #### Running the installer
 
-<div class="quickstart_os quickstart_os_debian10 quickstart_os_ubuntu2004 alert alert-info">
+<div class="quickstart_os quickstart_os_debian10 quickstart_os_debian11 quickstart_os_ubuntu2004 alert alert-info">
   Ensure that <code>ping $(hostname -f)</code> shows the real IP address, not 127.0.1.1.  Change or remove this entry from /etc/hosts if present.
 </div>
 
 The installation run is non-interactive, but the configuration can be customized by supplying any of the options listed in `foreman-installer --help`, or by running `foreman-installer -i` for interactive mode.  More examples are given in the [Installation Options](/manuals/{{page.version}}/index.html#3.2.2InstallerOptions) section.  Adding `-v` will disable the progress bar and display all changes.  To run the installer, execute:
 
-<div class="quickstart_os quickstart_os_none quickstart_os_el7 quickstart_os_rhel7 quickstart_os_debian10 quickstart_os_ubuntu2004 quickstart_os_el8 quickstart_os_rhel8">
+<div class="quickstart_os quickstart_os_none quickstart_os_el7 quickstart_os_rhel7 quickstart_os_debian10 quickstart_os_debian11 quickstart_os_ubuntu2004 quickstart_os_el8 quickstart_os_rhel8">
 {% highlight bash %}
 sudo foreman-installer
 {% endhighlight %}

--- a/_includes/manuals/nightly/2_quickstart_guide.md
+++ b/_includes/manuals/nightly/2_quickstart_guide.md
@@ -8,6 +8,7 @@ Components include the Foreman web UI, Smart Proxy, a Puppet server, and optiona
 * CentOS 8 x86_64
 * CentOS 8 Stream x86_64
 * Debian 10 (Buster), amd64
+* Debian 11 (Bullseye), amd64
 * Red Hat Enterprise Linux 7, x86_64
 * Red Hat Enterprise Linux 8, x86_64
 * Ubuntu 20.04 (Focal), amd64

--- a/_includes/manuals/nightly/3.1.1_supported_platforms.md
+++ b/_includes/manuals/nightly/3.1.1_supported_platforms.md
@@ -23,6 +23,8 @@ The following operating systems are supported by the installer, have packages an
   * Architectures: amd64
 * Debian 10 (Buster)
   * Architectures: amd64
+* Debian 11 (Bullseye)
+  * Architectures: amd64
 
 PostgreSQL version 10 or newer. For EL 7 this is available from Software Collections.
 

--- a/_includes/manuals/nightly/3.1.1_supported_platforms.md
+++ b/_includes/manuals/nightly/3.1.1_supported_platforms.md
@@ -19,7 +19,7 @@ The following operating systems are supported by the installer, have packages an
 * CentOS 8 Stream
   * Architectures: x86_64 only
   * **Note:** The RPM packages are built on CentOS Linux 8, but tested to work also on CentOS 8 Stream
-* Ubuntu 20.04 (Bionic)
+* Ubuntu 20.04 (Focal)
   * Architectures: amd64
 * Debian 10 (Buster)
   * Architectures: amd64

--- a/_includes/manuals/nightly/3.1.1_supported_platforms.md
+++ b/_includes/manuals/nightly/3.1.1_supported_platforms.md
@@ -28,7 +28,7 @@ PostgreSQL version 10 or newer. For EL 7 this is available from Software Collect
 
 It is recommended to apply all OS updates if possible.
 
-All platforms will require Puppet 5 or higher, which may be installed from OS or the Puppet Labs repositories.
+All platforms will require Puppet 6 or higher, which may be installed from Puppet's repositories.
 
 Other operating systems will need to use alternative installation methods, such as from source.
 

--- a/_includes/manuals/nightly/3.6_upgrade.md
+++ b/_includes/manuals/nightly/3.6_upgrade.md
@@ -38,6 +38,7 @@ To provide specific installation instructions, please select your operating syst
   <option value="el7">CentOS 7 / Red Hat Enterprise Linux 7</option>
   <option value="el8">CentOS 8 / CentOS 8 Stream / Red Hat Enterprise Linux 8</option>
   <option value="debian10">Debian 10 (Buster)</option>
+  <option value="debian11">Debian 11 (Bullseye)</option>
   <option value="ubuntu2004">Ubuntu 20.04 (Focal)</option>
 </select>
 
@@ -62,7 +63,7 @@ Before proceeding, it is necessary to shutdown the Foreman instance.
 systemctl stop httpd foreman.service foreman.socket dynflow\*
 {% endhighlight %}
 </div>
-<div class="upgrade_os upgrade_os_debian10 upgrade_os_ubuntu2004">
+<div class="upgrade_os upgrade_os_debian10 upgrade_os_debian11 upgrade_os_ubuntu2004">
 {% highlight bash %}
 systemctl stop apache foreman.service foreman.socket dynflow\*
 {% endhighlight %}
@@ -135,7 +136,7 @@ dnf upgrade ruby\* foreman\*
 {% endhighlight %}
 </div>
 
-<div class="upgrade_os upgrade_os_debian10 upgrade_os_ubuntu2004">
+<div class="upgrade_os upgrade_os_debian10 upgrade_os_debian11 upgrade_os_ubuntu2004">
 Upgrading from the last release to {{page.version}} has been tested. Updating
 the packages will upgrade the application and automatically migrate the
 database.
@@ -146,6 +147,12 @@ number from the previous release to `{{ page.version }}`:
 <div class="upgrade_os upgrade_os_debian10">
 {% highlight bash %}
 deb http://deb.theforeman.org/ buster {{ page.version }}
+deb http://deb.theforeman.org/ plugins {{ page.version }}
+{% endhighlight %}
+</div>
+<div class="upgrade_os upgrade_os_debian11">
+{% highlight bash %}
+deb http://deb.theforeman.org/ bullseye {{ page.version }}
 deb http://deb.theforeman.org/ plugins {{ page.version }}
 {% endhighlight %}
 </div>
@@ -214,7 +221,7 @@ rpmconf from the EPEL repository along with vim-enhanced (for vimdiff).
 rpmconf -a --frontend=vimdiff
 {% endhighlight %}
 </div>
-<div class="upgrade_os upgrade_os_el8 upgrade_os_debian10 upgrade_os_ubuntu2004">
+<div class="upgrade_os upgrade_os_el8 upgrade_os_debian10 upgrade_os_debian11 upgrade_os_ubuntu2004">
 This step is irrelevant for the chosen operating system.
 </div>
 
@@ -230,7 +237,7 @@ Start the application server. This is redundant if you previously ran `foreman-i
 systemctl start httpd foreman.service foreman.socket
 {% endhighlight %}
 </div>
-<div class="upgrade_os upgrade_os_debian10 upgrade_os_ubuntu2004">
+<div class="upgrade_os upgrade_os_debian10 upgrade_os_debian11 upgrade_os_ubuntu2004">
 {% highlight bash %}
 systemctl start apache foreman.service foreman.socket
 {% endhighlight %}


### PR DESCRIPTION
Puppetserver (which our default installer scenario depends on) is only built for Debian 11. However, in our CI we only test with version 7 anyway so it's a good suggestion. It also raises the minimum version to 6 because that's what the installer requires. There is some Puppet 5 specific documentation in the Smart Proxy, but that code still works so I've left the documentation in.