### PR TITLE
deprecate Ruby 2.5 deployments together with Debian 10

### DIFF
--- a/_includes/manuals/3.3/1.2_release_notes.md
+++ b/_includes/manuals/3.3/1.2_release_notes.md
@@ -24,9 +24,11 @@ Running Foreman with setting `unattended: false` is dropped.
 Every Foreman instance is now effectively running with this setting on.
 For more details and discussion read [the RFC](https://community.theforeman.org/t/rfc-remove-unattended-setting/10035).
 
-### Deprecations
+#### BMC credentials access turned off by default
 
 BMC credentials access through ENC YAML output and templates is turned off by default for increased security. To turn it on, go to Administer - Settings and turn the "BMC credentials access" setting on.
+
+#### Updated browser compatiblity
 
 We've updated our browsers compatibility to support the following:
 
@@ -35,6 +37,14 @@ We've updated our browsers compatibility to support the following:
 * Apple Safari - latest version
 * Mozilla Firefox - latest version
 * Mozilla Firefox Extended Support Release (ESR) - latest version
+
+### Deprecations
+
+#### Running Foreman on Ruby 2.5
+
+With the deprecation of Debian 10 deployments in Foreman 3.2 (and the removal of support in 3.4), there will be no supported platform with Ruby 2.5 anymore.
+Therefore running Foreman on Ruby 2.5 is deprecated and support will be dropped (together with Debian 10) in Foreman 3.4.
+Please switch to Ruby 2.7.
 
 ### Release notes for 3.3.0
 #### Foreman


### PR DESCRIPTION
also move BMC and browser to upgrade notes, not deprecations