### PR TITLE
Update release notes for Foreman 3.5.3

### DIFF
--- a/_includes/manuals/3.5/1.2_release_notes.md
+++ b/_includes/manuals/3.5/1.2_release_notes.md
@@ -59,6 +59,24 @@ It is safe to remove the file or remove all content.
   This data used to be part of Foreman, but was extracted to a plugin in Foreman 2.3.
   Until now this data was kept in the database, but now this data will be purged unless the plugin is installed.
 
+### Release notes for 3.5.3
+#### Foreman - Unattended Installations
+* preseed_netplan_generic_interface with DHCP interface - ([#35578](https://projects.theforeman.org/issues/35578))
+
+#### Foreman - API
+* Parameter 'search' on fact_value API endpoint results in internal server error ([#35990](https://projects.theforeman.org/issues/35990))
+
+#### Foreman - Inventory
+* Host Detail button landed to old Host UI page ([#36225](https://projects.theforeman.org/issues/36225))
+
+#### Foreman - PuppetCA
+* "change Puppet Master" option does not work ([#35949](https://projects.theforeman.org/issues/35949))
+
+#### Smart Proxy - TFTP
+* tftp initrd/vmlinux generation: curl malformed ([#36209](https://projects.theforeman.org/issues/36209))
+
+*A full list of changes in 3.5.3 is available via [Redmine](https://projects.theforeman.org/issues?set_filter=1&sort=id%3Adesc&status_id=closed&f[]=cf_12&op[cf_12]=%3D&v[cf_12]=1696)*
+
 ### Release notes for 3.5.2
 #### Foreman - API
 * Fixes API documentation typo ([#35648](https://projects.theforeman.org/issues/35648))


### PR DESCRIPTION
I didn't append anything to hammer because the release is back to 3.5.1 -- should I have? I didn't see any hammer-related notes to base it off of in the 3.5 changelog.