### PR TITLE
Use Foreman Documentation for REX plugin

### DIFF
--- a/plugins/foreman_remote_execution/10.0/index.md
+++ b/plugins/foreman_remote_execution/10.0/index.md
@@ -1,0 +1,39 @@
+---
+layout: plugin
+title: Foreman Remote Execution 10.0 Manual
+version: 10.0
+# uncomment for older versions than stable or nightly
+robots: noindex
+---
+
+# 1. {{ page.title }}
+
+If you want to use remote execution (REX) on Foreman, have a look at [Configuring and Setting Up Remote Jobs](https://docs.theforeman.org/{{ page.version }}/Managing_Hosts/index-katello.html#Configuring_and_Setting_Up_Remote_Jobs_managing-hosts) on _docs.theforeman.org_.
+
+# 2. Help
+
+Please follow our [standard procedures and contacts]({{site.baseurl}}support.html).
+
+# 3. Getting involved
+
+## 3.1 Troubleshooting
+
+If you find a bug, please file it in
+[Redmine](http://projects.theforeman.org/projects/foreman_remote_execution/issues/new).
+
+See the [troubleshooting section](/manuals/latest/index.html#7.2GettingHelp)
+in the Foreman manual for more info.
+
+
+## 3.2 Contributing
+
+Follow the [same process as Foreman](/contribute.html#SubmitPatches)
+for contributing.
+
+# 4. Links
+
+* foreman_remote_execution plugin [https://github.com/theforeman/foreman_remote_execution](https://github.com/theforeman/foreman_remote_execution)
+* foreman-tasks plugin [https://github.com/theforeman/foreman-tasks](https://github.com/theforeman/foreman-tasks)
+* smart_proxy_remote_execution_ssh [https://github.com/theforeman/smart_proxy_remote_execution_ssh](https://github.com/theforeman/smart_proxy_remote_execution_ssh)
+* smart_proxy_dynflow [https://github.com/theforeman/smart_proxy_dynflow](https://github.com/theforeman/smart_proxy_dynflow)
+* issue tracker [http://projects.theforeman.org/projects/foreman_remote_execution](http://projects.theforeman.org/projects/foreman_remote_execution)

--- a/plugins/foreman_remote_execution/index.md
+++ b/plugins/foreman_remote_execution/index.md
@@ -1,7 +1,7 @@
 ---
 layout: plugin_index
 title: Foreman Remote Execution Documentation
-versions: [1.7, 1.3, 0.3, 0.2, 0.1, 0.0]
+versions: [10.0, 1.7, 1.3, 0.3, 0.2, 0.1, 0.0]
 ---
 
 # Foreman Remote Execution manuals


### PR DESCRIPTION
Users have complained that we still mention `--enable-foreman-proxy-plugin-remote-execution-ssh` instead of `--enable-foreman-proxy-plugin-remote-execution-script` in Foreman Manual. This PR removes the content and instead refers users to docs.theforeman.org.

It was wrong since Foreman 3.3.

Does it make sense to version the REX plugin at all? Or should I only make changes to "nightly"?

Please also note that I did not check every line myself; but for reference, the last contribute was from lzap in 2019; before that, the last correction was by Ewoud in 2019 as well.

See https://github.com/theforeman/foreman-documentation/pull/1301 & https://community.theforeman.org/t/foreman-remote-execution-plugin-documentation/28889