### PR TITLE
Fix Debian family upgrade instructions w.r.t. stopping/starting Apache.

### DIFF
--- a/_includes/manuals/2.2/3.6_upgrade.md
+++ b/_includes/manuals/2.2/3.6_upgrade.md
@@ -33,7 +33,7 @@ For more information about how to backup your instance head over to
 
 Before proceeding, it is necessary to shutdown the Foreman instance (e.g.
 `systemctl stop httpd foreman.service foreman.socket` or
-`systemctl stop apache foreman.service foreman.socket` usually).
+`systemctl stop apache2 foreman.service foreman.socket` usually).
 
 Now it's time to perform the actual upgrade.  This process if different
 depending on how you downloaded Foreman.  You only need to perform *one* of
@@ -174,7 +174,7 @@ On RPM installations, run:
 
 And on Debian/Ubuntu installations, run:
 
-    systemctl start apache foreman.service foreman.socket
+    systemctl start apache2 foreman.service foreman.socket
 
 #### Optional Step 5 - Reclaim database space
 

--- a/_includes/manuals/2.3/3.6_upgrade.md
+++ b/_includes/manuals/2.3/3.6_upgrade.md
@@ -42,7 +42,7 @@ For more information about how to backup your instance head over to
 
 Before proceeding, it is necessary to shutdown the Foreman instance (e.g.
 `systemctl stop httpd foreman.service foreman.socket` or
-`systemctl stop apache foreman.service foreman.socket` usually).
+`systemctl stop apache2 foreman.service foreman.socket` usually).
 
 Now it's time to perform the actual upgrade.  This process if different
 depending on how you downloaded Foreman.  You only need to perform *one* of
@@ -183,7 +183,7 @@ On RPM installations, run:
 
 And on Debian/Ubuntu installations, run:
 
-    systemctl start apache foreman.service foreman.socket
+    systemctl start apache2 foreman.service foreman.socket
 
 #### Optional Step 5 - Reclaim database space
 

--- a/_includes/manuals/2.4/3.6_upgrade.md
+++ b/_includes/manuals/2.4/3.6_upgrade.md
@@ -64,7 +64,7 @@ systemctl stop httpd foreman.service foreman.socket dynflow\*
 </div>
 <div class="upgrade_os upgrade_os_debian10 upgrade_os_ubuntu1804">
 {% highlight bash %}
-systemctl stop apache foreman.service foreman.socket dynflow\*
+systemctl stop apache2 foreman.service foreman.socket dynflow\*
 {% endhighlight %}
 </div>
 
@@ -246,7 +246,7 @@ systemctl start httpd foreman.service foreman.socket
 </div>
 <div class="upgrade_os upgrade_os_debian10 upgrade_os_ubuntu1804">
 {% highlight bash %}
-systemctl start apache foreman.service foreman.socket
+systemctl start apache2 foreman.service foreman.socket
 {% endhighlight %}
 </div>
 

--- a/_includes/manuals/2.5/3.6_upgrade.md
+++ b/_includes/manuals/2.5/3.6_upgrade.md
@@ -65,7 +65,7 @@ systemctl stop httpd foreman.service foreman.socket dynflow\*
 </div>
 <div class="upgrade_os upgrade_os_debian10 upgrade_os_ubuntu1804 upgrade_os_ubuntu2004">
 {% highlight bash %}
-systemctl stop apache foreman.service foreman.socket dynflow\*
+systemctl stop apache2 foreman.service foreman.socket dynflow\*
 {% endhighlight %}
 </div>
 
@@ -239,7 +239,7 @@ systemctl start httpd foreman.service foreman.socket
 </div>
 <div class="upgrade_os upgrade_os_debian10 upgrade_os_ubuntu1804 upgrade_os_ubuntu2004">
 {% highlight bash %}
-systemctl start apache foreman.service foreman.socket
+systemctl start apache2 foreman.service foreman.socket
 {% endhighlight %}
 </div>
 

--- a/_includes/manuals/3.0/3.6_upgrade.md
+++ b/_includes/manuals/3.0/3.6_upgrade.md
@@ -65,7 +65,7 @@ systemctl stop httpd foreman.service foreman.socket dynflow\*
 </div>
 <div class="upgrade_os upgrade_os_debian10 upgrade_os_ubuntu1804 upgrade_os_ubuntu2004">
 {% highlight bash %}
-systemctl stop apache foreman.service foreman.socket dynflow\*
+systemctl stop apache2 foreman.service foreman.socket dynflow\*
 {% endhighlight %}
 </div>
 
@@ -263,7 +263,7 @@ systemctl start httpd foreman.service foreman.socket
 </div>
 <div class="upgrade_os upgrade_os_debian10 upgrade_os_ubuntu1804 upgrade_os_ubuntu2004">
 {% highlight bash %}
-systemctl start apache foreman.service foreman.socket
+systemctl start apache2 foreman.service foreman.socket
 {% endhighlight %}
 </div>
 

--- a/_includes/manuals/3.1/3.6_upgrade.md
+++ b/_includes/manuals/3.1/3.6_upgrade.md
@@ -64,7 +64,7 @@ systemctl stop httpd foreman.service foreman.socket dynflow\*
 </div>
 <div class="upgrade_os upgrade_os_debian10 upgrade_os_ubuntu2004">
 {% highlight bash %}
-systemctl stop apache foreman.service foreman.socket dynflow\*
+systemctl stop apache2 foreman.service foreman.socket dynflow\*
 {% endhighlight %}
 </div>
 
@@ -232,7 +232,7 @@ systemctl start httpd foreman.service foreman.socket
 </div>
 <div class="upgrade_os upgrade_os_debian10 upgrade_os_ubuntu2004">
 {% highlight bash %}
-systemctl start apache foreman.service foreman.socket
+systemctl start apache2 foreman.service foreman.socket
 {% endhighlight %}
 </div>
 

--- a/_includes/manuals/3.2/3.6_upgrade.md
+++ b/_includes/manuals/3.2/3.6_upgrade.md
@@ -65,7 +65,7 @@ systemctl stop httpd foreman.service foreman.socket dynflow\*
 </div>
 <div class="upgrade_os upgrade_os_debian10 upgrade_os_debian11 upgrade_os_ubuntu2004">
 {% highlight bash %}
-systemctl stop apache foreman.service foreman.socket dynflow\*
+systemctl stop apache2 foreman.service foreman.socket dynflow\*
 {% endhighlight %}
 </div>
 
@@ -239,7 +239,7 @@ systemctl start httpd foreman.service foreman.socket
 </div>
 <div class="upgrade_os upgrade_os_debian10 upgrade_os_debian11 upgrade_os_ubuntu2004">
 {% highlight bash %}
-systemctl start apache foreman.service foreman.socket
+systemctl start apache2 foreman.service foreman.socket
 {% endhighlight %}
 </div>
 

--- a/_includes/manuals/3.3/3.6_upgrade.md
+++ b/_includes/manuals/3.3/3.6_upgrade.md
@@ -65,7 +65,7 @@ systemctl stop httpd foreman.service foreman.socket dynflow\*
 </div>
 <div class="upgrade_os upgrade_os_debian10 upgrade_os_debian11 upgrade_os_ubuntu2004">
 {% highlight bash %}
-systemctl stop apache foreman.service foreman.socket dynflow\*
+systemctl stop apache2 foreman.service foreman.socket dynflow\*
 {% endhighlight %}
 </div>
 
@@ -244,7 +244,7 @@ systemctl start httpd foreman.service foreman.socket
 </div>
 <div class="upgrade_os upgrade_os_debian10 upgrade_os_debian11 upgrade_os_ubuntu2004">
 {% highlight bash %}
-systemctl start apache foreman.service foreman.socket
+systemctl start apache2 foreman.service foreman.socket
 {% endhighlight %}
 </div>
 

--- a/_includes/manuals/3.4/3.6_upgrade.md
+++ b/_includes/manuals/3.4/3.6_upgrade.md
@@ -63,7 +63,7 @@ systemctl stop httpd foreman.service foreman.socket dynflow\*
 </div>
 <div class="upgrade_os upgrade_os_debian11 upgrade_os_ubuntu2004">
 {% highlight bash %}
-systemctl stop apache foreman.service foreman.socket dynflow\*
+systemctl stop apache2 foreman.service foreman.socket dynflow\*
 {% endhighlight %}
 </div>
 
@@ -187,7 +187,7 @@ systemctl start httpd foreman.service foreman.socket
 </div>
 <div class="upgrade_os upgrade_os_debian11 upgrade_os_ubuntu2004">
 {% highlight bash %}
-systemctl start apache foreman.service foreman.socket
+systemctl start apache2 foreman.service foreman.socket
 {% endhighlight %}
 </div>
 


### PR DESCRIPTION
Since nobody seems to react on my FlySpray reports, I fixed the documentation myself. Looks like nightly was already fixed, but past releases were not.