### PR TITLE
the quickstart for 3.6 should be 3.6, not nightly

### DIFF
--- a/manuals/3.6/quickstart_guide.md
+++ b/manuals/3.6/quickstart_guide.md
@@ -1,7 +1,7 @@
 ---
 layout: quickstart
 title: Foreman Quickstart Guide
-version: "nightly"
+version: "3.6"
 ---
 
 # Quickstart Guide


### PR DESCRIPTION
Fixes: 0371ce0cdf7d37d98afa430b748a548a41625a40