### PR TITLE
Refs #35184 - Drop puppetca_puppet_cert documentation for 3.9+

### DIFF
--- a/_includes/manuals/3.10/4.3.7_smartproxy_puppetca.md
+++ b/_includes/manuals/3.10/4.3.7_smartproxy_puppetca.md
@@ -17,11 +17,6 @@ Also choose the provider to use, default should be `puppetca_hostname_whitelisti
 :use_provider: puppetca_hostname_whitelisting
 ```
 
-Lastly the Puppet version needs to be specified. Since version 6 the `puppetca_http_api` implementation is used while on earlier versions the `puppetca_puppet_cert` implementation is used.
-```yaml
-:puppet_version: '6.8.0'
-```
-
 #### puppetca_hostname_whitelisting
 
 The `puppetca_hostname_whitelisting` provider directly manages Puppet's `autosign.conf` file.
@@ -75,39 +70,7 @@ After deploying the script the Puppet configuration has to be changed to point t
 autosign = /usr/libexec/foreman-proxy/puppet_sign.rb
 ```
 
-#### puppetca_puppet_cert
-
-**Note** this is used in Puppet 5 and earlier as determined by the `puppet_version` setting in `puppetca.yml`.
-
-This implementation is used for managing certificates. It uses the `puppet cert` command and typically requires sudo access for the proxy.
-
-```yaml
-:ssldir: /etc/puppetlabs/puppet/ssl
-#:puppetca_use_sudo: false
-#:sudo_command: /usr/bin/sudo
-```
-
-The `ssldir` setting is required and can be determined with `puppet config print ssldir`. Puppet AIO defaults to using `/etc/puppetlabs/puppet/ssl`.
-
-By default sudo is used but can be disabled with `puppetca_use_sudo` setting. The sudo command is dermined via the `PATH` variable or can be explicitly set with the `sudo_command` setting.
-
-For sudo to work correctly, it must be configured to allow `puppet cert` with NOPASSWD and without requiretty. Under a Puppet AIO installation, configuration should be:
-
-```
-foreman-proxy ALL = NOPASSWD: /opt/puppetlabs/bin/puppet cert *
-Defaults:foreman-proxy !requiretty
-```
-
-Under a non-AIO Puppet installation:
-
-```
-foreman-proxy ALL = NOPASSWD: /usr/bin/puppet cert *
-Defaults:foreman-proxy !requiretty
-```
-
 #### puppetca_http_api
-
-**Note** this is used in Puppet 6 and newer as determined by the `puppet_version` setting in `puppetca.yml`.
 
 As the name implies, Puppetserver's HTTP API is used to manage certificates. In its configuration file `puppetca_http_api.yml` the connection details are configured:
 

--- a/_includes/manuals/3.11/4.3.7_smartproxy_puppetca.md
+++ b/_includes/manuals/3.11/4.3.7_smartproxy_puppetca.md
@@ -17,11 +17,6 @@ Also choose the provider to use, default should be `puppetca_hostname_whitelisti
 :use_provider: puppetca_hostname_whitelisting
 ```
 
-Lastly the Puppet version needs to be specified. Since version 6 the `puppetca_http_api` implementation is used while on earlier versions the `puppetca_puppet_cert` implementation is used.
-```yaml
-:puppet_version: '6.8.0'
-```
-
 #### puppetca_hostname_whitelisting
 
 The `puppetca_hostname_whitelisting` provider directly manages Puppet's `autosign.conf` file.
@@ -75,39 +70,7 @@ After deploying the script the Puppet configuration has to be changed to point t
 autosign = /usr/libexec/foreman-proxy/puppet_sign.rb
 ```
 
-#### puppetca_puppet_cert
-
-**Note** this is used in Puppet 5 and earlier as determined by the `puppet_version` setting in `puppetca.yml`.
-
-This implementation is used for managing certificates. It uses the `puppet cert` command and typically requires sudo access for the proxy.
-
-```yaml
-:ssldir: /etc/puppetlabs/puppet/ssl
-#:puppetca_use_sudo: false
-#:sudo_command: /usr/bin/sudo
-```
-
-The `ssldir` setting is required and can be determined with `puppet config print ssldir`. Puppet AIO defaults to using `/etc/puppetlabs/puppet/ssl`.
-
-By default sudo is used but can be disabled with `puppetca_use_sudo` setting. The sudo command is dermined via the `PATH` variable or can be explicitly set with the `sudo_command` setting.
-
-For sudo to work correctly, it must be configured to allow `puppet cert` with NOPASSWD and without requiretty. Under a Puppet AIO installation, configuration should be:
-
-```
-foreman-proxy ALL = NOPASSWD: /opt/puppetlabs/bin/puppet cert *
-Defaults:foreman-proxy !requiretty
-```
-
-Under a non-AIO Puppet installation:
-
-```
-foreman-proxy ALL = NOPASSWD: /usr/bin/puppet cert *
-Defaults:foreman-proxy !requiretty
-```
-
 #### puppetca_http_api
-
-**Note** this is used in Puppet 6 and newer as determined by the `puppet_version` setting in `puppetca.yml`.
 
 As the name implies, Puppetserver's HTTP API is used to manage certificates. In its configuration file `puppetca_http_api.yml` the connection details are configured:
 

--- a/_includes/manuals/3.9/4.3.7_smartproxy_puppetca.md
+++ b/_includes/manuals/3.9/4.3.7_smartproxy_puppetca.md
@@ -17,11 +17,6 @@ Also choose the provider to use, default should be `puppetca_hostname_whitelisti
 :use_provider: puppetca_hostname_whitelisting
 ```
 
-Lastly the Puppet version needs to be specified. Since version 6 the `puppetca_http_api` implementation is used while on earlier versions the `puppetca_puppet_cert` implementation is used.
-```yaml
-:puppet_version: '6.8.0'
-```
-
 #### puppetca_hostname_whitelisting
 
 The `puppetca_hostname_whitelisting` provider directly manages Puppet's `autosign.conf` file.
@@ -75,39 +70,7 @@ After deploying the script the Puppet configuration has to be changed to point t
 autosign = /usr/libexec/foreman-proxy/puppet_sign.rb
 ```
 
-#### puppetca_puppet_cert
-
-**Note** this is used in Puppet 5 and earlier as determined by the `puppet_version` setting in `puppetca.yml`.
-
-This implementation is used for managing certificates. It uses the `puppet cert` command and typically requires sudo access for the proxy.
-
-```yaml
-:ssldir: /etc/puppetlabs/puppet/ssl
-#:puppetca_use_sudo: false
-#:sudo_command: /usr/bin/sudo
-```
-
-The `ssldir` setting is required and can be determined with `puppet config print ssldir`. Puppet AIO defaults to using `/etc/puppetlabs/puppet/ssl`.
-
-By default sudo is used but can be disabled with `puppetca_use_sudo` setting. The sudo command is dermined via the `PATH` variable or can be explicitly set with the `sudo_command` setting.
-
-For sudo to work correctly, it must be configured to allow `puppet cert` with NOPASSWD and without requiretty. Under a Puppet AIO installation, configuration should be:
-
-```
-foreman-proxy ALL = NOPASSWD: /opt/puppetlabs/bin/puppet cert *
-Defaults:foreman-proxy !requiretty
-```
-
-Under a non-AIO Puppet installation:
-
-```
-foreman-proxy ALL = NOPASSWD: /usr/bin/puppet cert *
-Defaults:foreman-proxy !requiretty
-```
-
 #### puppetca_http_api
-
-**Note** this is used in Puppet 6 and newer as determined by the `puppet_version` setting in `puppetca.yml`.
 
 As the name implies, Puppetserver's HTTP API is used to manage certificates. In its configuration file `puppetca_http_api.yml` the connection details are configured:
 

--- a/_includes/manuals/nightly/4.3.7_smartproxy_puppetca.md
+++ b/_includes/manuals/nightly/4.3.7_smartproxy_puppetca.md
@@ -17,11 +17,6 @@ Also choose the provider to use, default should be `puppetca_hostname_whitelisti
 :use_provider: puppetca_hostname_whitelisting
 ```
 
-Lastly the Puppet version needs to be specified. Since version 6 the `puppetca_http_api` implementation is used while on earlier versions the `puppetca_puppet_cert` implementation is used.
-```yaml
-:puppet_version: '6.8.0'
-```
-
 #### puppetca_hostname_whitelisting
 
 The `puppetca_hostname_whitelisting` provider directly manages Puppet's `autosign.conf` file.
@@ -75,39 +70,7 @@ After deploying the script the Puppet configuration has to be changed to point t
 autosign = /usr/libexec/foreman-proxy/puppet_sign.rb
 ```
 
-#### puppetca_puppet_cert
-
-**Note** this is used in Puppet 5 and earlier as determined by the `puppet_version` setting in `puppetca.yml`.
-
-This implementation is used for managing certificates. It uses the `puppet cert` command and typically requires sudo access for the proxy.
-
-```yaml
-:ssldir: /etc/puppetlabs/puppet/ssl
-#:puppetca_use_sudo: false
-#:sudo_command: /usr/bin/sudo
-```
-
-The `ssldir` setting is required and can be determined with `puppet config print ssldir`. Puppet AIO defaults to using `/etc/puppetlabs/puppet/ssl`.
-
-By default sudo is used but can be disabled with `puppetca_use_sudo` setting. The sudo command is dermined via the `PATH` variable or can be explicitly set with the `sudo_command` setting.
-
-For sudo to work correctly, it must be configured to allow `puppet cert` with NOPASSWD and without requiretty. Under a Puppet AIO installation, configuration should be:
-
-```
-foreman-proxy ALL = NOPASSWD: /opt/puppetlabs/bin/puppet cert *
-Defaults:foreman-proxy !requiretty
-```
-
-Under a non-AIO Puppet installation:
-
-```
-foreman-proxy ALL = NOPASSWD: /usr/bin/puppet cert *
-Defaults:foreman-proxy !requiretty
-```
-
 #### puppetca_http_api
-
-**Note** this is used in Puppet 6 and newer as determined by the `puppet_version` setting in `puppetca.yml`.
 
 As the name implies, Puppetserver's HTTP API is used to manage certificates. In its configuration file `puppetca_http_api.yml` the connection details are configured:
 


### PR DESCRIPTION
Foreman 3.9 dropped support for old Puppet versions and with it the `puppetca_puppet_cert` provider.