### PR TITLE
Reflect TLS 1.1 disabling in Foreman Proxy 2.1+

### DIFF
--- a/_includes/manuals/2.1/4.3.2_smartproxy_settings.md
+++ b/_includes/manuals/2.1/4.3.2_smartproxy_settings.md
@@ -92,7 +92,7 @@ see [**SSL**](manuals/{{page.version}}/index.html#4.3.10SSL) for more informatio
 
 Specific SSL cipher suites can be disabled by using the `:ssl_disabled_ciphers:` option. For more information on which cipher suites are enabled by default and how to correctly disable specific ones, please see [**SSL cipher suites**](manuals/{{page.version}}/index.html#ssl-cipher-suites).
 
-The TLS versions can be disabled if requiring a specific version. So while insecure SSLv3 and TLS v1.0 are disabled by default, setting the array of `:tls_disabled_versions:` to include `1.1` will disable this version, too.
+The TLS versions can be disabled if requiring a specific version. SSLv3, TLS v1.0, and TLS v1.1 are disabled by default, setting the array of `:tls_disabled_versions:` to include `1.2` will disable this version, too.
 
 This is the list of hosts from which the smart proxy will accept connections.  For HTTPS connections, the name must match the common name (CN) within the subject DN and for HTTP connections, it must match the hostname from reverse DNS.
 

--- a/_includes/manuals/2.2/4.3.2_smartproxy_settings.md
+++ b/_includes/manuals/2.2/4.3.2_smartproxy_settings.md
@@ -92,7 +92,7 @@ see [**SSL**](manuals/{{page.version}}/index.html#4.3.10SSL) for more informatio
 
 Specific SSL cipher suites can be disabled by using the `:ssl_disabled_ciphers:` option. For more information on which cipher suites are enabled by default and how to correctly disable specific ones, please see [**SSL cipher suites**](manuals/{{page.version}}/index.html#ssl-cipher-suites).
 
-The TLS versions can be disabled if requiring a specific version. So while insecure SSLv3 and TLS v1.0 are disabled by default, setting the array of `:tls_disabled_versions:` to include `1.1` will disable this version, too.
+The TLS versions can be disabled if requiring a specific version. SSLv3, TLS v1.0, and TLS v1.1 are disabled by default, setting the array of `:tls_disabled_versions:` to include `1.2` will disable this version, too.
 
 This is the list of hosts from which the smart proxy will accept connections.  For HTTPS connections, the name must match the common name (CN) within the subject DN and for HTTP connections, it must match the hostname from reverse DNS.
 

--- a/_includes/manuals/2.3/4.3.2_smartproxy_settings.md
+++ b/_includes/manuals/2.3/4.3.2_smartproxy_settings.md
@@ -92,7 +92,7 @@ see [**SSL**](manuals/{{page.version}}/index.html#4.3.10SSL) for more informatio
 
 Specific SSL cipher suites can be disabled by using the `:ssl_disabled_ciphers:` option. For more information on which cipher suites are enabled by default and how to correctly disable specific ones, please see [**SSL cipher suites**](manuals/{{page.version}}/index.html#ssl-cipher-suites).
 
-The TLS versions can be disabled if requiring a specific version. So while insecure SSLv3 and TLS v1.0 are disabled by default, setting the array of `:tls_disabled_versions:` to include `1.1` will disable this version, too.
+The TLS versions can be disabled if requiring a specific version. SSLv3, TLS v1.0, and TLS v1.1 are disabled by default, setting the array of `:tls_disabled_versions:` to include `1.2` will disable this version, too.
 
 This is the list of hosts from which the smart proxy will accept connections.  For HTTPS connections, the name must match the common name (CN) within the subject DN and for HTTP connections, it must match the hostname from reverse DNS.
 

--- a/_includes/manuals/2.4/4.3.2_smartproxy_settings.md
+++ b/_includes/manuals/2.4/4.3.2_smartproxy_settings.md
@@ -92,7 +92,7 @@ see [**SSL**](manuals/{{page.version}}/index.html#4.3.10SSL) for more informatio
 
 Specific SSL cipher suites can be disabled by using the `:ssl_disabled_ciphers:` option. For more information on which cipher suites are enabled by default and how to correctly disable specific ones, please see [**SSL cipher suites**](manuals/{{page.version}}/index.html#ssl-cipher-suites).
 
-The TLS versions can be disabled if requiring a specific version. So while insecure SSLv3 and TLS v1.0 are disabled by default, setting the array of `:tls_disabled_versions:` to include `1.1` will disable this version, too.
+The TLS versions can be disabled if requiring a specific version. SSLv3, TLS v1.0, and TLS v1.1 are disabled by default, setting the array of `:tls_disabled_versions:` to include `1.2` will disable this version, too.
 
 This is the list of hosts from which the smart proxy will accept connections.  For HTTPS connections, the name must match the common name (CN) within the subject DN and for HTTP connections, it must match the hostname from reverse DNS.
 

--- a/_includes/manuals/2.5/4.3.2_smartproxy_settings.md
+++ b/_includes/manuals/2.5/4.3.2_smartproxy_settings.md
@@ -92,7 +92,7 @@ see [**SSL**](manuals/{{page.version}}/index.html#4.3.10SSL) for more informatio
 
 Specific SSL cipher suites can be disabled by using the `:ssl_disabled_ciphers:` option. For more information on which cipher suites are enabled by default and how to correctly disable specific ones, please see [**SSL cipher suites**](manuals/{{page.version}}/index.html#ssl-cipher-suites).
 
-The TLS versions can be disabled if requiring a specific version. So while insecure SSLv3 and TLS v1.0 are disabled by default, setting the array of `:tls_disabled_versions:` to include `1.1` will disable this version, too.
+The TLS versions can be disabled if requiring a specific version. SSLv3, TLS v1.0, and TLS v1.1 are disabled by default, setting the array of `:tls_disabled_versions:` to include `1.2` will disable this version, too.
 
 This is the list of hosts from which the smart proxy will accept connections.  For HTTPS connections, the name must match the common name (CN) within the subject DN and for HTTP connections, it must match the hostname from reverse DNS.
 

--- a/_includes/manuals/3.0/4.3.2_smartproxy_settings.md
+++ b/_includes/manuals/3.0/4.3.2_smartproxy_settings.md
@@ -92,7 +92,7 @@ see [**SSL**](manuals/{{page.version}}/index.html#4.3.10SSL) for more informatio
 
 Specific SSL cipher suites can be disabled by using the `:ssl_disabled_ciphers:` option. For more information on which cipher suites are enabled by default and how to correctly disable specific ones, please see [**SSL cipher suites**](manuals/{{page.version}}/index.html#ssl-cipher-suites).
 
-The TLS versions can be disabled if requiring a specific version. So while insecure SSLv3 and TLS v1.0 are disabled by default, setting the array of `:tls_disabled_versions:` to include `1.1` will disable this version, too.
+The TLS versions can be disabled if requiring a specific version. SSLv3, TLS v1.0, and TLS v1.1 are disabled by default, setting the array of `:tls_disabled_versions:` to include `1.2` will disable this version, too.
 
 This is the list of hosts from which the smart proxy will accept connections.  For HTTPS connections, the name must match the common name (CN) within the subject DN and for HTTP connections, it must match the hostname from reverse DNS.
 

--- a/_includes/manuals/3.1/4.3.2_smartproxy_settings.md
+++ b/_includes/manuals/3.1/4.3.2_smartproxy_settings.md
@@ -92,7 +92,7 @@ see [**SSL**](manuals/{{page.version}}/index.html#4.3.10SSL) for more informatio
 
 Specific SSL cipher suites can be disabled by using the `:ssl_disabled_ciphers:` option. For more information on which cipher suites are enabled by default and how to correctly disable specific ones, please see [**SSL cipher suites**](manuals/{{page.version}}/index.html#ssl-cipher-suites).
 
-The TLS versions can be disabled if requiring a specific version. So while insecure SSLv3 and TLS v1.0 are disabled by default, setting the array of `:tls_disabled_versions:` to include `1.1` will disable this version, too.
+The TLS versions can be disabled if requiring a specific version. SSLv3, TLS v1.0, and TLS v1.1 are disabled by default, setting the array of `:tls_disabled_versions:` to include `1.2` will disable this version, too.
 
 This is the list of hosts from which the smart proxy will accept connections.  For HTTPS connections, the name must match the common name (CN) within the subject DN and for HTTP connections, it must match the hostname from reverse DNS.
 

--- a/_includes/manuals/3.2/4.3.2_smartproxy_settings.md
+++ b/_includes/manuals/3.2/4.3.2_smartproxy_settings.md
@@ -94,7 +94,7 @@ see [**SSL**](manuals/{{page.version}}/index.html#4.3.10SSL) for more informatio
 
 Specific SSL cipher suites can be disabled by using the `:ssl_disabled_ciphers:` option. For more information on which cipher suites are enabled by default and how to correctly disable specific ones, please see [**SSL cipher suites**](manuals/{{page.version}}/index.html#ssl-cipher-suites).
 
-The TLS versions can be disabled if requiring a specific version. So while insecure SSLv3 and TLS v1.0 are disabled by default, setting the array of `:tls_disabled_versions:` to include `1.1` will disable this version, too.
+The TLS versions can be disabled if requiring a specific version. SSLv3, TLS v1.0, and TLS v1.1 are disabled by default, setting the array of `:tls_disabled_versions:` to include `1.2` will disable this version, too.
 
 This is the list of hosts from which the smart proxy will accept connections.  For HTTPS connections, the name must match the common name (CN) within the subject DN and for HTTP connections, it must match the hostname from reverse DNS.
 

--- a/_includes/manuals/3.3/4.3.2_smartproxy_settings.md
+++ b/_includes/manuals/3.3/4.3.2_smartproxy_settings.md
@@ -94,7 +94,7 @@ see [**SSL**](manuals/{{page.version}}/index.html#4.3.10SSL) for more informatio
 
 Specific SSL cipher suites can be disabled by using the `:ssl_disabled_ciphers:` option. For more information on which cipher suites are enabled by default and how to correctly disable specific ones, please see [**SSL cipher suites**](manuals/{{page.version}}/index.html#ssl-cipher-suites).
 
-The TLS versions can be disabled if requiring a specific version. So while insecure SSLv3 and TLS v1.0 are disabled by default, setting the array of `:tls_disabled_versions:` to include `1.1` will disable this version, too.
+The TLS versions can be disabled if requiring a specific version. SSLv3, TLS v1.0, and TLS v1.1 are disabled by default, setting the array of `:tls_disabled_versions:` to include `1.2` will disable this version, too.
 
 This is the list of hosts from which the smart proxy will accept connections.  For HTTPS connections, the name must match the common name (CN) within the subject DN and for HTTP connections, it must match the hostname from reverse DNS.
 

--- a/_includes/manuals/3.4/4.3.2_smartproxy_settings.md
+++ b/_includes/manuals/3.4/4.3.2_smartproxy_settings.md
@@ -92,7 +92,7 @@ see [**SSL**](manuals/{{page.version}}/index.html#4.3.10SSL) for more informatio
 
 Specific SSL cipher suites can be disabled by using the `:ssl_disabled_ciphers:` option. For more information on which cipher suites are enabled by default and how to correctly disable specific ones, please see [**SSL cipher suites**](manuals/{{page.version}}/index.html#ssl-cipher-suites).
 
-The TLS versions can be disabled if requiring a specific version. So while insecure SSLv3 and TLS v1.0 are disabled by default, setting the array of `:tls_disabled_versions:` to include `1.1` will disable this version, too.
+The TLS versions can be disabled if requiring a specific version. SSLv3, TLS v1.0, and TLS v1.1 are disabled by default, setting the array of `:tls_disabled_versions:` to include `1.2` will disable this version, too.
 
 This is the list of hosts from which the smart proxy will accept connections.  For HTTPS connections, the name must match the common name (CN) within the subject DN and for HTTP connections, it must match the hostname from reverse DNS.
 

--- a/_includes/manuals/nightly/4.3.2_smartproxy_settings.md
+++ b/_includes/manuals/nightly/4.3.2_smartproxy_settings.md
@@ -92,7 +92,7 @@ see [**SSL**](manuals/{{page.version}}/index.html#4.3.10SSL) for more informatio
 
 Specific SSL cipher suites can be disabled by using the `:ssl_disabled_ciphers:` option. For more information on which cipher suites are enabled by default and how to correctly disable specific ones, please see [**SSL cipher suites**](manuals/{{page.version}}/index.html#ssl-cipher-suites).
 
-The TLS versions can be disabled if requiring a specific version. So while insecure SSLv3 and TLS v1.0 are disabled by default, setting the array of `:tls_disabled_versions:` to include `1.1` will disable this version, too.
+The TLS versions can be disabled if requiring a specific version. SSLv3, TLS v1.0, and TLS v1.1 are disabled by default, setting the array of `:tls_disabled_versions:` to include `1.2` will disable this version, too.
 
 This is the list of hosts from which the smart proxy will accept connections.  For HTTPS connections, the name must match the common name (CN) within the subject DN and for HTTP connections, it must match the hostname from reverse DNS.
 


### PR DESCRIPTION
Since Foreman Proxy 2.1 TLS 1.1 is disabled out of the box. This makes the tls_disabled_versions setting a bit pointless. It can still be used to disable TLS 1.2, but there's little reason to. It's still useful to keep the section in to explain the TLS versions disabled by default. See https://projects.theforeman.org/issues/29252 for more details.