### PR TITLE
Updated command to setup foreman-proxy

### DIFF
--- a/_includes/manuals/3.0/3.2.3_installation_scenarios.md
+++ b/_includes/manuals/3.0/3.2.3_installation_scenarios.md
@@ -58,7 +58,7 @@ Command line arguments:
 {% highlight bash %}
 foreman-installer \
   --no-enable-foreman \
-  --no-enable-foreman-puppet \
+  --no-enable-foreman-plugin-puppet \
   --no-enable-foreman-cli \
   --no-enable-foreman-cli-puppet \
   --enable-puppet \

--- a/_includes/manuals/3.1/3.2.3_installation_scenarios.md
+++ b/_includes/manuals/3.1/3.2.3_installation_scenarios.md
@@ -58,7 +58,7 @@ Command line arguments:
 {% highlight bash %}
 foreman-installer \
   --no-enable-foreman \
-  --no-enable-foreman-puppet \
+  --no-enable-foreman-plugin-puppet \
   --no-enable-foreman-cli \
   --no-enable-foreman-cli-puppet \
   --enable-puppet \

--- a/_includes/manuals/nightly/3.2.3_installation_scenarios.md
+++ b/_includes/manuals/nightly/3.2.3_installation_scenarios.md
@@ -58,7 +58,7 @@ Command line arguments:
 {% highlight bash %}
 foreman-installer \
   --no-enable-foreman \
-  --no-enable-foreman-puppet \
+  --no-enable-foreman-plugin-puppet \
   --no-enable-foreman-cli \
   --no-enable-foreman-cli-puppet \
   --enable-puppet \


### PR DESCRIPTION
Per conversation with ewoud:
<ewoud> anheath: that's odd, somehow --no-enable-foreman-puppet isn't respected?
<ewoud> anheath: oh, it's --no-enable-foreman-plugin-puppet but it silently ignores the invalid option?
<anheath> ewoud, So the commanline aruments are incorrect?
<ewoud> anheath: line 3 (--no-enable-foreman-puppet) should be --no-enable-foreman-plugin-puppet