### PR TITLE
Update Puppet compatibility matrix

### DIFF
--- a/_includes/manuals/3.0/3.1.3_puppet_versions.md
+++ b/_includes/manuals/3.0/3.1.3_puppet_versions.md
@@ -21,12 +21,12 @@ Foreman integrates with Puppet and Facter in a few places, but generally using a
   </tr>
   <tr>
     <td>5.x</td>
-    <td>Supported</td>
+    <td>Not supported</td>
     <td>Untested</td>
-    <td>Supported</td>
+    <td>Deprecated</td>
   </tr>
   <tr>
-    <td>6.x</td>
+    <td>6.x - 7.x</td>
     <td>Supported</td>
     <td>Untested</td>
     <td>Supported</td>

--- a/_includes/manuals/3.1/3.1.3_puppet_versions.md
+++ b/_includes/manuals/3.1/3.1.3_puppet_versions.md
@@ -21,12 +21,12 @@ Foreman integrates with Puppet and Facter in a few places, but generally using a
   </tr>
   <tr>
     <td>5.x</td>
-    <td>Supported</td>
+    <td>Not supported</td>
     <td>Untested</td>
-    <td>Supported</td>
+    <td>Deprecated</td>
   </tr>
   <tr>
-    <td>6.x</td>
+    <td>6.x - 7.x</td>
     <td>Supported</td>
     <td>Untested</td>
     <td>Supported</td>

--- a/_includes/manuals/3.2/3.1.3_puppet_versions.md
+++ b/_includes/manuals/3.2/3.1.3_puppet_versions.md
@@ -21,12 +21,12 @@ Foreman integrates with Puppet and Facter in a few places, but generally using a
   </tr>
   <tr>
     <td>5.x</td>
-    <td>Supported</td>
+    <td>Not supported</td>
     <td>Untested</td>
-    <td>Supported</td>
+    <td>Deprecated</td>
   </tr>
   <tr>
-    <td>6.x</td>
+    <td>6.x - 7.x</td>
     <td>Supported</td>
     <td>Untested</td>
     <td>Supported</td>

--- a/_includes/manuals/3.6/3.1.3_puppet_versions.md
+++ b/_includes/manuals/3.6/3.1.3_puppet_versions.md
@@ -26,7 +26,13 @@ Foreman integrates with Puppet and Facter in a few places, but generally using a
     <td>Deprecated</td>
   </tr>
   <tr>
-    <td>6.x - 7.x</td>
+    <td>6.x</td>
+    <td>Deprecated</td>
+    <td>Untested</td>
+    <td>Deprecated</td>
+  </tr>
+  <tr>
+    <td>7.x</td>
     <td>Supported</td>
     <td>Untested</td>
     <td>Supported</td>

--- a/_includes/manuals/3.7/3.1.1_supported_platforms.md
+++ b/_includes/manuals/3.7/3.1.1_supported_platforms.md
@@ -17,7 +17,7 @@ PostgreSQL version 10 or newer.
 
 It is recommended to apply all OS updates if possible.
 
-All platforms will require Puppet 6 or higher, which may be installed from Puppet's repositories.
+All platforms will require Puppet 7 or higher, which may be installed from Puppet's repositories.
 
 Other operating systems will need to use alternative installation methods, such as from source.
 

--- a/_includes/manuals/3.7/3.1.3_puppet_versions.md
+++ b/_includes/manuals/3.7/3.1.3_puppet_versions.md
@@ -20,13 +20,13 @@ Foreman integrates with Puppet and Facter in a few places, but generally using a
     <td>Deprecated</td>
   </tr>
   <tr>
-    <td>5.x</td>
+    <td>5.x - 6.x</td>
     <td>Not supported</td>
     <td>Not supported</td>
     <td>Deprecated</td>
   </tr>
   <tr>
-    <td>6.x - 7.x</td>
+    <td>7.x</td>
     <td>Supported</td>
     <td>Untested</td>
     <td>Supported</td>

--- a/_includes/manuals/3.8/3.1.1_supported_platforms.md
+++ b/_includes/manuals/3.8/3.1.1_supported_platforms.md
@@ -17,7 +17,7 @@ PostgreSQL version 10 or newer.
 
 It is recommended to apply all OS updates if possible.
 
-All platforms will require Puppet 6 or higher, which may be installed from Puppet's repositories.
+All platforms will require Puppet 7 or higher, which may be installed from Puppet's repositories.
 
 Other operating systems will need to use alternative installation methods, such as from source.
 


### PR DESCRIPTION
The Puppet compatibility matrix has not been updated regularly and is currently outdated, stating that Puppet 6 is still supported in Foreman 3.7.

Updated the matrix and relevant text passages found according to what was in the changelog since Foreman 3.0