### PR TITLE
Update the Running Foreman on EL7 deprecation notice

### DIFF
--- a/_includes/manuals/3.0/1.2_release_notes.md
+++ b/_includes/manuals/3.0/1.2_release_notes.md
@@ -42,10 +42,7 @@ Note that this is only support to run Foreman and Foreman Proxy themselves on Ub
 
 #### Running Foreman on EL7
 
-Foreman 2.1 introduced EL8 support and Katello 4.0 (on Foreman 2.4) followed.
-While it's currently undecided when EL7 support will be dropped exactly, this is an early notice given the considerable number of EL7 deployments.
-For fresh installations, EL8 should considered the preferred target.
-Existing installations should start thinking about a migration plan.
+EL7 support is deprecated and will be dropped with Foreman 3.4. Starting Foreman 3.1 users can upgrade to EL8 using Leapp.
 
 Note that this is only support to run Foreman and Foreman Proxy themselves on EL7. Managing EL7 systems remains supported. See [the RFC](https://community.theforeman.org/t/deprecation-plans-for-foreman-on-el7-debian-10-and-ubuntu-18-04/25008) for more information.
 

--- a/_includes/manuals/3.1/1.2_release_notes.md
+++ b/_includes/manuals/3.1/1.2_release_notes.md
@@ -54,10 +54,7 @@ The host registration feature can be used to register hosts on Foreman for the s
 
 #### Running Foreman on EL7
 
-Foreman 2.1 introduced EL8 support and Katello 4.0 (on Foreman 2.4) followed.
-While it's currently undecided when EL7 support will be dropped exactly, this is an early notice given the considerable number of EL7 deployments.
-For fresh installations, it is advisable to install on EL8.
-Existing installations should start thinking about a migration plan.
+EL7 support is deprecated and will be dropped with Foreman 3.4. Users are advised to upgrade to EL8.
 
 Note that this support statement refers to running Foreman and Foreman Proxy themselves on EL7. Managing EL7 hosts remains supported. See [the RFC](https://community.theforeman.org/t/deprecation-plans-for-foreman-on-el7-debian-10-and-ubuntu-18-04/25008) for more information.
 

--- a/_includes/manuals/3.2/1.2_release_notes.md
+++ b/_includes/manuals/3.2/1.2_release_notes.md
@@ -18,10 +18,7 @@ For more information see the [RFC](https://community.theforeman.org/t/drop-requi
 
 #### Running Foreman on EL7
 
-Foreman 2.1 introduced EL8 support and Katello 4.0 (on Foreman 2.4) followed.
-While it's currently undecided when EL7 support will be dropped exactly, this is an early notice given the considerable number of EL7 deployments.
-For fresh installations, it is advisable to install on EL8.
-Existing installations should start thinking about a migration plan.
+EL7 support is deprecated and will be dropped with Foreman 3.4. Users are advised to upgrade to EL8.
 
 Note that this support statement refers to running Foreman and Foreman Smart Proxy themselves on EL7. Managing EL7 hosts remains supported. See [the RFC](https://community.theforeman.org/t/deprecation-plans-for-foreman-on-el7-debian-10-and-ubuntu-18-04/25008) for more information.
 


### PR DESCRIPTION
By now we know when support will be dropped. This pulls back the changes from the 3.3 release notes. In place upgrades on Foreman 3.0 are not supported.