### PR TITLE
update browsers compatibility

### DIFF
--- a/_includes/manuals/nightly/1.2_release_notes.md
+++ b/_includes/manuals/nightly/1.2_release_notes.md
@@ -8,6 +8,14 @@ This section will be updated prior to the next release.
 
 ### Deprecations
 
+We've updated our browsers compatibility to support the following:
+
+* Google Chrome - latest version
+* Microsoft Edge - latest version
+* Apple Safari - latest version
+* Mozilla Firefox - latest version
+* Mozilla Firefox Extended Support Release (ESR) - latest version
+
 ### Release Notes
 
 ### Contributors

--- a/_includes/manuals/nightly/3.1.4_browser_compatibility.md
+++ b/_includes/manuals/nightly/3.1.4_browser_compatibility.md
@@ -3,9 +3,10 @@ Using the most recent version of a major browser is highly recommended, as Forem
 
 The recommended requirements are as follows for major browsers:
 
-* Google Chrome 54 or higher
-* Microsoft Edge
-* Microsoft Internet Explorer 10 or higher
-* Mozilla Firefox 49 or higher
+* Google Chrome - latest version
+* Microsoft Edge - latest version
+* Apple Safari - latest version
+* Mozilla Firefox - latest version
+* Mozilla Firefox Extended Support Release (ESR) - latest version
 
 Other browsers may work unpredictably.


### PR DESCRIPTION
support the following:
* Google Chrome - latest version
* Microsoft Edge - latest version
* Apple Safari - latest version
* Mozilla Firefox - latest version
* Mozilla Firefox Extended Support Release (ESR) - latest version

based on the discussion in https://community.theforeman.org/t/officially-support-only-the-recent-versions-of-firefox-safari-edge-chrome-chromium-browsers/27139