### PR TITLE
Deprecate Chef plug-in for Foreman 3.5+

### DIFF
--- a/_includes/manuals/3.5/1.1_architecture.md
+++ b/_includes/manuals/3.5/1.1_architecture.md
@@ -8,7 +8,7 @@ Foreman installation supports unattended installations, then other
 operations need to be performed to fully automate this process. The
 Smart Proxy manages remote services and is generally installed with all
 Foreman installations to manage TFTP, DHCP, DNS, Puppet, Puppet CA,
-Ansible, Salt, and Chef.
+Ansible, and Salt.
 
 ## Smart-Proxy
 

--- a/_includes/manuals/3.5/3.5.2_configuration_options.md
+++ b/_includes/manuals/3.5/3.5.2_configuration_options.md
@@ -326,7 +326,7 @@ See also: dns_conflict_timeout
 
 ##### restrict_registered_smart_proxies
 
-When set to _true_, services such as Puppet servers (or Salt, Chef) need to have a smart proxy registered with the appropriate feature (e.g. Puppet) to access fact/report importers and ENC output.
+When set to _true_, services such as Puppet servers (or Salt) need to have a smart proxy registered with the appropriate feature (e.g. Puppet) to access fact/report importers and ENC output.
 Default: true
 
 ##### root_pass

--- a/_includes/manuals/3.5/4.2.5_matchers.md
+++ b/_includes/manuals/3.5/4.2.5_matchers.md
@@ -121,7 +121,7 @@ By entering a list (comma-separated, no spaces) or a regex (no delimiter require
 
 #### Template variables
 
-Because Foreman offers templating capabilities, you can utilise pre-existing variables, macros and or functions within your parameterized classes. This is especially useful if you need to send a string to Puppet/Chef, but have a need to embed host specific information within the string, such as the host's FQDN.
+Because Foreman offers templating capabilities, you can utilise pre-existing variables, macros and or functions within your parameterized classes. This is especially useful if you need to send a string to Puppet, but have a need to embed host specific information within the string, such as the host's FQDN.
 
 Let's look a quick example situation: we need to configure RabbitMQ and have it use our existing Puppet SSL certs. Using what we've learnt above, we jump into the RabbitMQ class and configure the "ssl cert" parameter as such:
 

--- a/_includes/manuals/nightly/1.1_architecture.md
+++ b/_includes/manuals/nightly/1.1_architecture.md
@@ -8,7 +8,7 @@ Foreman installation supports unattended installations, then other
 operations need to be performed to fully automate this process. The
 Smart Proxy manages remote services and is generally installed with all
 Foreman installations to manage TFTP, DHCP, DNS, Puppet, Puppet CA,
-Ansible, Salt, and Chef.
+Ansible, and Salt.
 
 ## Smart-Proxy
 

--- a/_includes/manuals/nightly/3.5.2_configuration_options.md
+++ b/_includes/manuals/nightly/3.5.2_configuration_options.md
@@ -326,7 +326,7 @@ See also: dns_conflict_timeout
 
 ##### restrict_registered_smart_proxies
 
-When set to _true_, services such as Puppet servers (or Salt, Chef) need to have a smart proxy registered with the appropriate feature (e.g. Puppet) to access fact/report importers and ENC output.
+When set to _true_, services such as Puppet servers (or Salt) need to have a smart proxy registered with the appropriate feature (e.g. Puppet) to access fact/report importers and ENC output.
 Default: true
 
 ##### root_pass

--- a/_includes/manuals/nightly/4.2.5_matchers.md
+++ b/_includes/manuals/nightly/4.2.5_matchers.md
@@ -121,7 +121,7 @@ By entering a list (comma-separated, no spaces) or a regex (no delimiter require
 
 #### Template variables
 
-Because Foreman offers templating capabilities, you can utilise pre-existing variables, macros and or functions within your parameterized classes. This is especially useful if you need to send a string to Puppet/Chef, but have a need to embed host specific information within the string, such as the host's FQDN.
+Because Foreman offers templating capabilities, you can utilise pre-existing variables, macros and or functions within your parameterized classes. This is especially useful if you need to send a string to Puppet, but have a need to embed host specific information within the string, such as the host's FQDN.
 
 Let's look a quick example situation: we need to configure RabbitMQ and have it use our existing Puppet SSL certs. Using what we've learnt above, we jump into the RabbitMQ class and configure the "ssl cert" parameter as such:
 

--- a/_includes/monitoring.html
+++ b/_includes/monitoring.html
@@ -1,3 +1,3 @@
 <img class="homepage-img" src="{{ site.baseurl }}static/images/monitoring.png">
 <h2>Monitoring</h2>
-<p>Collect Puppet, Chef, Salt and Ansible reports and facts. Monitor host configuration, report status, distribution and trends.</p>
+<p>Collect Puppet, Salt, and Ansible reports and facts. Monitor host configuration, report status, distribution and trends.</p>

--- a/_includes/screenshots.html
+++ b/_includes/screenshots.html
@@ -19,7 +19,7 @@
 			</div>
 			<div class='col-md-4'>
 				<h2>Configuration</h2>
-				<p>An external node classifier, hiera-like parameters, and reports monitoring for Puppet, Salt and Chef are included. Completely ready to tweak host groups in your data center.</p>
+				<p>An external node classifier, hiera-like parameters, and reports monitoring for Puppet and Salt are included. Completely ready to tweak host groups in your data center.</p>
 			</div>
 			<div class='col-md-4'>
 			 	<a href="#"><img src='static/images/screenshots/puppetclasses.png' class='img-thumbnail'/></a>


### PR DESCRIPTION
As mentioned in Foreman 3.5 Release Notes: https://github.com/theforeman/foreman-documentation/pull/1765/files#r1018976161