### PR TITLE
Add betadots to professional services and training

### DIFF
--- a/professional-services.md
+++ b/professional-services.md
@@ -24,6 +24,10 @@ The following companies provide Foreman consulting services. If you would like t
 
 ATIX specialize in support and operation consulting. For more information, check out their [Foreman](https://atix.de/en/foreman/) consulting page. You can also read about ATIX's areas of focus and contributions to the wider Foreman community in the guest blog [ATIX in the Foreman Community](https://theforeman.org/2020/10/atix-in-the-foreman-community.html).
 
+### betadots
+
+betadots specialize in operation consulting and training. Fore more information, check out their [homepage](https://www.betadots.de). You can read about betadots's focus and their contributions to the Foreman community in the blog post [betadots consulting services](https://theforeman.org/2024/06/betadots-consulting-services.html).
+
 ### inuits.eu
 
 Inuits specialize in open-source consulting and host our beloved ConfigMgmtCamp. For more information about the solutions they implement, check out their [case studies](https://inuits.eu/businesscases/). You can read about [inuits.eu](inuits.eu)'s history with Foreman in the guest blog [inuits.eu in the Foreman Community](https://theforeman.org/2021/06/inuitseu-in-the-foreman-community.html)

--- a/training.md
+++ b/training.md
@@ -22,6 +22,20 @@ more than welcome!
 [adfinis-slides]: https://docs.adfinis-sygroup.ch/public/trainings/#training-Foreman
 [adfinis-github]: https://github.com/adfinis-sygroup/adsy-trainings
 
+## betadots Training Course
+
+The [training][betadots-training] by [betadots][betadots] is designed as a three-day
+hands-on training in German language. It covers topics from the initial installation
+over content management with Katello, integration of configuration management and
+provisioning to plugins including their Hiera data manager and advanced topics.
+
+They provide [courses][betadots-schedule] together with training partners like Linuxhotel in Essen or
+Heinlein Academy in Berlin regularly. Also remote trainings are available as direct order.
+
+[betadots]: https://www.betadots.de
+[betadots-training]: https://github.com/betadots/foreman-training
+[betadots-schedule]: https://www.betadots.de/training
+
 ## Guru Labs Training Course
 
 The [GL650 - FOREMAN/KATELLO ADMINISTRATION][GL650] is a 4-day instructor led course that provides comprehensive hands on coverage all the of the major features of a Foreman+Katello deployment starting from best practices in installation and initial configuration, managing subscriptions, products and repositories, content views, lifecycles, activation keys, system registration of existing system, bare metal and virtualization provisioning including discovery, provisioning templates, configuration management with Puppet and Ansible, IdM integration, smart proxies/capsule servers, virt-who, and subscription management.


### PR DESCRIPTION
I want to see betadots added to professional services and training after they introduced to the community in their blogpost.

Please approve my summary for the two pages @bastelfreak or @tuxmea 