### PR TITLE
dnf: consistenty use -y

### DIFF
--- a/_includes/manuals/2.4/3.6_upgrade.md
+++ b/_includes/manuals/2.4/3.6_upgrade.md
@@ -141,8 +141,8 @@ If you're already on 12 or don't have the PostgreSQL server installed, you can c
 systemctl stop postgresql.service
 # https://bugzilla.redhat.com/1935301
 sed -i '/^data_directory =/d' /var/lib/pgsql/data/postgresql.conf
-dnf module reset postgresql
-dnf module install postgresql:12
+dnf -y module reset postgresql
+dnf -y module install postgresql:12
 dnf install postgresql-upgrade
 postgresql-setup --upgrade
 systemctl start postgresql.service

--- a/_includes/manuals/2.5/2.1_quickstart_installation.md
+++ b/_includes/manuals/2.5/2.1_quickstart_installation.md
@@ -114,8 +114,8 @@ sudo yum -y install https://mirror.centos.org/centos/7/extras/x86_64/Packages/ce
   <p>Enable the Ruby 2.7 module:</p>
 
 {% highlight bash %}
-sudo dnf module reset ruby
-sudo dnf module enable ruby:2.7
+sudo dnf -y module reset ruby
+sudo dnf -y module enable ruby:2.7
 {% endhighlight %}
 </div>
 

--- a/_includes/manuals/2.5/3.3.1_rpm_packages.md
+++ b/_includes/manuals/2.5/3.3.1_rpm_packages.md
@@ -36,8 +36,8 @@ To enable the optional repository on a RHEL 7 system using subscription-manager,
 
 The Ruby 2.7 module is required and is not the default stream for the Ruby module in EL8, therefore it must be enabled:
 
-    dnf module reset ruby
-    dnf module enable ruby:2.7
+    dnf -y module reset ruby
+    dnf -y module enable ruby:2.7
 
 ### Pre-requisites: Puppet
 

--- a/_includes/manuals/2.5/3.6_upgrade.md
+++ b/_includes/manuals/2.5/3.6_upgrade.md
@@ -125,8 +125,8 @@ dnf clean metadata
 Enable the Ruby 2.7 module:
 
 {% highlight bash %}
-dnf module reset ruby
-dnf module enable ruby:2.7
+dnf -y module reset ruby
+dnf -y module enable ruby:2.7
 {% endhighlight %}
 
 Next upgrade all Foreman packages:

--- a/_includes/manuals/3.0/2.1_quickstart_installation.md
+++ b/_includes/manuals/3.0/2.1_quickstart_installation.md
@@ -114,8 +114,8 @@ sudo yum -y install https://mirror.centos.org/centos/7/extras/x86_64/Packages/ce
   <p>Enable the Ruby 2.7 module:</p>
 
 {% highlight bash %}
-sudo dnf module reset ruby
-sudo dnf module enable ruby:2.7
+sudo dnf -y module reset ruby
+sudo dnf -y module enable ruby:2.7
 {% endhighlight %}
 </div>
 

--- a/_includes/manuals/3.0/3.3.1_rpm_packages.md
+++ b/_includes/manuals/3.0/3.3.1_rpm_packages.md
@@ -36,8 +36,8 @@ To enable the optional repository on a RHEL 7 system using subscription-manager,
 
 The Ruby 2.7 module is required and is not the default stream for the Ruby module in EL8, therefore it must be enabled:
 
-    dnf module reset ruby
-    dnf module enable ruby:2.7
+    dnf -y module reset ruby
+    dnf -y module enable ruby:2.7
 
 ### Pre-requisites: Puppet
 

--- a/_includes/manuals/3.0/3.6_upgrade.md
+++ b/_includes/manuals/3.0/3.6_upgrade.md
@@ -131,8 +131,8 @@ dnf clean metadata
 Enable the Ruby 2.7 module:
 
 {% highlight bash %}
-dnf module reset ruby
-dnf module enable ruby:2.7
+dnf -y module reset ruby
+dnf -y module enable ruby:2.7
 {% endhighlight %}
 
 Next upgrade all Foreman packages:

--- a/_includes/manuals/3.1/2.1_quickstart_installation.md
+++ b/_includes/manuals/3.1/2.1_quickstart_installation.md
@@ -113,8 +113,8 @@ sudo yum -y install https://mirror.centos.org/centos/7/extras/x86_64/Packages/ce
   <p>Enable the Ruby 2.7 module:</p>
 
 {% highlight bash %}
-sudo dnf module reset ruby
-sudo dnf module enable ruby:2.7
+sudo dnf -y module reset ruby
+sudo dnf -y module enable ruby:2.7
 {% endhighlight %}
 </div>
 

--- a/_includes/manuals/3.1/3.3.1_rpm_packages.md
+++ b/_includes/manuals/3.1/3.3.1_rpm_packages.md
@@ -36,8 +36,8 @@ To enable the optional repository on a RHEL 7 system using subscription-manager,
 
 The Ruby 2.7 module is required and is not the default stream for the Ruby module in EL8, therefore it must be enabled:
 
-    dnf module reset ruby
-    dnf module enable ruby:2.7
+    dnf -y module reset ruby
+    dnf -y module enable ruby:2.7
 
 ### Pre-requisites: Puppet
 

--- a/_includes/manuals/3.1/3.6_upgrade.md
+++ b/_includes/manuals/3.1/3.6_upgrade.md
@@ -124,8 +124,8 @@ dnf clean metadata
 Enable the Ruby 2.7 module:
 
 {% highlight bash %}
-dnf module reset ruby
-dnf module enable ruby:2.7
+dnf -y module reset ruby
+dnf -y module enable ruby:2.7
 {% endhighlight %}
 
 Next upgrade all Foreman packages:

--- a/_includes/manuals/3.2/2.1_quickstart_installation.md
+++ b/_includes/manuals/3.2/2.1_quickstart_installation.md
@@ -112,8 +112,8 @@ sudo yum -y install https://mirror.centos.org/centos/7/extras/x86_64/Packages/ce
   <p>Enable the Ruby 2.7 module:</p>
 
 {% highlight bash %}
-sudo dnf module reset ruby
-sudo dnf module enable ruby:2.7
+sudo dnf -y module reset ruby
+sudo dnf -y module enable ruby:2.7
 {% endhighlight %}
 </div>
 

--- a/_includes/manuals/3.2/3.3.1_rpm_packages.md
+++ b/_includes/manuals/3.2/3.3.1_rpm_packages.md
@@ -36,8 +36,8 @@ To enable the optional repository on a RHEL 7 system using subscription-manager,
 
 The Ruby 2.7 module is required and is not the default stream for the Ruby module in EL8, therefore it must be enabled:
 
-    dnf module reset ruby
-    dnf module enable ruby:2.7
+    dnf -y module reset ruby
+    dnf -y module enable ruby:2.7
 
 ### Pre-requisites: Puppet
 

--- a/_includes/manuals/3.2/3.6_upgrade.md
+++ b/_includes/manuals/3.2/3.6_upgrade.md
@@ -125,8 +125,8 @@ dnf clean metadata
 Enable the Ruby 2.7 module:
 
 {% highlight bash %}
-dnf module reset ruby
-dnf module enable ruby:2.7
+dnf -y module reset ruby
+dnf -y module enable ruby:2.7
 {% endhighlight %}
 
 Next upgrade all Foreman packages:

--- a/_includes/manuals/3.3/2.1_quickstart_installation.md
+++ b/_includes/manuals/3.3/2.1_quickstart_installation.md
@@ -120,7 +120,7 @@ sudo dnf -y install https://yum.theforeman.org/releases/{{page.version}}/el8/x86
   <p>Enable the Foreman module:</p>
 
 {% highlight bash %}
-sudo dnf module enable foreman:el8
+sudo dnf -y module enable foreman:el8
 {% endhighlight %}
 </div>
 

--- a/_includes/manuals/3.3/3.3.1_rpm_packages.md
+++ b/_includes/manuals/3.3/3.3.1_rpm_packages.md
@@ -36,8 +36,8 @@ To enable the optional repository on a RHEL 7 system using subscription-manager,
 
 The Ruby 2.7 module is required and is not the default stream for the Ruby module in EL8, therefore it must be enabled:
 
-    dnf module reset ruby
-    dnf module enable ruby:2.7
+    dnf -y module reset ruby
+    dnf -y module enable ruby:2.7
 
 ### Pre-requisites: Puppet
 

--- a/_includes/manuals/3.3/3.6_upgrade.md
+++ b/_includes/manuals/3.3/3.6_upgrade.md
@@ -125,13 +125,13 @@ dnf clean metadata
 If the Ruby 2.5 module was previously enabled, it must be reset:
 
 {% highlight bash %}
-dnf module reset ruby
+dnf -y module reset ruby
 {% endhighlight %}
 
 Enable the Foreman module:
 
 {% highlight bash %}
-dnf module enable foreman:el8
+dnf -y module enable foreman:el8
 {% endhighlight %}
 
 Next upgrade all Foreman packages:

--- a/_includes/manuals/3.4/2.1_quickstart_installation.md
+++ b/_includes/manuals/3.4/2.1_quickstart_installation.md
@@ -59,7 +59,7 @@ sudo dnf -y install https://yum.theforeman.org/releases/{{page.version}}/el8/x86
   <p>Enable the Foreman module:</p>
 
 {% highlight bash %}
-sudo dnf module enable foreman:el8
+sudo dnf -y module enable foreman:el8
 {% endhighlight %}
 </div>
 

--- a/_includes/manuals/3.4/3.3.1_rpm_packages.md
+++ b/_includes/manuals/3.4/3.3.1_rpm_packages.md
@@ -27,7 +27,7 @@ To set up the repository, foreman-release packages are provided which add a repo
 
     # EL8
     dnf install https://yum.theforeman.org/releases/{{page.version}}/el8/x86_64/foreman-release.rpm
-    dnf module enable foreman:el8
+    dnf -y module enable foreman:el8
 
 ### Signing
 

--- a/_includes/manuals/3.4/3.3.1_rpm_packages.md
+++ b/_includes/manuals/3.4/3.3.1_rpm_packages.md
@@ -26,7 +26,7 @@ Under each repo are directories for each distribution, then each architecture.
 To set up the repository, foreman-release packages are provided which add a repo definition to `/etc/yum.repos.d`. Install the release RPM and enable the module:
 
     # EL8
-    dnf install https://yum.theforeman.org/releases/{{page.version}}/el8/x86_64/foreman-release.rpm
+    dnf -y install https://yum.theforeman.org/releases/{{page.version}}/el8/x86_64/foreman-release.rpm
     dnf -y module enable foreman:el8
 
 ### Signing

--- a/_includes/manuals/3.4/3.6_upgrade.md
+++ b/_includes/manuals/3.4/3.6_upgrade.md
@@ -90,13 +90,13 @@ dnf clean metadata
 If the Ruby 2.5 module was previously enabled, it must be reset:
 
 {% highlight bash %}
-dnf module reset ruby
+dnf -y module reset ruby
 {% endhighlight %}
 
 Enable the Foreman module:
 
 {% highlight bash %}
-dnf module enable foreman:el8
+dnf -y module enable foreman:el8
 {% endhighlight %}
 
 Next upgrade all Foreman packages:

--- a/_includes/manuals/3.5/2.1_quickstart_installation.md
+++ b/_includes/manuals/3.5/2.1_quickstart_installation.md
@@ -57,7 +57,7 @@ sudo dnf -y install https://yum.theforeman.org/releases/{{page.version}}/el8/x86
   <p>Enable the Foreman module:</p>
 
 {% highlight bash %}
-sudo dnf module enable foreman:el8
+sudo dnf -y module enable foreman:el8
 {% endhighlight %}
 </div>
 

--- a/_includes/manuals/3.5/3.3.1_rpm_packages.md
+++ b/_includes/manuals/3.5/3.3.1_rpm_packages.md
@@ -27,7 +27,7 @@ To set up the repository, foreman-release packages are provided which add a repo
 
     # EL8
     dnf install https://yum.theforeman.org/releases/{{page.version}}/el8/x86_64/foreman-release.rpm
-    dnf module enable foreman:el8
+    dnf -y module enable foreman:el8
 
 ### Signing
 

--- a/_includes/manuals/3.5/3.3.1_rpm_packages.md
+++ b/_includes/manuals/3.5/3.3.1_rpm_packages.md
@@ -26,7 +26,7 @@ Under each repo are directories for each distribution, then each architecture.
 To set up the repository, foreman-release packages are provided which add a repo definition to `/etc/yum.repos.d`. Install the release RPM and enable the module:
 
     # EL8
-    dnf install https://yum.theforeman.org/releases/{{page.version}}/el8/x86_64/foreman-release.rpm
+    dnf -y install https://yum.theforeman.org/releases/{{page.version}}/el8/x86_64/foreman-release.rpm
     dnf -y module enable foreman:el8
 
 ### Signing

--- a/_includes/manuals/3.5/3.6_upgrade.md
+++ b/_includes/manuals/3.5/3.6_upgrade.md
@@ -90,13 +90,13 @@ dnf clean metadata
 If the Ruby 2.5 module was previously enabled, it must be reset:
 
 {% highlight bash %}
-dnf module reset ruby
+dnf -y module reset ruby
 {% endhighlight %}
 
 Enable the Foreman module:
 
 {% highlight bash %}
-dnf module enable foreman:el8
+dnf -y module enable foreman:el8
 {% endhighlight %}
 
 Next upgrade all Foreman packages:

--- a/_includes/manuals/3.6/2.1_quickstart_installation.md
+++ b/_includes/manuals/3.6/2.1_quickstart_installation.md
@@ -57,7 +57,7 @@ sudo dnf -y install https://yum.theforeman.org/releases/{{page.version}}/el8/x86
   <p>Enable the Foreman module:</p>
 
 {% highlight bash %}
-sudo dnf module enable foreman:el8
+sudo dnf -y module enable foreman:el8
 {% endhighlight %}
 </div>
 

--- a/_includes/manuals/3.6/3.3.1_rpm_packages.md
+++ b/_includes/manuals/3.6/3.3.1_rpm_packages.md
@@ -27,7 +27,7 @@ To set up the repository, foreman-release packages are provided which add a repo
 
     # EL8
     dnf install https://yum.theforeman.org/releases/{{page.version}}/el8/x86_64/foreman-release.rpm
-    dnf module enable foreman:el8
+    dnf -y module enable foreman:el8
 
 ### Signing
 

--- a/_includes/manuals/3.6/3.3.1_rpm_packages.md
+++ b/_includes/manuals/3.6/3.3.1_rpm_packages.md
@@ -26,7 +26,7 @@ Under each repo are directories for each distribution, then each architecture.
 To set up the repository, foreman-release packages are provided which add a repo definition to `/etc/yum.repos.d`. Install the release RPM and enable the module:
 
     # EL8
-    dnf install https://yum.theforeman.org/releases/{{page.version}}/el8/x86_64/foreman-release.rpm
+    dnf -y install https://yum.theforeman.org/releases/{{page.version}}/el8/x86_64/foreman-release.rpm
     dnf -y module enable foreman:el8
 
 ### Signing

--- a/_includes/manuals/3.6/3.6_upgrade.md
+++ b/_includes/manuals/3.6/3.6_upgrade.md
@@ -90,13 +90,13 @@ dnf clean metadata
 If the Ruby 2.5 module was previously enabled, it must be reset:
 
 {% highlight bash %}
-dnf module reset ruby
+dnf -y module reset ruby
 {% endhighlight %}
 
 Enable the Foreman module:
 
 {% highlight bash %}
-dnf module enable foreman:el8
+dnf -y module enable foreman:el8
 {% endhighlight %}
 
 Next upgrade all Foreman packages:

--- a/_includes/manuals/3.7/2.1_quickstart_installation.md
+++ b/_includes/manuals/3.7/2.1_quickstart_installation.md
@@ -57,7 +57,7 @@ sudo dnf -y install https://yum.theforeman.org/releases/{{page.version}}/el8/x86
   <p>Enable the Foreman module:</p>
 
 {% highlight bash %}
-sudo dnf module enable foreman:el8
+sudo dnf -y module enable foreman:el8
 {% endhighlight %}
 </div>
 

--- a/_includes/manuals/3.7/3.3.1_rpm_packages.md
+++ b/_includes/manuals/3.7/3.3.1_rpm_packages.md
@@ -27,7 +27,7 @@ To set up the repository, foreman-release packages are provided which add a repo
 
     # EL8
     dnf install https://yum.theforeman.org/releases/{{page.version}}/el8/x86_64/foreman-release.rpm
-    dnf module enable foreman:el8
+    dnf -y module enable foreman:el8
 
 ### Signing
 

--- a/_includes/manuals/3.7/3.3.1_rpm_packages.md
+++ b/_includes/manuals/3.7/3.3.1_rpm_packages.md
@@ -26,7 +26,7 @@ Under each repo are directories for each distribution, then each architecture.
 To set up the repository, foreman-release packages are provided which add a repo definition to `/etc/yum.repos.d`. Install the release RPM and enable the module:
 
     # EL8
-    dnf install https://yum.theforeman.org/releases/{{page.version}}/el8/x86_64/foreman-release.rpm
+    dnf -y install https://yum.theforeman.org/releases/{{page.version}}/el8/x86_64/foreman-release.rpm
     dnf -y module enable foreman:el8
 
 ### Signing

--- a/_includes/manuals/3.7/3.6_upgrade.md
+++ b/_includes/manuals/3.7/3.6_upgrade.md
@@ -90,13 +90,13 @@ dnf clean metadata
 If the Ruby 2.5 module was previously enabled, it must be reset:
 
 {% highlight bash %}
-dnf module reset ruby
+dnf -y module reset ruby
 {% endhighlight %}
 
 Enable the Foreman module:
 
 {% highlight bash %}
-dnf module enable foreman:el8
+dnf -y module enable foreman:el8
 {% endhighlight %}
 
 Next upgrade all Foreman packages:

--- a/_includes/manuals/3.8/2.1_quickstart_installation.md
+++ b/_includes/manuals/3.8/2.1_quickstart_installation.md
@@ -57,7 +57,7 @@ sudo dnf -y install https://yum.theforeman.org/releases/{{page.version}}/el8/x86
   <p>Enable the Foreman module:</p>
 
 {% highlight bash %}
-sudo dnf module enable foreman:el8
+sudo dnf -y module enable foreman:el8
 {% endhighlight %}
 </div>
 

--- a/_includes/manuals/3.8/3.3.1_rpm_packages.md
+++ b/_includes/manuals/3.8/3.3.1_rpm_packages.md
@@ -27,7 +27,7 @@ To set up the repository, foreman-release packages are provided which add a repo
 
     # EL8
     dnf install https://yum.theforeman.org/releases/{{page.version}}/el8/x86_64/foreman-release.rpm
-    dnf module enable foreman:el8
+    dnf -y module enable foreman:el8
 
 ### Signing
 

--- a/_includes/manuals/3.8/3.3.1_rpm_packages.md
+++ b/_includes/manuals/3.8/3.3.1_rpm_packages.md
@@ -26,7 +26,7 @@ Under each repo are directories for each distribution, then each architecture.
 To set up the repository, foreman-release packages are provided which add a repo definition to `/etc/yum.repos.d`. Install the release RPM and enable the module:
 
     # EL8
-    dnf install https://yum.theforeman.org/releases/{{page.version}}/el8/x86_64/foreman-release.rpm
+    dnf -y install https://yum.theforeman.org/releases/{{page.version}}/el8/x86_64/foreman-release.rpm
     dnf -y module enable foreman:el8
 
 ### Signing

--- a/_includes/manuals/3.8/3.6_upgrade.md
+++ b/_includes/manuals/3.8/3.6_upgrade.md
@@ -90,13 +90,13 @@ dnf clean metadata
 If the Ruby 2.5 module was previously enabled, it must be reset:
 
 {% highlight bash %}
-dnf module reset ruby
+dnf -y module reset ruby
 {% endhighlight %}
 
 Enable the Foreman module:
 
 {% highlight bash %}
-dnf module enable foreman:el8
+dnf -y module enable foreman:el8
 {% endhighlight %}
 
 Next upgrade all Foreman packages:

--- a/_includes/manuals/nightly/2.1_quickstart_installation.md
+++ b/_includes/manuals/nightly/2.1_quickstart_installation.md
@@ -57,7 +57,7 @@ sudo dnf -y install https://yum.theforeman.org/releases/{{page.version}}/el8/x86
   <p>Enable the Foreman module:</p>
 
 {% highlight bash %}
-sudo dnf module enable foreman:el8
+sudo dnf -y module enable foreman:el8
 {% endhighlight %}
 </div>
 

--- a/_includes/manuals/nightly/3.3.1_rpm_packages.md
+++ b/_includes/manuals/nightly/3.3.1_rpm_packages.md
@@ -27,7 +27,7 @@ To set up the repository, foreman-release packages are provided which add a repo
 
     # EL8
     dnf install https://yum.theforeman.org/releases/{{page.version}}/el8/x86_64/foreman-release.rpm
-    dnf module enable foreman:el8
+    dnf -y module enable foreman:el8
 
 ### Signing
 

--- a/_includes/manuals/nightly/3.3.1_rpm_packages.md
+++ b/_includes/manuals/nightly/3.3.1_rpm_packages.md
@@ -26,7 +26,7 @@ Under each repo are directories for each distribution, then each architecture.
 To set up the repository, foreman-release packages are provided which add a repo definition to `/etc/yum.repos.d`. Install the release RPM and enable the module:
 
     # EL8
-    dnf install https://yum.theforeman.org/releases/{{page.version}}/el8/x86_64/foreman-release.rpm
+    dnf -y install https://yum.theforeman.org/releases/{{page.version}}/el8/x86_64/foreman-release.rpm
     dnf -y module enable foreman:el8
 
 ### Signing

--- a/_includes/manuals/nightly/3.6_upgrade.md
+++ b/_includes/manuals/nightly/3.6_upgrade.md
@@ -90,13 +90,13 @@ dnf clean metadata
 If the Ruby 2.5 module was previously enabled, it must be reset:
 
 {% highlight bash %}
-dnf module reset ruby
+dnf -y module reset ruby
 {% endhighlight %}
 
 Enable the Foreman module:
 
 {% highlight bash %}
-dnf module enable foreman:el8
+dnf -y module enable foreman:el8
 {% endhighlight %}
 
 Next upgrade all Foreman packages:


### PR DESCRIPTION
The installation guidelines use `-y` for all dnf/yum operations, except for enabling the module. DNF support `-y` here as well, so we can use it.