### PR TITLE
Link to Foreman Documentation in navbar

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -37,8 +37,8 @@ navigation:
         url: /sponsors.html
   - title: Get Help
     sublinks:
-      - title: Manual
-        url: /manuals/latest/index.html
+      - title: Documentation
+        url: https://docs.theforeman.org/
       - title: Plugins
         url: /plugins/
       - title: API docs


### PR DESCRIPTION
Replace the link to the old Foreman Manual & instead refer users to our new, shiny, and well maintained Foreman Documentation!