### PR TITLE
Add Debian 12 support to the Foreman 3.11 manual

### DIFF
--- a/_includes/manuals/3.11/1.2_release_notes.md
+++ b/_includes/manuals/3.11/1.2_release_notes.md
@@ -18,6 +18,11 @@ For more details, see https://projects.theforeman.org/issues/37252 and https://p
 
 Foreman 3.10 only supported Enterprise Linux 9 as experimental, but with this release it is fully supported.
 
+#### Running Foreman on Debian 12 is supported
+
+Packages for Debian 12 were built with 3.11.0, but our automated pipelines rely on Puppetserver.
+Now that Puppetserver packages for Debian 12 are available, with Foreman 3.11.4 Debian 12 is considered a supported platform.
+
 ### Upgrade warnings
 
 #### keycloak-httpd-client-install dropped from Enterprise Linux 9
@@ -42,6 +47,13 @@ Note this is for running Foreman itself.
 Clients will remain supported.
 
 For more details and discussion, see https://community.theforeman.org/t/drop-support-for-running-on-el8-with-foreman-3-13/38083.
+
+#### Running Foreman on Debian 11 removal in Foreman 3.14
+
+Users are encouraged to upgrade to Debian 12.
+
+Note this is for running Foreman itself.
+Clients will remain supported.
 
 ### Release notes for 3.11.4
 *Packages for Debian 12 were built with 3.11.0, but our automated pipelines rely on Puppetserver.

--- a/_includes/manuals/3.11/2.1_quickstart_installation.md
+++ b/_includes/manuals/3.11/2.1_quickstart_installation.md
@@ -27,6 +27,7 @@ To provide specific installation instructions, please select your operating syst
   <option value="el8">Enterprise Linux 8</option>
   <option value="el9">Enterprise Linux 9</option>
   <option value="debian11">Debian 11 (Bullseye)</option>
+  <option value="debian12">Debian 12 (Bookworm)</option>
   <option value="ubuntu2004">Ubuntu 20.04 (Focal)</option>
   <option value="ubuntu2204">Ubuntu 22.04 (Jammy)</option>
 </select>
@@ -121,6 +122,26 @@ echo "deb http://deb.theforeman.org/ plugins {{page.version}}" | sudo tee -a /et
 {% endhighlight %}
 </div>
 
+<div class="quickstart_os quickstart_os_debian12">
+  <p>
+    Enable Puppet's 8.x repository:
+  </p>
+
+{% highlight bash %}
+sudo apt-get -y install ca-certificates
+cd /tmp && wget https://apt.puppet.com/puppet8-release-bookworm.deb
+sudo apt-get install /tmp/puppet8-release-bookworm.deb
+{% endhighlight %}
+
+  <p>Enable the Foreman repositories:</p>
+
+{% highlight bash %}
+sudo wget https://deb.theforeman.org/foreman.asc -O /etc/apt/trusted.gpg.d/foreman.asc
+echo "deb http://deb.theforeman.org/ bookworm {{page.version}}" | sudo tee /etc/apt/sources.list.d/foreman.list
+echo "deb http://deb.theforeman.org/ plugins {{page.version}}" | sudo tee -a /etc/apt/sources.list.d/foreman.list
+{% endhighlight %}
+</div>
+
 <div class="quickstart_os quickstart_os_ubuntu2204">
   <p>
     Enable Puppet's 7.x repository:
@@ -153,7 +174,7 @@ sudo dnf -y install foreman-installer
 {% endhighlight %}
 </div>
 
-<div class="quickstart_os quickstart_os_debian11 quickstart_os_ubuntu2004 quickstart_os_ubuntu2204">
+<div class="quickstart_os quickstart_os_debian11 quickstart_os_debian12 quickstart_os_ubuntu2004 quickstart_os_ubuntu2204">
 {% highlight bash %}
 sudo apt-get update && sudo apt-get -y install foreman-installer
 {% endhighlight %}
@@ -161,13 +182,13 @@ sudo apt-get update && sudo apt-get -y install foreman-installer
 
 #### Running the installer
 
-<div class="quickstart_os quickstart_os_debian11 quickstart_os_ubuntu2004 quickstart_os_ubuntu2204 alert alert-info">
+<div class="quickstart_os quickstart_os_debian11 quickstart_os_debian12 quickstart_os_ubuntu2004 quickstart_os_ubuntu2204 alert alert-info">
   Ensure that <code>ping $(hostname -f)</code> shows the real IP address, not 127.0.1.1.  Change or remove this entry from /etc/hosts if present.
 </div>
 
 The installation run is non-interactive, but the configuration can be customized by supplying any of the options listed in `foreman-installer --help`, or by running `foreman-installer -i` for interactive mode.  More examples are given in the [Installation Options](/manuals/{{page.version}}/index.html#3.2.2InstallerOptions) section.  Adding `-v` will disable the progress bar and display all changes.  To run the installer, execute:
 
-<div class="quickstart_os quickstart_os_none quickstart_os_debian11 quickstart_os_ubuntu2004 quickstart_os_ubuntu2204 quickstart_os_el8 quickstart_os_el9">
+<div class="quickstart_os quickstart_os_none quickstart_os_debian11 quickstart_os_debian12 quickstart_os_ubuntu2004 quickstart_os_ubuntu2204 quickstart_os_el8 quickstart_os_el9">
 {% highlight bash %}
 sudo foreman-installer
 {% endhighlight %}

--- a/_includes/manuals/3.11/2_quickstart_guide.md
+++ b/_includes/manuals/3.11/2_quickstart_guide.md
@@ -10,6 +10,7 @@ The installation will require 4GB of memory, see [System Requirements](manuals/{
 * Enterprise Linux 8, x86_64
 * Enterprise Linux 9, x86_64
 * Debian 11 (Bullseye), amd64
+* Debian 12 (Bookworm), amd64
 * Ubuntu 20.04 (Focal), amd64
 * Ubuntu 22.04 (Jammy), amd64
 

--- a/_includes/manuals/3.11/3.1.1_supported_platforms.md
+++ b/_includes/manuals/3.11/3.1.1_supported_platforms.md
@@ -17,6 +17,8 @@ The following operating systems are supported by the installer, have packages an
   * Architectures: amd64
 * Debian 11 (Bullseye)
   * Architectures: amd64
+* Debian 12 (Bookworm)
+  * Architectures: amd64
 
 PostgreSQL version 10 or newer.
 

--- a/_includes/manuals/3.11/3.3.2_debian_packages.md
+++ b/_includes/manuals/3.11/3.3.2_debian_packages.md
@@ -4,6 +4,7 @@ The Foreman packages should work on the following Debian-based Linux distributio
 #### Distributions
 
 * Debian Linux 11 (Bullseye), amd64
+* Debian Linux 12 (Bookworm), amd64
 * Ubuntu Linux 20.04 LTS (Focal Fossa), amd64
 * Ubuntu Linux 22.04 LTS (Jammy Jellyfish), amd64
 
@@ -16,6 +17,8 @@ Add one of the following lines to your */etc/apt/sources.list* (alternatively in
 ```
 # Debian Bullseye
 deb http://deb.theforeman.org/ bullseye {{page.version}}
+# Debian Bookworm
+deb http://deb.theforeman.org/ bookworm {{page.version}}
 # Ubuntu 20.04 Focal
 deb http://deb.theforeman.org/ focal {{page.version}}
 # Ubuntu 22.04 Jammy

--- a/_includes/manuals/3.11/3.6_upgrade.md
+++ b/_includes/manuals/3.11/3.6_upgrade.md
@@ -38,6 +38,7 @@ To provide specific installation instructions, please select your operating syst
   <option value="el8">Red Hat Enterprise Linux 8</option>
   <option value="el9">CentOS Stream 9 / Red Hat Enterprise Linux 9</option>
   <option value="debian11">Debian 11 (Bullseye)</option>
+  <option value="debian12">Debian 12 (Bookworm)</option>
   <option value="ubuntu2004">Ubuntu 20.04 (Focal)</option>
   <option value="ubuntu2204">Ubuntu 22.04 (Jammy)</option>
 </select>
@@ -63,7 +64,7 @@ Before proceeding, it is necessary to shutdown the Foreman instance.
 systemctl stop httpd foreman.service foreman.socket dynflow\*
 {% endhighlight %}
 </div>
-<div class="upgrade_os upgrade_os_debian11 upgrade_os_ubuntu2004 upgrade_os_ubuntu2204">
+<div class="upgrade_os upgrade_os_debian11 upgrade_os_debian12 upgrade_os_ubuntu2004 upgrade_os_ubuntu2204">
 {% highlight bash %}
 systemctl stop apache2 foreman.service foreman.socket dynflow\*
 {% endhighlight %}
@@ -135,7 +136,7 @@ dnf upgrade ruby\* foreman\*
 {% endhighlight %}
 </div>
 
-<div class="upgrade_os upgrade_os_debian11 upgrade_os_ubuntu2004 upgrade_os_ubuntu2204">
+<div class="upgrade_os upgrade_os_debian11 upgrade_os_debian12 upgrade_os_ubuntu2004 upgrade_os_ubuntu2204">
 Upgrading from the last release to {{page.version}} has been tested. Updating
 the packages will upgrade the application and automatically migrate the
 database.
@@ -146,6 +147,12 @@ number from the previous release to `{{ page.version }}`:
 <div class="upgrade_os upgrade_os_debian11">
 {% highlight bash %}
 deb http://deb.theforeman.org/ bullseye {{ page.version }}
+deb http://deb.theforeman.org/ plugins {{ page.version }}
+{% endhighlight %}
+</div>
+<div class="upgrade_os upgrade_os_debian12">
+{% highlight bash %}
+deb http://deb.theforeman.org/ bookworm {{ page.version }}
 deb http://deb.theforeman.org/ plugins {{ page.version }}
 {% endhighlight %}
 </div>
@@ -220,7 +227,7 @@ Start the application server. This is redundant if you previously ran `foreman-i
 systemctl start httpd foreman.service foreman.socket
 {% endhighlight %}
 </div>
-<div class="upgrade_os upgrade_os_debian11 upgrade_os_ubuntu2004 upgrade_os_ubuntu2204">
+<div class="upgrade_os upgrade_os_debian11 upgrade_os_debian12 upgrade_os_ubuntu2004 upgrade_os_ubuntu2204">
 {% highlight bash %}
 systemctl start apache2 foreman.service foreman.socket
 {% endhighlight %}


### PR DESCRIPTION
This applies 3c30513b8a54576949b099f1df0f1385304ecb96 to 3.11 and adds the headline feature.