### PR TITLE
Update Dockerfile for get-params to use EL9

### DIFF
--- a/scripts/installer/Dockerfile
+++ b/scripts/installer/Dockerfile
@@ -1,8 +1,7 @@
-FROM quay.io/centos/centos:stream8
+FROM quay.io/centos/centos:stream9
 
-RUN dnf -y install https://yum.puppetlabs.com/puppet7/puppet7-release-el-8.noarch.rpm
+RUN dnf -y install https://yum.puppetlabs.com/puppet7-release-el-9.noarch.rpm
 
 ARG FOREMAN_VERSION
-RUN dnf -y install https://yum.theforeman.org/releases/$FOREMAN_VERSION/el8/x86_64/foreman-release.rpm
-RUN dnf -y module enable foreman:el8
+RUN dnf -y install https://yum.theforeman.org/releases/$FOREMAN_VERSION/el9/x86_64/foreman-release.rpm
 RUN dnf -y install foreman-installer


### PR DESCRIPTION
CentOS stream 8 is no longer available so we should update this to EL9.