### PR TITLE
fix syntax highlighting

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1048,33 +1048,6 @@ fieldset[disabled] .btn-primary.active {
 	width: auto !important;
 }
 
-pre {
-  font-size: 14px;
-  padding: 10px;
-  display: inline-block;
-  position: relative;
-  font-family: FreeMono,monospace;
-  color: white;
-  background-color: #2f2f2f;
-  line-height: 14px;
-  height: auto;
-  max-width: 850px;
-}
-
-pre code {
-  background-color: #2f2f2f;
-}
-
-pre.highlight {
-  background-color: #2f2f2f;
-}
-
-code {
-  color: #000;
-	background-color: white;
-	font-size: 14px;
-}
-
 .alert {
 	padding: 10px;
 	margin-bottom: 10px;

--- a/static/css/syntax.css
+++ b/static/css/syntax.css
@@ -1,58 +1,59 @@
-.highlight  { background: #ffffff; }
+.highlight .hll { background-color: #ffffcc }
 .highlight .c { color: #999988; font-style: italic } /* Comment */
 .highlight .err { color: #a61717; background-color: #e3d2d2 } /* Error */
-.highlight .k { color: #195f91; } /* Keyword */
-.highlight .o { color: #93a1a1; } /* Operator */
+.highlight .k { color: #000000; font-weight: bold } /* Keyword */
+.highlight .o { color: #000000; font-weight: bold } /* Operator */
 .highlight .cm { color: #999988; font-style: italic } /* Comment.Multiline */
-.highlight .cp { color: #999999; font-weight: bold } /* Comment.Preproc */
+.highlight .cp { color: #999999; font-weight: bold; font-style: italic } /* Comment.Preproc */
 .highlight .c1 { color: #999988; font-style: italic } /* Comment.Single */
 .highlight .cs { color: #999999; font-weight: bold; font-style: italic } /* Comment.Special */
 .highlight .gd { color: #000000; background-color: #ffdddd } /* Generic.Deleted */
-.highlight .gd .x { color: #000000; background-color: #ffaaaa } /* Generic.Deleted.Specific */
-.highlight .ge { font-style: italic } /* Generic.Emph */
+.highlight .ge { color: #000000; font-style: italic } /* Generic.Emph */
 .highlight .gr { color: #aa0000 } /* Generic.Error */
 .highlight .gh { color: #999999 } /* Generic.Heading */
 .highlight .gi { color: #000000; background-color: #ddffdd } /* Generic.Inserted */
-.highlight .gi .x { color: #000000; background-color: #aaffaa } /* Generic.Inserted.Specific */
 .highlight .go { color: #888888 } /* Generic.Output */
 .highlight .gp { color: #555555 } /* Generic.Prompt */
 .highlight .gs { font-weight: bold } /* Generic.Strong */
 .highlight .gu { color: #aaaaaa } /* Generic.Subheading */
 .highlight .gt { color: #aa0000 } /* Generic.Traceback */
-.highlight .kc { font-weight: bold } /* Keyword.Constant */
-.highlight .kd { font-weight: bold } /* Keyword.Declaration */
-.highlight .kp { } /* Keyword.Pseudo */
-.highlight .kr { font-weight: bold } /* Keyword.Reserved */
+.highlight .kc { color: #000000; font-weight: bold } /* Keyword.Constant */
+.highlight .kd { color: #000000; font-weight: bold } /* Keyword.Declaration */
+.highlight .kn { color: #000000; font-weight: bold } /* Keyword.Namespace */
+.highlight .kp { color: #000000; font-weight: bold } /* Keyword.Pseudo */
+.highlight .kr { color: #000000; font-weight: bold } /* Keyword.Reserved */
 .highlight .kt { color: #445588; font-weight: bold } /* Keyword.Type */
 .highlight .m { color: #009999 } /* Literal.Number */
-.highlight .s { color: rgba(35, 255, 247, 1) } /* Literal.String */
+.highlight .s { color: #d01040 } /* Literal.String */
 .highlight .na { color: #008080 } /* Name.Attribute */
-.highlight .nb { color: #71FF3D } /* Name.Builtin */
-.highlight .nc { color: #CB4B16 } /* Name.Class */
-.highlight .no { color: #FF8F63 } /* Name.Constant */
+.highlight .nb { color: #0086B3 } /* Name.Builtin */
+.highlight .nc { color: #445588; font-weight: bold } /* Name.Class */
+.highlight .no { color: #008080 } /* Name.Constant */
+.highlight .nd { color: #3c5d5d; font-weight: bold } /* Name.Decorator */
 .highlight .ni { color: #800080 } /* Name.Entity */
 .highlight .ne { color: #990000; font-weight: bold } /* Name.Exception */
-.highlight .nf { color: #444444 } /* Name.Function */
+.highlight .nf { color: #990000; font-weight: bold } /* Name.Function */
+.highlight .nl { color: #990000; font-weight: bold } /* Name.Label */
 .highlight .nn { color: #555555 } /* Name.Namespace */
-.highlight .nt { color: #C6A4FF } /* Name.Tag */
+.highlight .nt { color: #000080 } /* Name.Tag */
 .highlight .nv { color: #008080 } /* Name.Variable */
-.highlight .ow { font-weight: bold } /* Operator.Word */
+.highlight .ow { color: #000000; font-weight: bold } /* Operator.Word */
 .highlight .w { color: #bbbbbb } /* Text.Whitespace */
 .highlight .mf { color: #009999 } /* Literal.Number.Float */
 .highlight .mh { color: #009999 } /* Literal.Number.Hex */
 .highlight .mi { color: #009999 } /* Literal.Number.Integer */
 .highlight .mo { color: #009999 } /* Literal.Number.Oct */
-.highlight .sb { color: #d14 } /* Literal.String.Backtick */
-.highlight .sc { color: #d14 } /* Literal.String.Char */
-.highlight .sd { color: #d14 } /* Literal.String.Doc */
-.highlight .s2 { color: rgba(104, 180, 255, 1) } /* Literal.String.Double */
-.highlight .se { color: #FB6389 } /* Literal.String.Escape */
-.highlight .sh { color: #d14 } /* Literal.String.Heredoc */
-.highlight .si { color: #d14 } /* Literal.String.Interpol */
-.highlight .sx { color: #d14 } /* Literal.String.Other */
+.highlight .sb { color: #d01040 } /* Literal.String.Backtick */
+.highlight .sc { color: #d01040 } /* Literal.String.Char */
+.highlight .sd { color: #d01040 } /* Literal.String.Doc */
+.highlight .s2 { color: #d01040 } /* Literal.String.Double */
+.highlight .se { color: #d01040 } /* Literal.String.Escape */
+.highlight .sh { color: #d01040 } /* Literal.String.Heredoc */
+.highlight .si { color: #d01040 } /* Literal.String.Interpol */
+.highlight .sx { color: #d01040 } /* Literal.String.Other */
 .highlight .sr { color: #009926 } /* Literal.String.Regex */
-.highlight .s1 { color: #268bd2 } /* Literal.String.Single */
-.highlight .ss { color: rgba(255, 244, 22, 1) } /* Literal.String.Symbol */
+.highlight .s1 { color: #d01040 } /* Literal.String.Single */
+.highlight .ss { color: #990073 } /* Literal.String.Symbol */
 .highlight .bp { color: #999999 } /* Name.Builtin.Pseudo */
 .highlight .vc { color: #008080 } /* Name.Variable.Class */
 .highlight .vg { color: #008080 } /* Name.Variable.Global */


### PR DESCRIPTION
before:
* a yaml code block in the blog: 
  ![Screenshot from 2023-03-21 09-39-36](https://user-images.githubusercontent.com/94284/226556196-a46e3e91-707e-4e9b-83f7-4a2c32640bb1.png)
* a few inline `<code>` items in the plugins install guide:
  ![Screenshot from 2023-03-21 09-46-15](https://user-images.githubusercontent.com/94284/226556210-0a304665-a004-4816-a5dc-c5d38b0dfc66.png)

after:
* a yaml code block in the blog: 
![Screenshot from 2023-03-21 09-39-49](https://user-images.githubusercontent.com/94284/226556238-2426a7b0-d92a-4a00-a9b0-f2bd4a1ec449.png)
* a few inline `<code>` items in the plugins install guide:
![Screenshot from 2023-03-21 09-46-25](https://user-images.githubusercontent.com/94284/226556252-a3157767-9020-46cd-b011-428738cf1024.png)