### PR TITLE
fix: replace deprecated foreman-rake task

### DIFF
--- a/plugins/foreman_openscap/1.0/index.md
+++ b/plugins/foreman_openscap/1.0/index.md
@@ -186,7 +186,7 @@ __Creating default SCAP content__
 
 * Install smart_proxy_openscap on one (or more) of your proxies
 * Refresh features of that proxy (so it will register with OpenSCAP feature on the Foreman)
-* from terminal run `foreman-rake foreman_openscap:bulk_upload:default`
+* from terminal run `hammer scap-content bulk-upload --type default`
 
 This will search for scap-security-guide SCAP contents and create SCAP content on the Foreman.
 


### PR DESCRIPTION
`foreman-rake foreman_openscap:bulk_upload:default` returns "DEPRECATION WARNING: Uploading scap contents using rake task is deprecated and will be removed in a future version. Please use API or CLI.", replace with Hammer CLI command.