### PR TITLE
Add GitHub Action to deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,35 @@
+name: Deployment
+
+concurrency:
+  group: production
+
+on:
+  push:
+    branches:
+      - gh-pages
+
+jobs:
+  deployment:
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3'
+          bundler-cache: true
+      - name: Build website
+        run: bundle exec rake build
+      - name: Set up SSH key
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_rsa
+          chmod 600 ~/.ssh/id_rsa
+          echo "${{ secrets.SSH_KNOWN_HOSTS }}" > ~/.ssh/known_hosts
+      - name: Create a log file
+        run: echo "rsync_log=$(mktemp)" >> "$GITHUB_ENV"
+      - name: Copy files
+        run: rsync --log-file "${rsync_log}" --log-file-format 'CHANGED %f' --archive --checksum --verbose --one-file-system --compress --stats --delete-after ./_site/ ${{ secrets.DEPLOY_TARGET }}
+      - name: Purge CDN
+        run: awk '/ CHANGED /{print $5}' "${rsync_log}" | xargs --no-run-if-empty fastly-purge 'https://theforeman.org/'


### PR DESCRIPTION
Today we use GitHub Actions to build and deploy using Jenkins. This implements a deployment using GitHub Actions so we use a single environment.

The design is to build the website just like we do in CI, but then set up SSH for rsync followed by the actual rsync.

It introduces 3 secrets that are intended to be set as environment secrets:

* `SSH_PRIVATE_KEY`
* `SSH_KNOWN_HOSTS`
* `DEPLOY_TARGET`

Link: https://docs.github.com/en/actions/use-cases-and-examples/deploying/deploying-with-github-actions