### PR TITLE
Use Ruby 3 to run CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '2.7'
+          ruby-version: '3'
           bundler-cache: true
       - name: Run tests
         run: bundle exec rake build


### PR DESCRIPTION
Using unqualified 3 means just use the latest released version.