### PR TITLE
Add Katello API docs to website navigation

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -48,8 +48,10 @@ navigation:
         url: /manuals/latest/index.html
       - title: Plugins
         url: /plugins/
-      - title: API docs
+      - title: Foreman API docs
         url: https://apidocs.theforeman.org/foreman/latest/apidoc/v2.html
+      - title: Foreman+Katello API docs
+        url: https://apidocs.theforeman.org/katello/latest/apidoc/v2.html
       - title: Training
         url: /training.html
       - title: Support


### PR DESCRIPTION
Tested locally in a container as documented in the README. :heavy_check_mark: 

cc @dosas @knoppi @nadjaheitmann