### PR TITLE
Use modularity on EL8

### DIFF
--- a/_includes/manuals/nightly/2.1_quickstart_installation.md
+++ b/_includes/manuals/nightly/2.1_quickstart_installation.md
@@ -73,7 +73,7 @@ sudo yum -y install https://yum.puppet.com/puppet7-release-el-7.noarch.rpm
   </p>
 
 {% highlight bash %}
-sudo yum -y install https://yum.puppet.com/puppet7-release-el-8.noarch.rpm
+sudo dnf -y install https://yum.puppet.com/puppet7-release-el-8.noarch.rpm
 {% endhighlight %}
 </div>
 
@@ -109,19 +109,18 @@ sudo yum -y install https://mirror.centos.org/centos/7/extras/x86_64/Packages/ce
 </div>
 
 <div class="quickstart_os quickstart_os_rhel8 quickstart_os_el8">
-  <p>Enable the Ruby 2.7 module:</p>
+  <p>Enable the Foreman repositories:</p>
 
 {% highlight bash %}
-sudo dnf module reset ruby
-sudo dnf module enable ruby:2.7
+sudo dnf -y install https://yum.theforeman.org/releases/{{page.version}}/el8/x86_64/foreman-release.rpm
 {% endhighlight %}
 </div>
 
 <div class="quickstart_os quickstart_os_rhel8 quickstart_os_el8">
-  <p>Enable the Foreman repositories:</p>
+  <p>Enable the Foreman module:</p>
 
 {% highlight bash %}
-sudo yum -y install https://yum.theforeman.org/releases/{{page.version}}/el8/x86_64/foreman-release.rpm
+sudo dnf module enable foreman:el8
 {% endhighlight %}
 </div>
 

--- a/_includes/manuals/nightly/3.1.3_puppet_versions.md
+++ b/_includes/manuals/nightly/3.1.3_puppet_versions.md
@@ -21,12 +21,12 @@ Foreman integrates with Puppet and Facter in a few places, but generally using a
   </tr>
   <tr>
     <td>5.x</td>
-    <td>Supported</td>
-    <td>Untested</td>
-    <td>Supported</td>
+    <td>Not supported</td>
+    <td>Not supported</td>
+    <td>Deprecated</td>
   </tr>
   <tr>
-    <td>6.x</td>
+    <td>6.x - 7.x</td>
     <td>Supported</td>
     <td>Untested</td>
     <td>Supported</td>
@@ -43,7 +43,7 @@ Puppetserver is the application for serving Puppet agents used by default since 
 
 #### Facter compatibility
 
-Foreman is known to be compatible with all Facter 1.x to 3.x releases.
+Foreman is known to be compatible with all Facter 2.x to 4.x releases.
 
 #### Puppet Enterprise compatibility
 

--- a/_includes/manuals/nightly/3.6_upgrade.md
+++ b/_includes/manuals/nightly/3.6_upgrade.md
@@ -122,11 +122,16 @@ Clean up the yum metadata cache:
 dnf clean metadata
 {% endhighlight %}
 
-Enable the Ruby 2.7 module:
+If the Ruby 2.5 module was previously enabled, it must be reset:
 
 {% highlight bash %}
 dnf module reset ruby
-dnf module enable ruby:2.7
+{% endhighlight %}
+
+Enable the Foreman module:
+
+{% highlight bash %}
+dnf module enable foreman:el8
 {% endhighlight %}
 
 Next upgrade all Foreman packages:


### PR DESCRIPTION
A foreman module is now used on EL8 which enables the correct modules, including Ruby. For this the order needs to be changed: the release repo must be present prior to enabling the module.