### PR TITLE
Use a git mailmap to correct contributor names

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,82 @@
+Adam Cécile <acecile@letz-it.lu>
+Adam Cécile <acecile@letz-it.lu> <acecile@le-vert.net>
+Adam Růžička <aruzicka@redhat.com> <a.ruzicka@outlook.com>
+Adam Růžička <aruzicka@redhat.com> <adamruzicka@users.noreply.github.com>
+Adam Růžička <aruzicka@redhat.com> <aruzicka@redhat.com>
+Adi Abramovich <aabramov@redhat.com>
+Adi Abramovich <aabramov@redhat.com> <57755873+adiabramovitch@users.noreply.github.com>
+Alexander Olofsson <ace@haxalot.com>
+Alexander Olofsson <ace@haxalot.com> Alexander Olofsson <alexander.olofsson@liu.se>
+Amir Fefer <amirfefer@gmail.com>
+Amir Fefer <amirfefer@gmail.com> <afeferku@dhcp-4-115.tlv.redhat.com>
+Amit Karsale <akarsale@redhat.com> <karsale.amit@gmail.com>
+Amit Upadhye <upadhyeammit@gmail.com> <amitupadhye@foreman.example.com>
+Andrew Dewar <andrewgdewar@gmail.com>
+Andrew Kofink <akofink@redhat.com> <ajkofink@gmail.com>
+Archana Kumari <ak31960466@gmail.com>
+Arend Lapere <arend.lapere@gmail.com> <test@foreman-develop.televic-test.com>
+Avi Sharvit <asharvit@redhat.com> <sharvita@gmail.com>
+Bernhard Suttner <suttner@atix.de> <BernhardAtix@users.noreply.github.com>
+Bernhard Suttner <suttner@atix.de> <sbernhard@users.noreply.github.com>
+Boaz Shuster <ripcurld.github@gmail.com>
+Boaz Shuster <ripcurld.github@gmail.com> <2453279+boaz1337@users.noreply.github.com>
+Boaz Shuster <ripcurld.github@gmail.com> <boaz.shuster.github@gmail.com>
+Boaz Shuster <ripcurld.github@gmail.com> <bshuster@fedora-work.mynet>
+Boaz Shuster <ripcurld.github@gmail.com> <ripcurld.github@gmail.com>
+Daniel Lobato García <elobatocs@gmail.com>
+Daniel Lobato García <elobatocs@gmail.com> <me@daniellobato.me>
+Dirk Götz <dirk.goetz@netways.de>
+Dominik Hlavac Duran <dhlavacd@redhat.com>
+Dominik Hlavac Duran <dhlavacd@redhat.com> <xhlava42@stud.fit.vutbr.cz>
+Dominik Hlavac Duran <dhlavacd@redhat.com> <xhlava42@vutbr.cz>
+Dominik Matoulek <domitea@gmail.com> <domitea@users.noreply.github.com>
+Eric Helms <ericdhelms@gmail.com> <eric.d.helms@gmail.com>
+Eric Helms <ericdhelms@gmail.com> Eric D. Helms <ericdhelms@gmail.com>
+Girija Soni <gisoni@redhat.com>
+Ian Ballou <ianballou67@gmail.com>
+Imri Zvik <imrizvik@gmail.com>
+Ivan Nečas <inecas@redhat.com>
+Ivan Nečas <inecas@redhat.com> <necasik@gmail.com>
+Joseph Magen <jmagen@redhat.com>
+Joseph Magen <jmagen@redhat.com> <joseph@isratrade.co.il>
+Kamil Szubrycht <kamil.szubrycht@ironin.pl>
+Karolina Malyjurkova <kmalyjur@redhat.com> <78563507+kmalyjur@users.noreply.github.com>
+Leos Stejskal <lstejska@redhat.com> <github@stejskalleos.cz>
+Lukáš Zapletal <lzap@redhat.com>
+Lukáš Zapletal <lzap@redhat.com> <lukas@zapletalovi.com>
+Lukáš Zapletal <lzap@redhat.com> <lzap+git@redhat.com>
+Marcel Kühlhorn <marcelk@atix.de> <tux93@users.noreply.github.com>
+Marek Hulán <mhulan@redhat.com> <ares@igloonet.cz>
+Marek Hulán <mhulan@redhat.com> <ares@users.noreply.github.com>
+Marek Hulán <mhulan@redhat.com> <mhulan@redhat.com>
+Maria Agaphontzev <mariaaga@redhat.com>
+Maria Agaphontzev <mariaaga@redhat.com> <magaphon@localhost.localdomain>
+Maria Agaphontzev <mariaaga@redhat.com> <mariaagaphonchev@gmail.com>
+Maria Nita <maria.nita.dn@gmail.com>
+Martin Bačovský <mbacovsk@redhat.com> <martin.bacovsky@gmail.com>
+Martin Matuska <martin@matuska.org> <martin.matuska@axelspringer.de>
+Matan Werbner <mwerbner@redhat.com>
+Matan Werbner <mwerbner@redhat.com> <matan@dhcp-3-121.tlv.redhat.com>
+Matan Werbner <mwerbner@redhat.com> <matan@dhcp-3-123.tlv.redhat.com>
+Matan Werbner <mwerbner@redhat.com> <matanw@dhcp-2-138.tlv.redhat.com>
+Matan Werbner <mwerbner@redhat.com> <verbmat@gmail.com>
+Mirek Długosz <mzalewsk@redhat.com>
+Nadja Heitmann <nadjah@atix.de> <71487468+nadjaheitmann@users.noreply.github.com>
+Nofar Alfassi <nalfassi@redhat.com>
+Nofar Alfassi <nalfassi@redhat.com> <nofaralfasi@gmail.com>
+Ondřej Ezr <oezr@redhat.com>
+Ondřej Ezr <oezr@redhat.com> <ezrik12@gmail.com>
+Ondřej Pražák <oprazak@redhat.com>
+Ondřej Pražák <oprazak@redhat.com> <xprazak2@users.noreply.github.com>
+Ori Rabin <orabin@redhat.com>
+Ori Rabin <orabin@redhat.com> <orrabin@gmail.com>
+Peter Koprda <peto.koprda@gmail.com>
+Peter Koprda <petokoprda@gmail.com> <47797196+pkoprda@users.noreply.github.com>
+Peter Koprda <petokoprda@gmail.com> <petokoprda@gmail.com>
+Sean O'Keeffe <seanokeeffe797@gmail.com>
+Shimon Shtein <sshtein@redhat.com> <sshtein@redhat.com>
+Till Adam <till.adam@dm.de>
+Vijaykumar Sawant <vijaysawant36@gmail.com>
+Yifat Makias <ymakias@redhat.com> <42476762+yifatmakias@users.noreply.github.com>
+Yifat Makias <ymakias@redhat.com> <ymakias@redhat.com>
+Štefan Németh <snemeth@dynamic-2a00-1028-83a6-3cba-0eb1-2bbc-4b42-8938.ipv6.o2.cz>

--- a/scripts/committers.rb
+++ b/scripts/committers.rb
@@ -2,6 +2,8 @@
 require 'tmpdir'
 require 'git'
 
+MAILMAP = File.join(__dir__, '..', '.mailmap')
+
 @tag_from  = "3.4.0"
 @tag_to    = "3.5.0-rc1"
 @date_from = nil # derived from the tag
@@ -43,99 +45,6 @@ require 'git'
   puppetdb_foreman
 )
 
-@author_map = {
-  "aabramov"       => "Adi Abramovich",
-  "abenari"        => "Amos Benari",
-  "adamruzicka"    => "Adam Ruzicka",
-  "Alexander Fisher" => "Alex Fisher",
-  "alongoldboim"   => "Alon Goldboim",
-  "Daniel Lobato"  => "Daniel Lobato Garcia",
-  "Daniel Lobato García" => "Daniel Lobato Garcia",
-  "Dirk Goetz"     => "Dirk Götz",
-  "Eric D Helms"   => "Eric D. Helms",
-  "Eric Helms"     => "Eric D. Helms",
-  "Joseph Magen"   => "Joseph Mitchell Magen",
-  "Ivan Necas"     => "Ivan Nečas",
-  "Lukas Zapletal" => "Lukáš Zapletal",
-  "Marek Hulan"    => "Marek Hulán",
-  "mbacovsky"      => "Martin Bačovský",
-  "amirfefer"      => "Amir Fefer",
-  "Amir Feferkuchen" => "Amir Fefer",
-  "Amir"           => "Amir Fefer",
-  "imriz"          => "Imri Zvik",
-  "Sean OKeeffe"   => "Sean O'Keeffe",
-  "treydock"       => "Trey Dockendorf",
-  "orrabin"        => "Ori Rabin",
-  "Ondrej Prazak"  => "Ondřej Pražák",
-  "lfisher47"      => "Leah Fisher",
-  "pkranenburg"    => "Paul Kranenburg",
-  "alejandrocfg"   => "Alejandro Falcon",
-  "chbaldwi"       => "Chris Baldwin",
-  "dhlavac"        => "Dominik Hlavac",
-  "kgaikwad"       => "Kavita Gaikwad",
-  "lizagilman"     => "Liza Gilman",
-  "marten"         => "Marten Veldthuis",
-  "matan"          => "Matan Uberstein",
-  "matanwerbner"   => "Matan Werbner",
-  "oogs"           => "Chris Baldwin",
-  "thomasmckay"    => "Thomas McKay",
-  "Zjhuntin"       => "Zach Huntington-Meath",
-  "Adam Růžička"   => "Adam Ruzicka",
-  "Dominik Hlavac Duran" => "Dominik Hlavac",
-  "Fabien COMBERNOUS" => "Fabien Combernous",
-  "bshuster"       => "Boaz Shuster",
-  "jyejare"        => "Jitendra Yejare",
-  "ldjebran"       => "Djebran Lezzoum",
-  "UXabre"         => "Arend Lapere",
-  "ofedoren"       => "Oleh Fedorenko",
-  "swadeley"       => "Stephen Wadeley",
-  "odovzhenko"     => "Oleg Dovzhenko",
-  "Luuk"           => "Luuk Hafkamp",
-  "Alexander \"Ananace\" Olofsson" => "Alexander Olofsson",
-  "Sebastian Gräßl" =>  "Sebastian Gräßl",
-  "boaz1337" => "Boaz Shuster",
-  "kamils-iRonin" => "Kamil Szubrycht",
-  "laviro" => "Ron Lavi",
-  "Ahmet DEMIR" => "Ahmet Demir",
-  "arend.lapere@gmail.com" => "Arend Lapere",
-  "MariaAga" => "Maria Agaphontzev",
-  "Maria" => "Maria Agaphontzev",
-  "magaphon" => "Maria Agaphontzev",
-  "stefanlasiewski" => "Stephan Lasiewski",
-  "dima" => "Dima Berastau",
-  "damon" => "Damon Clinkscales",
-  "hao-yu" => "Hao Chang Yu",
-  "Rohan21Lobo" => "Rohan Arora",
-  "amard33p" => "Amardeep Kahali",
-  "ianballou" => "Ian Ballou",
-  "san7ket" => "Sanket Jagtap",
-  "sjha4" => "Samir Jha",
-  "yifatmakias" => "Yifat Makias",
-  "sthirugn" => "Sureshkumar Thirugnanasambandan",
-  "swetha" => "Swetha Seelam Lakshmi Narayanan",
-  "jkalchik" => "Jeff Kalchik",
-  "fschaer" => "Frederic Schaer",
-  "ksagarwal007" => "Kaushik Agarwal",
-  "neilfromit" => "Neil Townsend",
-  "William Bradford Clark" => "William Clark",
-  "calvingsmith" => "Calivn Smith",
-  "grizzthedj" => "Chris Smith",
-  "tomabg" => "Thomas Pietzka",
-  "Emil DRAGU" => "Emil Dragu",
-  "vsedmik" => "Vladimir Sedmik",
-  "hsahmed" => "Hesham S. Ahmed",
-  "Mirek Długosz (Mirosław Długosz-Zalewski)" => "Mirek Długosz",
-  "JaskaranNarula" => "Jaskaran Singh Narula",
-  "r.stricklin" => "R. Stricklin",
-  "brimioulle" => "Fabrice Brimioulle",
-  "nofar" => "Nofar Alfassi",
-  "nofaralfasi" => "Nofar Alfassi",
-  "kmalyjur" => "Karolina Malyjurkova",
-  "tux93" => "Marcel Kühlhorn",
-  "snemeth" => "Štefan Németh",
-  "Stejskal Leos" => "Leos Stejskal",
-}
-
 @authors={}
 
 def get_repo_committers repo, tagged = false
@@ -143,6 +52,8 @@ def get_repo_committers repo, tagged = false
   raw = []
   g = Git.clone("https://github.com/theforeman/#{repo}", repo)
   g.chdir do
+    FileUtils.cp(MAILMAP, '.mailmap') unless File.exist?('.mailmap')
+
     if tagged
       raw = `git log #{@tag_from}..#{@tag_to} --pretty="%aN" --abbrev-commit`.split("\n")
 
@@ -154,7 +65,6 @@ def get_repo_committers repo, tagged = false
     end
   end
   raw.each do |author|
-    author = @author_map.fetch(author, author)
     @authors[author] ||= Hash.new(0)
     @authors[author][repo] += 1
   end


### PR DESCRIPTION
Git can natively map names. This keeps a mailmap in this repository and copies it in the (temporarily) cloned repositories if it doesn't exist.  Then it relies on git to do the right thing.

The mailmap is not a complete translation of the existing mapping since it also contains people who haven't contributed in a long time. It also adds a few missing items.