### PR TITLE
Update statements around EL support

### DIFF
--- a/_includes/manuals/3.5/2.1_quickstart_installation.md
+++ b/_includes/manuals/3.5/2.1_quickstart_installation.md
@@ -24,10 +24,8 @@ function update_quickstart_os(select) {
 To provide specific installation instructions, please select your operating system:
 <select onChange="update_quickstart_os(this);">
   <option value="none">-- select operating system --</option>
-  <option value="el8">CentOS 8</option>
-  <option value="el8">CentOS 8 Stream</option>
+  <option value="el8">Enterprise Linux 8</option>
   <option value="debian11">Debian 11 (Bullseye)</option>
-  <option value="rhel8">Red Hat Enterprise Linux 8</option>
   <option value="ubuntu2004">Ubuntu 20.04 (Focal)</option>
 </select>
 
@@ -37,7 +35,7 @@ To provide specific installation instructions, please select your operating syst
   <i>No operating system selected.</i>
 </div>
 
-<div class="quickstart_os quickstart_os_rhel8 quickstart_os_el8">
+<div class="quickstart_os quickstart_os_el8">
   <p>
     Enable Puppet's 7.x repository:
   </p>
@@ -47,7 +45,7 @@ sudo dnf -y install https://yum.puppet.com/puppet7-release-el-8.noarch.rpm
 {% endhighlight %}
 </div>
 
-<div class="quickstart_os quickstart_os_rhel8 quickstart_os_el8">
+<div class="quickstart_os quickstart_os_el8">
   <p>Enable the Foreman repositories:</p>
 
 {% highlight bash %}
@@ -55,7 +53,7 @@ sudo dnf -y install https://yum.theforeman.org/releases/{{page.version}}/el8/x86
 {% endhighlight %}
 </div>
 
-<div class="quickstart_os quickstart_os_rhel8 quickstart_os_el8">
+<div class="quickstart_os quickstart_os_el8">
   <p>Enable the Foreman module:</p>
 
 {% highlight bash %}
@@ -109,7 +107,7 @@ echo "deb http://deb.theforeman.org/ plugins {{page.version}}" | sudo tee -a /et
   <i>No operating system selected.</i>
 </div>
 
-<div class="quickstart_os quickstart_os_rhel8 quickstart_os_el8">
+<div class="quickstart_os quickstart_os_el8">
 {% highlight bash %}
 sudo dnf -y install foreman-installer
 {% endhighlight %}
@@ -129,7 +127,7 @@ sudo apt-get update && sudo apt-get -y install foreman-installer
 
 The installation run is non-interactive, but the configuration can be customized by supplying any of the options listed in `foreman-installer --help`, or by running `foreman-installer -i` for interactive mode.  More examples are given in the [Installation Options](/manuals/{{page.version}}/index.html#3.2.2InstallerOptions) section.  Adding `-v` will disable the progress bar and display all changes.  To run the installer, execute:
 
-<div class="quickstart_os quickstart_os_none quickstart_os_debian11 quickstart_os_ubuntu2004 quickstart_os_el8 quickstart_os_rhel8">
+<div class="quickstart_os quickstart_os_none quickstart_os_debian11 quickstart_os_ubuntu2004 quickstart_os_el8">
 {% highlight bash %}
 sudo foreman-installer
 {% endhighlight %}

--- a/_includes/manuals/3.5/2_quickstart_guide.md
+++ b/_includes/manuals/3.5/2_quickstart_guide.md
@@ -3,19 +3,14 @@ The Foreman installer is a collection of Puppet modules that installs everything
 
 Components include the Foreman web UI, Smart Proxy, a Puppet server, and optionally TFTP, DNS and DHCP servers. It is configurable and the Puppet modules can be read or run in "no-op" mode to see what changes it will make.
 
+The installation will require 4GB of memory, see [System Requirements](manuals/{{page.version}}/index.html#3.1SystemRequirements) for more information.
+
 #### Supported platforms
-* CentOS 8 x86_64
-* CentOS 8 Stream x86_64
+
+* Enterprise Linux 8, x86_64
 * Debian 11 (Bullseye), amd64
-* Red Hat Enterprise Linux 8, x86_64
 * Ubuntu 20.04 (Focal), amd64
 
-#### Untested platforms (packages may not work on these)
+#### Enterprise Linux
 
-These platforms are not tested by automatic installations. They are generally close to supported platforms so the packages may work, but additional work may be needed. For any queries for these platforms raise a question in [discourse support section](https://community.theforeman.org/c/support/10)
-
-  * Scientific Linux and Oracle Linux, x86_64
-
-Other operating systems will need to use alternative installation methods (see the manual).
-
-The installation will require 4GB of memory, see [System Requirements](manuals/{{page.version}}/index.html#3.1SystemRequirements) for more information.
+The Foreman packages and installer are tested on AlmaLinux 8 and CentOS 8 Stream, but other RHEL derivatives can work because they're similar. Sometimes additional work may be needed. For any queries for these platforms raise a question in [discourse support section](https://community.theforeman.org/c/support/10)

--- a/_includes/manuals/3.5/3.1.1_supported_platforms.md
+++ b/_includes/manuals/3.5/3.1.1_supported_platforms.md
@@ -3,8 +3,6 @@ The following operating systems are supported by the installer, have packages an
 * Red Hat Enterprise Linux 8
   * Architectures: x86_64 only
   * Apply all SELinux-related errata.
-* CentOS 8
-  * Architectures: x86_64 only
 * CentOS 8 Stream
   * Architectures: x86_64 only
   * **Note:**
@@ -25,7 +23,7 @@ Other operating systems will need to use alternative installation methods, such 
 
 The following operating systems are known to install successfully from Foreman:
 
-* RHEL and derivatives (CentOS, Scientific Linux, Oracle Linux) 3+
+* Enterprise Linux (RHEL, AlmaLinux, CentOS, Oracle Linux, Rocky Linux)
 * Fedora
 * Ubuntu
 * Debian

--- a/_includes/manuals/nightly/2.1_quickstart_installation.md
+++ b/_includes/manuals/nightly/2.1_quickstart_installation.md
@@ -24,10 +24,8 @@ function update_quickstart_os(select) {
 To provide specific installation instructions, please select your operating system:
 <select onChange="update_quickstart_os(this);">
   <option value="none">-- select operating system --</option>
-  <option value="el8">CentOS 8</option>
-  <option value="el8">CentOS 8 Stream</option>
+  <option value="el8">Enterprise Linux 8</option>
   <option value="debian11">Debian 11 (Bullseye)</option>
-  <option value="rhel8">Red Hat Enterprise Linux 8</option>
   <option value="ubuntu2004">Ubuntu 20.04 (Focal)</option>
 </select>
 
@@ -37,7 +35,7 @@ To provide specific installation instructions, please select your operating syst
   <i>No operating system selected.</i>
 </div>
 
-<div class="quickstart_os quickstart_os_rhel8 quickstart_os_el8">
+<div class="quickstart_os quickstart_os_el8">
   <p>
     Enable Puppet's 7.x repository:
   </p>
@@ -47,7 +45,7 @@ sudo dnf -y install https://yum.puppet.com/puppet7-release-el-8.noarch.rpm
 {% endhighlight %}
 </div>
 
-<div class="quickstart_os quickstart_os_rhel8 quickstart_os_el8">
+<div class="quickstart_os quickstart_os_el8">
   <p>Enable the Foreman repositories:</p>
 
 {% highlight bash %}
@@ -55,7 +53,7 @@ sudo dnf -y install https://yum.theforeman.org/releases/{{page.version}}/el8/x86
 {% endhighlight %}
 </div>
 
-<div class="quickstart_os quickstart_os_rhel8 quickstart_os_el8">
+<div class="quickstart_os quickstart_os_el8">
   <p>Enable the Foreman module:</p>
 
 {% highlight bash %}
@@ -109,7 +107,7 @@ echo "deb http://deb.theforeman.org/ plugins {{page.version}}" | sudo tee -a /et
   <i>No operating system selected.</i>
 </div>
 
-<div class="quickstart_os quickstart_os_rhel8 quickstart_os_el8">
+<div class="quickstart_os quickstart_os_el8">
 {% highlight bash %}
 sudo dnf -y install foreman-installer
 {% endhighlight %}
@@ -129,7 +127,7 @@ sudo apt-get update && sudo apt-get -y install foreman-installer
 
 The installation run is non-interactive, but the configuration can be customized by supplying any of the options listed in `foreman-installer --help`, or by running `foreman-installer -i` for interactive mode.  More examples are given in the [Installation Options](/manuals/{{page.version}}/index.html#3.2.2InstallerOptions) section.  Adding `-v` will disable the progress bar and display all changes.  To run the installer, execute:
 
-<div class="quickstart_os quickstart_os_none quickstart_os_debian11 quickstart_os_ubuntu2004 quickstart_os_el8 quickstart_os_rhel8">
+<div class="quickstart_os quickstart_os_none quickstart_os_debian11 quickstart_os_ubuntu2004 quickstart_os_el8">
 {% highlight bash %}
 sudo foreman-installer
 {% endhighlight %}

--- a/_includes/manuals/nightly/2_quickstart_guide.md
+++ b/_includes/manuals/nightly/2_quickstart_guide.md
@@ -3,19 +3,14 @@ The Foreman installer is a collection of Puppet modules that installs everything
 
 Components include the Foreman web UI, Smart Proxy, a Puppet server, and optionally TFTP, DNS and DHCP servers. It is configurable and the Puppet modules can be read or run in "no-op" mode to see what changes it will make.
 
+The installation will require 4GB of memory, see [System Requirements](manuals/{{page.version}}/index.html#3.1SystemRequirements) for more information.
+
 #### Supported platforms
-* CentOS 8 x86_64
-* CentOS 8 Stream x86_64
+
+* Enterprise Linux 8, x86_64
 * Debian 11 (Bullseye), amd64
-* Red Hat Enterprise Linux 8, x86_64
 * Ubuntu 20.04 (Focal), amd64
 
-#### Untested platforms (packages may not work on these)
+#### Enterprise Linux
 
-These platforms are not tested by automatic installations. They are generally close to supported platforms so the packages may work, but additional work may be needed. For any queries for these platforms raise a question in [discourse support section](https://community.theforeman.org/c/support/10)
-
-  * Scientific Linux and Oracle Linux, x86_64
-
-Other operating systems will need to use alternative installation methods (see the manual).
-
-The installation will require 4GB of memory, see [System Requirements](manuals/{{page.version}}/index.html#3.1SystemRequirements) for more information.
+The Foreman packages and installer are tested on AlmaLinux 8 and CentOS 8 Stream, but other RHEL derivatives can work because they're similar. Sometimes additional work may be needed. For any queries for these platforms raise a question in [discourse support section](https://community.theforeman.org/c/support/10)

--- a/_includes/manuals/nightly/3.1.1_supported_platforms.md
+++ b/_includes/manuals/nightly/3.1.1_supported_platforms.md
@@ -3,8 +3,6 @@ The following operating systems are supported by the installer, have packages an
 * Red Hat Enterprise Linux 8
   * Architectures: x86_64 only
   * Apply all SELinux-related errata.
-* CentOS 8
-  * Architectures: x86_64 only
 * CentOS 8 Stream
   * Architectures: x86_64 only
   * **Note:**
@@ -25,7 +23,7 @@ Other operating systems will need to use alternative installation methods, such 
 
 The following operating systems are known to install successfully from Foreman:
 
-* RHEL and derivatives (CentOS, Scientific Linux, Oracle Linux) 3+
+* Enterprise Linux (RHEL, AlmaLinux, CentOS, Oracle Linux, Rocky Linux)
 * Fedora
 * Ubuntu
 * Debian


### PR DESCRIPTION
Scientific Linux never released version 8 so it can be dropped starting Foreman 3.4. It also generalizes the descriptions and mentions AlmaLinux which is used in our pipelines. CentOS Linux 8 is EOL and can be removed.

If this is approved I'll also apply the changes to 3.4 & 3.5.