### PR TITLE
Add faraday-retry to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,4 @@ source "https://rubygems.org"
 gem 'github-pages', '>= 147'
 gem 'rake'
 gem 'webrick'
+gem 'faraday-retry'


### PR DESCRIPTION
It's an optional dependency of octokit. Without it we always get a warning on the CLI:

```
To use retry middleware with Faraday v2.0+, install `faraday-retry` gem
```