### PR TITLE
remove CentOS 7/RHEL 7 from list of supported platforms

### DIFF
--- a/_includes/manuals/3.4/2_quickstart_guide.md
+++ b/_includes/manuals/3.4/2_quickstart_guide.md
@@ -4,7 +4,6 @@ The Foreman installer is a collection of Puppet modules that installs everything
 Components include the Foreman web UI, Smart Proxy, a Puppet server, and optionally TFTP, DNS and DHCP servers. It is configurable and the Puppet modules can be read or run in "no-op" mode to see what changes it will make.
 
 #### Supported platforms
-* CentOS 7 x86_64
 * CentOS 8 x86_64
 * CentOS 8 Stream x86_64
 * Debian 11 (Bullseye), amd64

--- a/_includes/manuals/3.4/2_quickstart_guide.md
+++ b/_includes/manuals/3.4/2_quickstart_guide.md
@@ -7,7 +7,6 @@ Components include the Foreman web UI, Smart Proxy, a Puppet server, and optiona
 * CentOS 8 x86_64
 * CentOS 8 Stream x86_64
 * Debian 11 (Bullseye), amd64
-* Red Hat Enterprise Linux 7, x86_64
 * Red Hat Enterprise Linux 8, x86_64
 * Ubuntu 20.04 (Focal), amd64
 

--- a/_includes/manuals/nightly/2_quickstart_guide.md
+++ b/_includes/manuals/nightly/2_quickstart_guide.md
@@ -4,11 +4,9 @@ The Foreman installer is a collection of Puppet modules that installs everything
 Components include the Foreman web UI, Smart Proxy, a Puppet server, and optionally TFTP, DNS and DHCP servers. It is configurable and the Puppet modules can be read or run in "no-op" mode to see what changes it will make.
 
 #### Supported platforms
-* CentOS 7 x86_64
 * CentOS 8 x86_64
 * CentOS 8 Stream x86_64
 * Debian 11 (Bullseye), amd64
-* Red Hat Enterprise Linux 7, x86_64
 * Red Hat Enterprise Linux 8, x86_64
 * Ubuntu 20.04 (Focal), amd64
 


### PR DESCRIPTION
Since Foreman 3.4 CentOS 7 is not longer supported as host platform. 