### PR TITLE
Add missing OS deprecations for Foreman 3.3

### DIFF
--- a/_includes/manuals/3.3/1.2_release_notes.md
+++ b/_includes/manuals/3.3/1.2_release_notes.md
@@ -44,6 +44,18 @@ We've updated our browsers compatibility to support the following:
 
 ### Deprecations
 
+#### Running Foreman on EL7
+
+EL7 support is deprecated and will be dropped with Foreman 3.4. Users are advised to upgrade to EL8.
+
+Note that this support statement refers to running Foreman and Foreman Smart Proxy themselves on EL7. Managing EL7 hosts remains supported. See [the RFC](https://community.theforeman.org/t/deprecation-plans-for-foreman-on-el7-debian-10-and-ubuntu-18-04/25008) for more information.
+
+#### Running Foreman on Debian 10
+
+Debian 10 support is deprecated and will be dropped with Foreman 3.4. Users are advised to upgrade to Debian 11.
+
+Note that this support statement refers to running Foreman and Foreman Proxy themselves on Debian 10. Managing Debian 10 hosts remains supported. See [the RFC](https://community.theforeman.org/t/deprecation-plans-for-foreman-on-el7-debian-10-and-ubuntu-18-04/25008) for more information.
+
 #### Running Foreman on Ruby 2.5
 
 With the deprecation of Debian 10 deployments in Foreman 3.2 (and the removal of support in 3.4), there will be no supported platform with Ruby 2.5 anymore.


### PR DESCRIPTION
In efd17623bee071723bddebf0e70e2db0791dae6e the deprecations for Foreman 3.4 were removed from nightly, which meant they weren't branched to Foreman 3.3. However, users should certainly be notified.

The messaging is modified to clearly state 3.4 is the last version.