### PR TITLE
Update Realm FreeIPA Keytab Documentation with SELinux permissions fix for 3.12<

### DIFF
--- a/_includes/manuals/3.12/4.3.8.2_freeipa_realm.md
+++ b/_includes/manuals/3.12/4.3.8.2_freeipa_realm.md
@@ -29,8 +29,12 @@ Do not use 'foreman-proxy' as the username for this -- this is a local user used
 Copy the freeipa.keytab created above to /etc/foreman-proxy/freeipa.keytab and set
 the correct permissions:
 
-        chown foreman-proxy /etc/foreman-proxy/freeipa.keytab
-        chmod 600 /etc/foreman-proxy/freeipa.keytab
+    chown foreman-proxy /etc/foreman-proxy/freeipa.keytab
+    chmod 600 /etc/foreman-proxy/freeipa.keytab
+
+If you have SELinux enforcing on the system, ensure that the file security context is correct:
+
+    restorecon -vF /etc/foreman-proxy/freeipa.keytab
 
 Then update `settings.d/realm_freeipa.yml` with the relevant settings.
 

--- a/_includes/manuals/3.13/4.3.8.2_freeipa_realm.md
+++ b/_includes/manuals/3.13/4.3.8.2_freeipa_realm.md
@@ -29,8 +29,12 @@ Do not use 'foreman-proxy' as the username for this -- this is a local user used
 Copy the freeipa.keytab created above to /etc/foreman-proxy/freeipa.keytab and set
 the correct permissions:
 
-        chown foreman-proxy /etc/foreman-proxy/freeipa.keytab
-        chmod 600 /etc/foreman-proxy/freeipa.keytab
+    chown foreman-proxy /etc/foreman-proxy/freeipa.keytab
+    chmod 600 /etc/foreman-proxy/freeipa.keytab
+
+If you have SELinux enforcing on the system, ensure that the file security context is correct:
+
+    restorecon -vF /etc/foreman-proxy/freeipa.keytab
 
 Then update `settings.d/realm_freeipa.yml` with the relevant settings.
 

--- a/_includes/manuals/3.14/4.3.8.2_freeipa_realm.md
+++ b/_includes/manuals/3.14/4.3.8.2_freeipa_realm.md
@@ -29,8 +29,12 @@ Do not use 'foreman-proxy' as the username for this -- this is a local user used
 Copy the freeipa.keytab created above to /etc/foreman-proxy/freeipa.keytab and set
 the correct permissions:
 
-        chown foreman-proxy /etc/foreman-proxy/freeipa.keytab
-        chmod 600 /etc/foreman-proxy/freeipa.keytab
+    chown foreman-proxy /etc/foreman-proxy/freeipa.keytab
+    chmod 600 /etc/foreman-proxy/freeipa.keytab
+
+If you have SELinux enforcing on the system, ensure that the file security context is correct:
+
+    restorecon -vF /etc/foreman-proxy/freeipa.keytab
 
 Then update `settings.d/realm_freeipa.yml` with the relevant settings.
 

--- a/_includes/manuals/3.15/4.3.8.2_freeipa_realm.md
+++ b/_includes/manuals/3.15/4.3.8.2_freeipa_realm.md
@@ -29,8 +29,12 @@ Do not use 'foreman-proxy' as the username for this -- this is a local user used
 Copy the freeipa.keytab created above to /etc/foreman-proxy/freeipa.keytab and set
 the correct permissions:
 
-        chown foreman-proxy /etc/foreman-proxy/freeipa.keytab
-        chmod 600 /etc/foreman-proxy/freeipa.keytab
+    chown foreman-proxy /etc/foreman-proxy/freeipa.keytab
+    chmod 600 /etc/foreman-proxy/freeipa.keytab
+
+If you have SELinux enforcing on the system, ensure that the file security context is correct:
+
+    restorecon -vF /etc/foreman-proxy/freeipa.keytab
 
 Then update `settings.d/realm_freeipa.yml` with the relevant settings.
 

--- a/_includes/manuals/nightly/4.3.8.2_freeipa_realm.md
+++ b/_includes/manuals/nightly/4.3.8.2_freeipa_realm.md
@@ -29,8 +29,12 @@ Do not use 'foreman-proxy' as the username for this -- this is a local user used
 Copy the freeipa.keytab created above to /etc/foreman-proxy/freeipa.keytab and set
 the correct permissions:
 
-        chown foreman-proxy /etc/foreman-proxy/freeipa.keytab
-        chmod 600 /etc/foreman-proxy/freeipa.keytab
+    chown foreman-proxy /etc/foreman-proxy/freeipa.keytab
+    chmod 600 /etc/foreman-proxy/freeipa.keytab
+
+If you have SELinux enforcing on the system, ensure that the file security context is correct:
+
+    restorecon -vF /etc/foreman-proxy/freeipa.keytab
 
 Then update `settings.d/realm_freeipa.yml` with the relevant settings.
 


### PR DESCRIPTION
If using mv instead of cp to place the freeipa.keytab file into the foreman-proxy directory then it's possible for the SELinux context to be admin_home_t instead of etc_t.

By adding restorecon to the instructions can ensure that deployers who prefer using mv over cp as a security measure or habit (i.e to avoid forgetting to clean it out of /root) is a smoother experience as not repairing the SELinux context can cause generic permission errors on the Foreman Installer for the file when enabling the Realm feature.

Also gets rid of the extra white space padding at the beginning of the chown and chmod commands to bring it more inline with rest of docs.