### PR TITLE
Fix stop/start commands of upgrade manual

### DIFF
--- a/_includes/manuals/nightly/3.6_upgrade.md
+++ b/_includes/manuals/nightly/3.6_upgrade.md
@@ -63,7 +63,7 @@ systemctl stop httpd foreman.service foreman.socket dynflow\*
 </div>
 <div class="upgrade_os upgrade_os_debian11 upgrade_os_ubuntu2004">
 {% highlight bash %}
-systemctl stop apache foreman.service foreman.socket dynflow\*
+systemctl stop apache2 foreman.service foreman.socket dynflow\*
 {% endhighlight %}
 </div>
 
@@ -187,7 +187,7 @@ systemctl start httpd foreman.service foreman.socket
 </div>
 <div class="upgrade_os upgrade_os_debian11 upgrade_os_ubuntu2004">
 {% highlight bash %}
-systemctl start apache foreman.service foreman.socket
+systemctl start apache2 foreman.service foreman.socket
 {% endhighlight %}
 </div>
 


### PR DESCRIPTION
This bugged me a long time already. I don't know in which world "apache" might work without the "2", but in ours it doesn't. I hope i raised the PR for the right document.