### PR TITLE
Reflect that foreman-gce was replaced by foreman_google

### DIFF
--- a/_includes/manuals/3.5/3.3.2_debian_packages.md
+++ b/_includes/manuals/3.5/3.3.2_debian_packages.md
@@ -45,7 +45,7 @@ apt-get update
 
 #### Install packages
 
-The packages are split by gem dependencies - there are 15 packages to choose from. These are:
+The packages are split by gem dependencies - there are 13 packages to choose from. These are:
 
 Main package:
 
@@ -61,7 +61,6 @@ Optional functionality:
 * foreman-debug
 * foreman-dynflow-sidekiq
 * foreman-ec2
-* foreman-gce
 * foreman-journald
 * foreman-libvirt
 * foreman-openstack

--- a/_includes/manuals/3.6/3.3.1_rpm_packages.md
+++ b/_includes/manuals/3.6/3.3.1_rpm_packages.md
@@ -41,7 +41,6 @@ Install foreman and other foreman-* packages to add functionality:
     foreman-proxy         Foreman Smart Proxy
     foreman-debug         Log and debug collection tools
     foreman-ec2           Amazon EC2 provisioning support
-    foreman-gce           Google Compute Engine provisioning support
     foreman-libvirt       libvirt provisioning support
     foreman-openstack     OpenStack Nova provisioning support
     foreman-ovirt         oVirt/RHEV provisioning support

--- a/_includes/manuals/3.6/3.3.2_debian_packages.md
+++ b/_includes/manuals/3.6/3.3.2_debian_packages.md
@@ -45,7 +45,7 @@ apt-get update
 
 #### Install packages
 
-The packages are split by gem dependencies - there are 15 packages to choose from. These are:
+The packages are split by gem dependencies - there are 13 packages to choose from. These are:
 
 Main package:
 
@@ -61,7 +61,6 @@ Optional functionality:
 * foreman-debug
 * foreman-dynflow-sidekiq
 * foreman-ec2
-* foreman-gce
 * foreman-journald
 * foreman-libvirt
 * foreman-openstack

--- a/_includes/manuals/3.6/5.2_compute_resources.md
+++ b/_includes/manuals/3.6/5.2_compute_resources.md
@@ -24,7 +24,7 @@ The capabilities vary between implementations, depending on how the compute reso
   </tr>
   <tr>
     <td><a href="/manuals/{{page.version}}/index.html#5.2.4GoogleComputeEngineNotes">Google Compute Engine</a></td>
-    <td>foreman-gce</td>
+    <td>foreman-plugin-google</td>
     <td>no</td>
     <td>yes</td>
     <td>read-only</td>

--- a/_includes/manuals/3.7/3.3.1_rpm_packages.md
+++ b/_includes/manuals/3.7/3.3.1_rpm_packages.md
@@ -41,7 +41,6 @@ Install foreman and other foreman-* packages to add functionality:
     foreman-proxy         Foreman Smart Proxy
     foreman-debug         Log and debug collection tools
     foreman-ec2           Amazon EC2 provisioning support
-    foreman-gce           Google Compute Engine provisioning support
     foreman-libvirt       libvirt provisioning support
     foreman-openstack     OpenStack Nova provisioning support
     foreman-ovirt         oVirt/RHEV provisioning support

--- a/_includes/manuals/3.7/3.3.2_debian_packages.md
+++ b/_includes/manuals/3.7/3.3.2_debian_packages.md
@@ -45,7 +45,7 @@ apt-get update
 
 #### Install packages
 
-The packages are split by gem dependencies - there are 15 packages to choose from. These are:
+The packages are split by gem dependencies - there are 13 packages to choose from. These are:
 
 Main package:
 
@@ -61,7 +61,6 @@ Optional functionality:
 * foreman-debug
 * foreman-dynflow-sidekiq
 * foreman-ec2
-* foreman-gce
 * foreman-journald
 * foreman-libvirt
 * foreman-openstack

--- a/_includes/manuals/3.7/5.2_compute_resources.md
+++ b/_includes/manuals/3.7/5.2_compute_resources.md
@@ -24,7 +24,7 @@ The capabilities vary between implementations, depending on how the compute reso
   </tr>
   <tr>
     <td><a href="/manuals/{{page.version}}/index.html#5.2.4GoogleComputeEngineNotes">Google Compute Engine</a></td>
-    <td>foreman-gce</td>
+    <td>foreman-plugin-google</td>
     <td>no</td>
     <td>yes</td>
     <td>read-only</td>

--- a/_includes/manuals/3.8/3.3.1_rpm_packages.md
+++ b/_includes/manuals/3.8/3.3.1_rpm_packages.md
@@ -41,7 +41,6 @@ Install foreman and other foreman-* packages to add functionality:
     foreman-proxy         Foreman Smart Proxy
     foreman-debug         Log and debug collection tools
     foreman-ec2           Amazon EC2 provisioning support
-    foreman-gce           Google Compute Engine provisioning support
     foreman-libvirt       libvirt provisioning support
     foreman-openstack     OpenStack Nova provisioning support
     foreman-ovirt         oVirt/RHEV provisioning support

--- a/_includes/manuals/3.8/5.2_compute_resources.md
+++ b/_includes/manuals/3.8/5.2_compute_resources.md
@@ -24,7 +24,7 @@ The capabilities vary between implementations, depending on how the compute reso
   </tr>
   <tr>
     <td><a href="/manuals/{{page.version}}/index.html#5.2.4GoogleComputeEngineNotes">Google Compute Engine</a></td>
-    <td>foreman-gce</td>
+    <td>foreman-plugin-google</td>
     <td>no</td>
     <td>yes</td>
     <td>read-only</td>

--- a/_includes/manuals/nightly/3.3.1_rpm_packages.md
+++ b/_includes/manuals/nightly/3.3.1_rpm_packages.md
@@ -41,7 +41,6 @@ Install foreman and other foreman-* packages to add functionality:
     foreman-proxy         Foreman Smart Proxy
     foreman-debug         Log and debug collection tools
     foreman-ec2           Amazon EC2 provisioning support
-    foreman-gce           Google Compute Engine provisioning support
     foreman-libvirt       libvirt provisioning support
     foreman-openstack     OpenStack Nova provisioning support
     foreman-ovirt         oVirt/RHEV provisioning support

--- a/_includes/manuals/nightly/3.3.2_debian_packages.md
+++ b/_includes/manuals/nightly/3.3.2_debian_packages.md
@@ -45,7 +45,7 @@ apt-get update
 
 #### Install packages
 
-The packages are split by gem dependencies - there are 15 packages to choose from. These are:
+The packages are split by gem dependencies - there are 13 packages to choose from. These are:
 
 Main package:
 
@@ -61,7 +61,6 @@ Optional functionality:
 * foreman-debug
 * foreman-dynflow-sidekiq
 * foreman-ec2
-* foreman-gce
 * foreman-journald
 * foreman-libvirt
 * foreman-openstack

--- a/_includes/manuals/nightly/5.2_compute_resources.md
+++ b/_includes/manuals/nightly/5.2_compute_resources.md
@@ -24,7 +24,7 @@ The capabilities vary between implementations, depending on how the compute reso
   </tr>
   <tr>
     <td><a href="/manuals/{{page.version}}/index.html#5.2.4GoogleComputeEngineNotes">Google Compute Engine</a></td>
-    <td>foreman-gce</td>
+    <td>foreman-plugin-google</td>
     <td>no</td>
     <td>yes</td>
     <td>read-only</td>


### PR DESCRIPTION
In Foreman 3.5 the foreman-gce package was dropped and replaced by a foreman_google plugin.

It doesn't review the existing documentation section, but at least corrects the pacakage names. I didn't check if foreman-plugin-google is actually provided on Debian.