### PR TITLE
Drop Google Analytics from our website

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -19,19 +19,5 @@
     <p>Thanks to <a href="/sponsors.html">our sponsors</a> for hosting this website and our project services.</p>
   </div>
 </div>
-
-<script type="text/javascript">
-  var _gaq = _gaq || [];
-  _gaq.push(['_setAccount', 'UA-2134730-5']);
-  _gaq.push(['_gat._anonymizeIp']);
-  _gaq.push(['_trackPageview']);
-
-  (function() {
-      var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-      ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-      var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
-  })();
-</script>
-
 </body>
 </html>

--- a/privacy.md
+++ b/privacy.md
@@ -32,12 +32,7 @@ information or set cookies. There is no account for the website itself. The
 webserver (Apache) logs will contain IP addresses, timestamps, and UserAgent
 strings - these are log-rotated and deleted after 4 weeks.
 
-The website also uses Google Analytics, but we only collect anonymous data. IP
-addresses are [anonymised][GA-anonIP], and we do not use User-ID, or any linked
-Google product (e.g. AdWords). Google Analytics data is deleted after 26 months
-(the default for Google Analytics).
-
-The webserver logs and Google Analytics are used to produce aggregated
+The webserver logs are used to produce aggregated
 statistics about the community, such as popularity of different browsers,
 operating system packages, plugins, etc.
 

--- a/slides/foreman-intro.html
+++ b/slides/foreman-intro.html
@@ -71,16 +71,7 @@ ready(function() {
     }
 });
 </script>
-<script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-
-    ga('create', 'UA-42322531-1', 'strut.io');
-    ga('send', 'pageview');
-    </script>
-<style type="text/css"></style></head>
+</head>
 <body class="impress-supported impress-enabled" style="height: 100%; overflow: hidden;">
 <style type="text/css">
 .strut-surface .themedArea h1, 


### PR DESCRIPTION
It's unclear who currently has access to it. Probably people who have left the project by now. Since nobody is analyzing the data, it's better to drop is and improve our users' privacy.