### PR TITLE
Update 3.16 release notes to mention oVirt plugin migration

### DIFF
--- a/_includes/manuals/3.16/1.2_release_notes.md
+++ b/_includes/manuals/3.16/1.2_release_notes.md
@@ -26,7 +26,7 @@
   - **Previous Deprecation**: Feature was deprecated in Foreman 3.15
   - **Impact**: Users with RHV/oVirt compute resources will lose this functionality unless they install the new ForemanOvirt plugin
   - **Alternative Solution**: Install the new ForemanOvirt plugin to maintain oVirt functionality
-  - **Action Required**: If using RHV compute resources, plan migration to alternative platforms or install the ForemanOvirt plugin before upgrading. Users who want to keep oVirt support must install the ForemanOvirt plugin before upgrading. Users who do not want oVirt support are advised to run `foreman-rake ovirt:drop` before upgrading.
+  - **Action Required**: If using oVirt compute resources, plan migration to alternative platforms or install the ForemanOvirt plugin before upgrading. Users who want to keep oVirt support must install the ForemanOvirt plugin before upgrading. Users who do not want oVirt support are advised to run `foreman-rake ovirt:drop` before upgrading.
 
 #### UI Component Phase-Outs
 - **Legacy AngularJS Pages** - Continued elimination of AngularJS-based UI components as part of All Hosts redesign

--- a/_includes/manuals/3.16/1.2_release_notes.md
+++ b/_includes/manuals/3.16/1.2_release_notes.md
@@ -24,8 +24,9 @@
 
 - **🚨 RHV/oVirt Support Completely Removed** - Red Hat Virtualization (RHV) and oVirt compute resource support has been fully removed
   - **Previous Deprecation**: Feature was deprecated in Foreman 3.15
-  - **Impact**: Users with RHV/oVirt compute resources will lose this functionality
-  - **Action Required**: Users are advised to run `foreman-rake ovirt:drop` before upgrading.
+  - **Impact**: Users with RHV/oVirt compute resources will lose this functionality unless they install the new ForemanOvirt plugin
+  - **Alternative Solution**: Install the new ForemanOvirt plugin to maintain oVirt functionality
+  - **Action Required**: If using RHV compute resources, plan migration to alternative platforms or install the ForemanOvirt plugin before upgrading. Users who want to keep oVirt support must install the ForemanOvirt plugin before upgrading. Users who do not want oVirt support are advised to run `foreman-rake ovirt:drop` before upgrading.
 
 #### UI Component Phase-Outs
 - **Legacy AngularJS Pages** - Continued elimination of AngularJS-based UI components as part of All Hosts redesign


### PR DESCRIPTION
Based on https://community.theforeman.org/t/foreman-3-16-0-is-now-available/44354/5, this patch changes the following:

- Add ForemanOvirt plugin as alternative solution for oVirt users
- Clarify that functionality is preserved via third-party plugin
- Provide clear migration paths for users who want to keep/remove oVirt support
- Align with foreman-documentation release notes content
