### PR TITLE
Add a warning that Katello docs have moved to docs.theforeman.org

### DIFF
--- a/plugins/katello/index.md
+++ b/plugins/katello/index.md
@@ -11,6 +11,12 @@ title: Katello Documentation
     </h1>
 
     <br/>
+	<b style="font-size: 26px">
+	  Katello's documentation for versions 4.0+ has moved to <a href="https://docs.theforeman.org">docs.theforeman.org</a>.
+	</b>
+
+	<br/>
+	<br/>
     <p>
       Katello brings the full power of content management alongside the provisioning and configuration capabilities of <a href="http://theforeman.org">Foreman.</a>
     </p>


### PR DESCRIPTION
theforeman.org is still the top search result on Google, so I figured we should make it more obvious where the official Katello docs live.