### PR TITLE
drop therubyracer dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,4 @@
 source "https://rubygems.org"
 
-group :therubyracer do
-    gem 'therubyracer', :require => 'v8'
-end
-
 gem 'github-pages', '>= 147'
 gem 'rake'


### PR DESCRIPTION
* it's incompatible with Ruby 3.0+
* execjs doesn't support it since 2.8.0
* it's only needed for jekyll-coffeescript, which we don't use