### PR TITLE
Fix `Foreman installer` puppet version reference

### DIFF
--- a/_includes/manuals/3.0/2.1_quickstart_installation.md
+++ b/_includes/manuals/3.0/2.1_quickstart_installation.md
@@ -1,4 +1,4 @@
-[The Foreman installer](/manuals/{{page.version}}/index.html#3.2ForemanInstaller) uses Puppet **(5 or later required)** to install Foreman. This guide assumes that you have a newly installed operating system, on which the installer will setup Foreman, a Puppet server, and the [Smart Proxy](/manuals/{{page.version}}/index.html#4.3SmartProxies) by default. It's **not advisable** to follow the steps below on an existing system, since the installer will affect the configuration of several components.
+[The Foreman installer](/manuals/{{page.version}}/index.html#3.2ForemanInstaller) uses Puppet **(6 or later required)** to install Foreman. This guide assumes that you have a newly installed operating system, on which the installer will setup Foreman, a Puppet server, and the [Smart Proxy](/manuals/{{page.version}}/index.html#4.3SmartProxies) by default. It's **not advisable** to follow the steps below on an existing system, since the installer will affect the configuration of several components.
 
 <div class="alert alert-info">
 

--- a/_includes/manuals/3.1/2.1_quickstart_installation.md
+++ b/_includes/manuals/3.1/2.1_quickstart_installation.md
@@ -1,4 +1,4 @@
-[The Foreman installer](/manuals/{{page.version}}/index.html#3.2ForemanInstaller) uses Puppet **(5 or later required)** to install Foreman. This guide assumes that you have a newly installed operating system, on which the installer will setup Foreman, a Puppet server, and the [Smart Proxy](/manuals/{{page.version}}/index.html#4.3SmartProxies) by default. It's **not advisable** to follow the steps below on an existing system, since the installer will affect the configuration of several components.
+[The Foreman installer](/manuals/{{page.version}}/index.html#3.2ForemanInstaller) uses Puppet **(6 or later required)** to install Foreman. This guide assumes that you have a newly installed operating system, on which the installer will setup Foreman, a Puppet server, and the [Smart Proxy](/manuals/{{page.version}}/index.html#4.3SmartProxies) by default. It's **not advisable** to follow the steps below on an existing system, since the installer will affect the configuration of several components.
 
 <div class="alert alert-info">
 

--- a/_includes/manuals/3.2/2.1_quickstart_installation.md
+++ b/_includes/manuals/3.2/2.1_quickstart_installation.md
@@ -1,4 +1,4 @@
-[The Foreman installer](/manuals/{{page.version}}/index.html#3.2ForemanInstaller) uses Puppet **(5 or later required)** to install Foreman. This guide assumes that you have a newly installed operating system, on which the installer will setup Foreman, a Puppet server, and the [Smart Proxy](/manuals/{{page.version}}/index.html#4.3SmartProxies) by default. It's **not advisable** to follow the steps below on an existing system, since the installer will affect the configuration of several components.
+[The Foreman installer](/manuals/{{page.version}}/index.html#3.2ForemanInstaller) uses Puppet **(6 or later required)** to install Foreman. This guide assumes that you have a newly installed operating system, on which the installer will setup Foreman, a Puppet server, and the [Smart Proxy](/manuals/{{page.version}}/index.html#4.3SmartProxies) by default. It's **not advisable** to follow the steps below on an existing system, since the installer will affect the configuration of several components.
 
 <div class="alert alert-info">
 

--- a/_includes/manuals/3.3/2.1_quickstart_installation.md
+++ b/_includes/manuals/3.3/2.1_quickstart_installation.md
@@ -1,4 +1,4 @@
-[The Foreman installer](/manuals/{{page.version}}/index.html#3.2ForemanInstaller) uses Puppet **(5 or later required)** to install Foreman. This guide assumes that you have a newly installed operating system, on which the installer will setup Foreman, a Puppet server, and the [Smart Proxy](/manuals/{{page.version}}/index.html#4.3SmartProxies) by default. It's **not advisable** to follow the steps below on an existing system, since the installer will affect the configuration of several components.
+[The Foreman installer](/manuals/{{page.version}}/index.html#3.2ForemanInstaller) uses Puppet **(6 or later required)** to install Foreman. This guide assumes that you have a newly installed operating system, on which the installer will setup Foreman, a Puppet server, and the [Smart Proxy](/manuals/{{page.version}}/index.html#4.3SmartProxies) by default. It's **not advisable** to follow the steps below on an existing system, since the installer will affect the configuration of several components.
 
 <div class="alert alert-info">
 

--- a/_includes/manuals/3.4/2.1_quickstart_installation.md
+++ b/_includes/manuals/3.4/2.1_quickstart_installation.md
@@ -1,4 +1,4 @@
-[The Foreman installer](/manuals/{{page.version}}/index.html#3.2ForemanInstaller) uses Puppet **(5 or later required)** to install Foreman. This guide assumes that you have a newly installed operating system, on which the installer will setup Foreman, a Puppet server, and the [Smart Proxy](/manuals/{{page.version}}/index.html#4.3SmartProxies) by default. It's **not advisable** to follow the steps below on an existing system, since the installer will affect the configuration of several components.
+[The Foreman installer](/manuals/{{page.version}}/index.html#3.2ForemanInstaller) uses Puppet **(6 or later required)** to install Foreman. This guide assumes that you have a newly installed operating system, on which the installer will setup Foreman, a Puppet server, and the [Smart Proxy](/manuals/{{page.version}}/index.html#4.3SmartProxies) by default. It's **not advisable** to follow the steps below on an existing system, since the installer will affect the configuration of several components.
 
 <div class="alert alert-info">
 

--- a/_includes/manuals/3.5/2.1_quickstart_installation.md
+++ b/_includes/manuals/3.5/2.1_quickstart_installation.md
@@ -1,4 +1,4 @@
-[The Foreman installer](/manuals/{{page.version}}/index.html#3.2ForemanInstaller) uses Puppet **(5 or later required)** to install Foreman. This guide assumes that you have a newly installed operating system, on which the installer will setup Foreman, a Puppet server, and the [Smart Proxy](/manuals/{{page.version}}/index.html#4.3SmartProxies) by default. It's **not advisable** to follow the steps below on an existing system, since the installer will affect the configuration of several components.
+[The Foreman installer](/manuals/{{page.version}}/index.html#3.2ForemanInstaller) uses Puppet **(6 or later required)** to install Foreman. This guide assumes that you have a newly installed operating system, on which the installer will setup Foreman, a Puppet server, and the [Smart Proxy](/manuals/{{page.version}}/index.html#4.3SmartProxies) by default. It's **not advisable** to follow the steps below on an existing system, since the installer will affect the configuration of several components.
 
 <div class="alert alert-info">
 

--- a/_includes/manuals/nightly/2.1_quickstart_installation.md
+++ b/_includes/manuals/nightly/2.1_quickstart_installation.md
@@ -1,4 +1,4 @@
-[The Foreman installer](/manuals/{{page.version}}/index.html#3.2ForemanInstaller) uses Puppet **(5 or later required)** to install Foreman. This guide assumes that you have a newly installed operating system, on which the installer will setup Foreman, a Puppet server, and the [Smart Proxy](/manuals/{{page.version}}/index.html#4.3SmartProxies) by default. It's **not advisable** to follow the steps below on an existing system, since the installer will affect the configuration of several components.
+[The Foreman installer](/manuals/{{page.version}}/index.html#3.2ForemanInstaller) uses Puppet **(6 or later required)** to install Foreman. This guide assumes that you have a newly installed operating system, on which the installer will setup Foreman, a Puppet server, and the [Smart Proxy](/manuals/{{page.version}}/index.html#4.3SmartProxies) by default. It's **not advisable** to follow the steps below on an existing system, since the installer will affect the configuration of several components.
 
 <div class="alert alert-info">
 


### PR DESCRIPTION
At least some of the installer modules have required Puppet 6 since Foreman 3.0