### PR TITLE
smartproxy_tftp, prov_os: Add `Provisioning Setup` submenu navigation

### DIFF
--- a/_includes/manuals/3.8/4.3.9_smartproxy_tftp.md
+++ b/_includes/manuals/3.8/4.3.9_smartproxy_tftp.md
@@ -42,7 +42,7 @@ The setup is very simple, and may be performed manually if desired.
 6. Make sure */var/lib/tftpboot/grub* and */var/lib/tftpboot/grub2* are both writeable by the foreman proxy user (foreman-proxy).
 7. Verify SELinux labels when using SELinux.
 
-* Note: if CentOS 7 is used, please make sure to edit the URL under Hosts -> Installation Media, to to exclude the $minor version. For example: http://mirror.centos.org/centos/$major/os/$arch
+* Note: if CentOS 7 is used, please make sure to edit the URL under Hosts -> Provisioning Setup -> Installation Media, to to exclude the $minor version. For example: http://mirror.centos.org/centos/$major/os/$arch
 
 ##### Setting Up Foreman
 

--- a/_includes/manuals/3.8/4.4.1_prov_os.md
+++ b/_includes/manuals/3.8/4.4.1_prov_os.md
@@ -1,5 +1,5 @@
 
-The Operating Systems page (*Hosts -> Operating Systems*) details the OSs known to Foreman, and is the central point that the other required components tie into.
+The Operating Systems page (*Hosts -> Provisioning Setup -> Operating Systems*) details the OSs known to Foreman, and is the central point that the other required components tie into.
 
 #### Creating an Operating System
 

--- a/_includes/manuals/nightly/4.3.9_smartproxy_tftp.md
+++ b/_includes/manuals/nightly/4.3.9_smartproxy_tftp.md
@@ -42,7 +42,7 @@ The setup is very simple, and may be performed manually if desired.
 6. Make sure */var/lib/tftpboot/grub* and */var/lib/tftpboot/grub2* are both writeable by the foreman proxy user (foreman-proxy).
 7. Verify SELinux labels when using SELinux.
 
-* Note: if CentOS 7 is used, please make sure to edit the URL under Hosts -> Installation Media, to to exclude the $minor version. For example: http://mirror.centos.org/centos/$major/os/$arch
+* Note: if CentOS 7 is used, please make sure to edit the URL under Hosts -> Provisioning Setup -> Installation Media, to to exclude the $minor version. For example: http://mirror.centos.org/centos/$major/os/$arch
 
 ##### Setting Up Foreman
 

--- a/_includes/manuals/nightly/4.4.1_prov_os.md
+++ b/_includes/manuals/nightly/4.4.1_prov_os.md
@@ -1,5 +1,5 @@
 
-The Operating Systems page (*Hosts -> Operating Systems*) details the OSs known to Foreman, and is the central point that the other required components tie into.
+The Operating Systems page (*Hosts -> Provisioning Setup -> Operating Systems*) details the OSs known to Foreman, and is the central point that the other required components tie into.
 
 #### Creating an Operating System
 


### PR DESCRIPTION
I guess the Provisioning Setup submenu was added to the web interface at
some point, but wasn't added to the documentation. This commit adds the
submenu.
