### PR TITLE
List Puppet 8 as supported

### DIFF
--- a/_includes/manuals/3.12/3.1.3_puppet_versions.md
+++ b/_includes/manuals/3.12/3.1.3_puppet_versions.md
@@ -25,6 +25,12 @@ Foreman integrates with Puppet and Facter in a few places, but generally using a
     <td>Untested</td>
     <td>Supported</td>
   </tr>
+  <tr>
+    <td>8.x</td>
+    <td>Supported</td>
+    <td>Untested</td>
+    <td>Supported</td>
+  </tr>
 </table>
 
 #### AIO installer compatibility

--- a/_includes/manuals/3.13/3.1.3_puppet_versions.md
+++ b/_includes/manuals/3.13/3.1.3_puppet_versions.md
@@ -25,6 +25,12 @@ Foreman integrates with Puppet and Facter in a few places, but generally using a
     <td>Untested</td>
     <td>Supported</td>
   </tr>
+  <tr>
+    <td>8.x</td>
+    <td>Supported</td>
+    <td>Untested</td>
+    <td>Supported</td>
+  </tr>
 </table>
 
 #### AIO installer compatibility

--- a/_includes/manuals/3.14/3.1.3_puppet_versions.md
+++ b/_includes/manuals/3.14/3.1.3_puppet_versions.md
@@ -25,6 +25,12 @@ Foreman integrates with Puppet and Facter in a few places, but generally using a
     <td>Untested</td>
     <td>Supported</td>
   </tr>
+  <tr>
+    <td>8.x</td>
+    <td>Supported</td>
+    <td>Untested</td>
+    <td>Supported</td>
+  </tr>
 </table>
 
 #### AIO installer compatibility

--- a/_includes/manuals/3.15/3.1.3_puppet_versions.md
+++ b/_includes/manuals/3.15/3.1.3_puppet_versions.md
@@ -25,6 +25,12 @@ Foreman integrates with Puppet and Facter in a few places, but generally using a
     <td>Untested</td>
     <td>Supported</td>
   </tr>
+  <tr>
+    <td>8.x</td>
+    <td>Supported</td>
+    <td>Untested</td>
+    <td>Supported</td>
+  </tr>
 </table>
 
 #### AIO installer compatibility

--- a/_includes/manuals/nightly/3.1.3_puppet_versions.md
+++ b/_includes/manuals/nightly/3.1.3_puppet_versions.md
@@ -25,6 +25,12 @@ Foreman integrates with Puppet and Facter in a few places, but generally using a
     <td>Untested</td>
     <td>Supported</td>
   </tr>
+  <tr>
+    <td>8.x</td>
+    <td>Supported</td>
+    <td>Untested</td>
+    <td>Supported</td>
+  </tr>
 </table>
 
 #### AIO installer compatibility


### PR DESCRIPTION
The 3.12 release notes list Puppet 8 as supported:

https://theforeman.org/manuals/3.12/index.html#Headlinefeatures