### PR TITLE
Refs #36573 - Drop puppet-server-foreman-url parameter

### DIFF
--- a/_includes/manuals/3.8/3.2.3_installation_scenarios.md
+++ b/_includes/manuals/3.8/3.2.3_installation_scenarios.md
@@ -63,7 +63,6 @@ foreman-installer \
   --no-enable-foreman-cli-puppet \
   --enable-puppet \
   --puppet-server-ca=false \
-  --puppet-server-foreman-url=https://foreman.example.com \
   --enable-foreman-proxy \
   --foreman-proxy-puppetca=false \
   --foreman-proxy-foreman-base-url=https://foreman.example.com \

--- a/_includes/manuals/nightly/3.2.3_installation_scenarios.md
+++ b/_includes/manuals/nightly/3.2.3_installation_scenarios.md
@@ -63,7 +63,6 @@ foreman-installer \
   --no-enable-foreman-cli-puppet \
   --enable-puppet \
   --puppet-server-ca=false \
-  --puppet-server-foreman-url=https://foreman.example.com \
   --enable-foreman-proxy \
   --foreman-proxy-puppetca=false \
   --foreman-proxy-foreman-base-url=https://foreman.example.com \


### PR DESCRIPTION
Since Foreman 3.8 this defaults to the value specified in `--foreman-proxy-foreman-base-url`.