### PR TITLE
4.4.1_prov_os: fix `Create Operating System` button label

### DIFF
--- a/_includes/manuals/3.8/4.4.1_prov_os.md
+++ b/_includes/manuals/3.8/4.4.1_prov_os.md
@@ -3,7 +3,7 @@ The Operating Systems page (*Hosts -> Operating Systems*) details the OSs known 
 
 #### Creating an Operating System
 
-Simply click *New Operating system* on the main page. You will be taken to a screen where you can create the bare essentials of a new OS. Not everything required for a successful provision is on this page (yet) - the remaining components will appear for selection as we create them.
+Simply click *Create Operating System* on the main page. You will be taken to a screen where you can create the bare essentials of a new OS. Not everything required for a successful provision is on this page (yet) - the remaining components will appear for selection as we create them.
 
 You will need to fill in the first few parts of the form (Name, Major, Minor, Family, and possibly some family-dependant information). In the case of OSs like Fedora, it is fine to leave Minor blank.
 

--- a/_includes/manuals/nightly/4.4.1_prov_os.md
+++ b/_includes/manuals/nightly/4.4.1_prov_os.md
@@ -3,7 +3,7 @@ The Operating Systems page (*Hosts -> Operating Systems*) details the OSs known 
 
 #### Creating an Operating System
 
-Simply click *New Operating system* on the main page. You will be taken to a screen where you can create the bare essentials of a new OS. Not everything required for a successful provision is on this page (yet) - the remaining components will appear for selection as we create them.
+Simply click *Create Operating System* on the main page. You will be taken to a screen where you can create the bare essentials of a new OS. Not everything required for a successful provision is on this page (yet) - the remaining components will appear for selection as we create them.
 
 You will need to fill in the first few parts of the form (Name, Major, Minor, Family, and possibly some family-dependant information). In the case of OSs like Fedora, it is fine to leave Minor blank.
 


### PR DESCRIPTION
The button is now labeled `Create Operating System`, not `New Operating
system`.
