### PR TITLE
Clarify that foreman_scap_client is included in client repo

### DIFF
--- a/plugins/foreman_openscap/1.0/index.md
+++ b/plugins/foreman_openscap/1.0/index.md
@@ -128,8 +128,6 @@ Workflow with Puppet and Ansible is similar. In the first step, you install appr
 
 It is important to make sure the *foreman_scap_client* package is available on your client system. The package is included in the [Foreman client repository](https://yum.theforeman.org/client/3.13/el9/x86_64/).
 
-Do not enable the Foreman plugins repository on client systems. It is intended for Foreman server components. You can optionally enable the repo using the appropriate parameters/variables. It is disabled by default as users may prefer to use their own mirror.
-
 ### 2.3.1 Puppet
 
 Recommended way is to install the packaged version from our repositories using the installer:

--- a/plugins/foreman_openscap/1.0/index.md
+++ b/plugins/foreman_openscap/1.0/index.md
@@ -126,7 +126,9 @@ Edit ```/etc/foreman-proxy/settings.d/openscap.yml``` with the appropriate setti
 
 Workflow with Puppet and Ansible is similar. In the first step, you install appropriate package and import module or role which takes care of the client deployment. Foreman overrides parameters/variables for port, server and policies behind the scenes to make sure appropriate configuration is available to the client. When configuration is applied to host, foreman_scap_client is installed, client config is written to ```/etc/foreman_scap_client/config.yaml``` and a cron that will upload reports based on configuration of each policy is created.
 
-It is important to make sure *foreman_scap_client* package is available to your client system. Foreman plugins repo can be optionally enabled using the appropriate parameters/variables. The repo is disabled by default as users may prefer to use their own mirror.
+It is important to make sure the *foreman_scap_client* package is available on your client system. The package is included in the [Foreman client repository](https://yum.theforeman.org/client/3.13/el9/x86_64/).
+
+Do not enable the Foreman plugins repository on client systems. It is intended for Foreman server components. You can optionally enable the repo using the appropriate parameters/variables. It is disabled by default as users may prefer to use their own mirror.
 
 ### 2.3.1 Puppet
 

--- a/plugins/foreman_openscap/1.0/index.md
+++ b/plugins/foreman_openscap/1.0/index.md
@@ -126,7 +126,7 @@ Edit ```/etc/foreman-proxy/settings.d/openscap.yml``` with the appropriate setti
 
 Workflow with Puppet and Ansible is similar. In the first step, you install appropriate package and import module or role which takes care of the client deployment. Foreman overrides parameters/variables for port, server and policies behind the scenes to make sure appropriate configuration is available to the client. When configuration is applied to host, foreman_scap_client is installed, client config is written to ```/etc/foreman_scap_client/config.yaml``` and a cron that will upload reports based on configuration of each policy is created.
 
-It is important to make sure the *foreman_scap_client* package is available on your client system. The package is included in the [Foreman client repository](https://yum.theforeman.org/client/3.13/el9/x86_64/).
+It is important to make sure the *rubygem-foreman_scap_client* package is available on your client system. The package is included in the [Foreman client repository](https://yum.theforeman.org/client/3.13/el9/x86_64/).
 
 ### 2.3.1 Puppet
 


### PR DESCRIPTION
https://community.theforeman.org/t/unable-to-install-foreman-scap-client/42039 reports an issue in the foreman_scap_client manual:

> It is important to make sure foreman_scap_client package is available to your client system. Foreman plugins repo can be optionally enabled using the appropriate parameters/variables. The repo is disabled by default as users may prefer to use their own mirror.

Feedback:

> That’s an unfortunate wording, foreman_scap_client lives in the client repo[1]. You shouldn’t really enable the plugin repo on the clients. And of course, we’ll fix that in the docs, thank you for pointing it out.

I'd like to try to fix those docs.