### PR TITLE
Update Puppet Smart-Proxy compatibility

### DIFF
--- a/_includes/manuals/3.4/3.1.3_puppet_versions.md
+++ b/_includes/manuals/3.4/3.1.3_puppet_versions.md
@@ -8,22 +8,10 @@ Foreman integrates with Puppet and Facter in a few places, but generally using a
     <th>Smart Proxy</th>
   </tr>
   <tr>
-    <td>0.x-4.3</td>
+    <td>0.x-5.x</td>
     <td>Not supported</td>
     <td>Not supported</td>
     <td>Not supported</td>
-  </tr>
-  <tr>
-    <td>4.4-4.10</td>
-    <td>Not supported</td>
-    <td>Not supported</td>
-    <td>Deprecated</td>
-  </tr>
-  <tr>
-    <td>5.x</td>
-    <td>Not supported</td>
-    <td>Not supported</td>
-    <td>Deprecated</td>
   </tr>
   <tr>
     <td>6.x - 7.x</td>

--- a/_includes/manuals/3.5/3.1.3_puppet_versions.md
+++ b/_includes/manuals/3.5/3.1.3_puppet_versions.md
@@ -8,22 +8,10 @@ Foreman integrates with Puppet and Facter in a few places, but generally using a
     <th>Smart Proxy</th>
   </tr>
   <tr>
-    <td>0.x-4.3</td>
+    <td>0.x-5.x</td>
     <td>Not supported</td>
     <td>Not supported</td>
     <td>Not supported</td>
-  </tr>
-  <tr>
-    <td>4.4-4.10</td>
-    <td>Not supported</td>
-    <td>Not supported</td>
-    <td>Deprecated</td>
-  </tr>
-  <tr>
-    <td>5.x</td>
-    <td>Not supported</td>
-    <td>Not supported</td>
-    <td>Deprecated</td>
   </tr>
   <tr>
     <td>6.x - 7.x</td>

--- a/_includes/manuals/3.6/3.1.3_puppet_versions.md
+++ b/_includes/manuals/3.6/3.1.3_puppet_versions.md
@@ -8,22 +8,10 @@ Foreman integrates with Puppet and Facter in a few places, but generally using a
     <th>Smart Proxy</th>
   </tr>
   <tr>
-    <td>0.x-4.3</td>
+    <td>0.x-5.x</td>
     <td>Not supported</td>
     <td>Not supported</td>
     <td>Not supported</td>
-  </tr>
-  <tr>
-    <td>4.4-4.10</td>
-    <td>Not supported</td>
-    <td>Not supported</td>
-    <td>Deprecated</td>
-  </tr>
-  <tr>
-    <td>5.x</td>
-    <td>Not supported</td>
-    <td>Not supported</td>
-    <td>Deprecated</td>
   </tr>
   <tr>
     <td>6.x</td>

--- a/_includes/manuals/3.7/3.1.3_puppet_versions.md
+++ b/_includes/manuals/3.7/3.1.3_puppet_versions.md
@@ -8,19 +8,13 @@ Foreman integrates with Puppet and Facter in a few places, but generally using a
     <th>Smart Proxy</th>
   </tr>
   <tr>
-    <td>0.x-4.3</td>
+    <td>0.x-5.x</td>
     <td>Not supported</td>
     <td>Not supported</td>
     <td>Not supported</td>
   </tr>
   <tr>
-    <td>4.4-4.10</td>
-    <td>Not supported</td>
-    <td>Not supported</td>
-    <td>Deprecated</td>
-  </tr>
-  <tr>
-    <td>5.x - 6.x</td>
+    <td>6.x</td>
     <td>Not supported</td>
     <td>Not supported</td>
     <td>Deprecated</td>

--- a/_includes/manuals/3.8/3.1.3_puppet_versions.md
+++ b/_includes/manuals/3.8/3.1.3_puppet_versions.md
@@ -8,25 +8,19 @@ Foreman integrates with Puppet and Facter in a few places, but generally using a
     <th>Smart Proxy</th>
   </tr>
   <tr>
-    <td>0.x-4.3</td>
+    <td>0.x-5.x</td>
     <td>Not supported</td>
     <td>Not supported</td>
     <td>Not supported</td>
   </tr>
   <tr>
-    <td>4.4-4.10</td>
+    <td>6.x</td>
     <td>Not supported</td>
     <td>Not supported</td>
     <td>Deprecated</td>
   </tr>
   <tr>
-    <td>5.x</td>
-    <td>Not supported</td>
-    <td>Not supported</td>
-    <td>Deprecated</td>
-  </tr>
-  <tr>
-    <td>6.x - 7.x</td>
+    <td>7.x</td>
     <td>Supported</td>
     <td>Untested</td>
     <td>Supported</td>

--- a/_includes/manuals/nightly/3.1.3_puppet_versions.md
+++ b/_includes/manuals/nightly/3.1.3_puppet_versions.md
@@ -8,25 +8,19 @@ Foreman integrates with Puppet and Facter in a few places, but generally using a
     <th>Smart Proxy</th>
   </tr>
   <tr>
-    <td>0.x-4.3</td>
+    <td>0.x-5.x</td>
     <td>Not supported</td>
     <td>Not supported</td>
     <td>Not supported</td>
   </tr>
   <tr>
-    <td>4.4-4.10</td>
+    <td>6.x</td>
     <td>Not supported</td>
     <td>Not supported</td>
     <td>Deprecated</td>
   </tr>
   <tr>
-    <td>5.x</td>
-    <td>Not supported</td>
-    <td>Not supported</td>
-    <td>Deprecated</td>
-  </tr>
-  <tr>
-    <td>6.x - 7.x</td>
+    <td>7.x</td>
     <td>Supported</td>
     <td>Untested</td>
     <td>Supported</td>


### PR DESCRIPTION
Smart-Proxy compatibility changed in Foreman 3.4 to only support Puppet>=6.
I also copied #2103 to the docs for 3.8 and nightly, which were missing in the original PR.