### PR TITLE
Update Puppet compatibility matrix

### DIFF
--- a/_includes/manuals/3.4/3.1.3_puppet_versions.md
+++ b/_includes/manuals/3.4/3.1.3_puppet_versions.md
@@ -8,25 +8,13 @@ Foreman integrates with Puppet and Facter in a few places, but generally using a
     <th>Smart Proxy</th>
   </tr>
   <tr>
-    <td>0.x-4.3</td>
+    <td>0.x-5.x</td>
     <td>Not supported</td>
     <td>Not supported</td>
     <td>Not supported</td>
   </tr>
   <tr>
-    <td>4.4-4.10</td>
-    <td>Not supported</td>
-    <td>Not supported</td>
-    <td>Deprecated</td>
-  </tr>
-  <tr>
-    <td>5.x</td>
-    <td>Not supported</td>
-    <td>Not supported</td>
-    <td>Deprecated</td>
-  </tr>
-  <tr>
-    <td>6.x - 7.x</td>
+    <td>6.x-7.x</td>
     <td>Supported</td>
     <td>Untested</td>
     <td>Supported</td>

--- a/_includes/manuals/3.5/3.1.3_puppet_versions.md
+++ b/_includes/manuals/3.5/3.1.3_puppet_versions.md
@@ -8,25 +8,13 @@ Foreman integrates with Puppet and Facter in a few places, but generally using a
     <th>Smart Proxy</th>
   </tr>
   <tr>
-    <td>0.x-4.3</td>
+    <td>0.x-5.x</td>
     <td>Not supported</td>
     <td>Not supported</td>
     <td>Not supported</td>
   </tr>
   <tr>
-    <td>4.4-4.10</td>
-    <td>Not supported</td>
-    <td>Not supported</td>
-    <td>Deprecated</td>
-  </tr>
-  <tr>
-    <td>5.x</td>
-    <td>Not supported</td>
-    <td>Not supported</td>
-    <td>Deprecated</td>
-  </tr>
-  <tr>
-    <td>6.x - 7.x</td>
+    <td>6.x-7.x</td>
     <td>Supported</td>
     <td>Untested</td>
     <td>Supported</td>

--- a/_includes/manuals/3.6/3.1.3_puppet_versions.md
+++ b/_includes/manuals/3.6/3.1.3_puppet_versions.md
@@ -8,31 +8,13 @@ Foreman integrates with Puppet and Facter in a few places, but generally using a
     <th>Smart Proxy</th>
   </tr>
   <tr>
-    <td>0.x-4.3</td>
+    <td>0.x-5.x</td>
     <td>Not supported</td>
     <td>Not supported</td>
     <td>Not supported</td>
   </tr>
   <tr>
-    <td>4.4-4.10</td>
-    <td>Not supported</td>
-    <td>Not supported</td>
-    <td>Deprecated</td>
-  </tr>
-  <tr>
-    <td>5.x</td>
-    <td>Not supported</td>
-    <td>Not supported</td>
-    <td>Deprecated</td>
-  </tr>
-  <tr>
-    <td>6.x</td>
-    <td>Deprecated</td>
-    <td>Untested</td>
-    <td>Deprecated</td>
-  </tr>
-  <tr>
-    <td>7.x</td>
+    <td>6.x-7.x</td>
     <td>Supported</td>
     <td>Untested</td>
     <td>Supported</td>

--- a/_includes/manuals/3.7/3.1.3_puppet_versions.md
+++ b/_includes/manuals/3.7/3.1.3_puppet_versions.md
@@ -8,22 +8,16 @@ Foreman integrates with Puppet and Facter in a few places, but generally using a
     <th>Smart Proxy</th>
   </tr>
   <tr>
-    <td>0.x-4.3</td>
+    <td>0.x-5.x</td>
     <td>Not supported</td>
     <td>Not supported</td>
     <td>Not supported</td>
   </tr>
   <tr>
-    <td>4.4-4.10</td>
+    <td>6.x</td>
     <td>Not supported</td>
     <td>Not supported</td>
-    <td>Deprecated</td>
-  </tr>
-  <tr>
-    <td>5.x - 6.x</td>
-    <td>Not supported</td>
-    <td>Not supported</td>
-    <td>Deprecated</td>
+    <td>Supported</td>
   </tr>
   <tr>
     <td>7.x</td>

--- a/_includes/manuals/3.8/3.1.3_puppet_versions.md
+++ b/_includes/manuals/3.8/3.1.3_puppet_versions.md
@@ -8,25 +8,19 @@ Foreman integrates with Puppet and Facter in a few places, but generally using a
     <th>Smart Proxy</th>
   </tr>
   <tr>
-    <td>0.x-4.3</td>
+    <td>0.x-5.x</td>
     <td>Not supported</td>
     <td>Not supported</td>
     <td>Not supported</td>
   </tr>
   <tr>
-    <td>4.4-4.10</td>
+    <td>6.x</td>
     <td>Not supported</td>
     <td>Not supported</td>
-    <td>Deprecated</td>
+    <td>Supported</td>
   </tr>
   <tr>
-    <td>5.x</td>
-    <td>Not supported</td>
-    <td>Not supported</td>
-    <td>Deprecated</td>
-  </tr>
-  <tr>
-    <td>6.x - 7.x</td>
+    <td>7.x</td>
     <td>Supported</td>
     <td>Untested</td>
     <td>Supported</td>

--- a/_includes/manuals/nightly/3.1.3_puppet_versions.md
+++ b/_includes/manuals/nightly/3.1.3_puppet_versions.md
@@ -8,25 +8,19 @@ Foreman integrates with Puppet and Facter in a few places, but generally using a
     <th>Smart Proxy</th>
   </tr>
   <tr>
-    <td>0.x-4.3</td>
+    <td>0.x-5.x</td>
     <td>Not supported</td>
     <td>Not supported</td>
     <td>Not supported</td>
   </tr>
   <tr>
-    <td>4.4-4.10</td>
+    <td>6.x</td>
     <td>Not supported</td>
     <td>Not supported</td>
-    <td>Deprecated</td>
+    <td>Supported</td>
   </tr>
   <tr>
-    <td>5.x</td>
-    <td>Not supported</td>
-    <td>Not supported</td>
-    <td>Deprecated</td>
-  </tr>
-  <tr>
-    <td>6.x - 7.x</td>
+    <td>7.x</td>
     <td>Supported</td>
     <td>Untested</td>
     <td>Supported</td>


### PR DESCRIPTION
Since Smart Proxy 3.4.0[1] only Puppetserver 6 & 7 are supported. Version 4.4 - 5.x have partial compatibility, but are listed as unsupported. Those are end of life anyway.

For the installer it's as follows:

| Version | Puppet | commit |
|---------|--------|--------|
| 3.9     | 7.9.0  | https://github.com/theforeman/foreman-installer/commit/08ee2b88f34ea4751cf8d34887cb9bf14d473c44 |
| 3.7     | 7.0.0  | https://github.com/theforeman/foreman-installer/commit/fe392fdf4696bf95e9ffb68626375e25f0982a9e |
| 3.4     | 6.23.0 | https://github.com/theforeman/foreman-installer/commit/4f543833adb3cf129bba49a1b6cb24700ec42005 |
| 3.1     | 6.1.0  | https://github.com/theforeman/foreman-installer/commit/cbd44c86f658d361c1304d1c0ab8fbb779c82d19 |

[1]: https://github.com/theforeman/smart-proxy/commit/6983107b997e66c4fff5b4d447b29dbc6c251d2c