### PR TITLE
Simpler execution of committers script

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,4 @@ source "https://rubygems.org"
 gem 'github-pages', '>= 147'
 gem 'rake'
 gem 'webrick'
+gem 'git'

--- a/Gemfile
+++ b/Gemfile
@@ -3,4 +3,3 @@ source "https://rubygems.org"
 gem 'github-pages', '>= 147'
 gem 'rake'
 gem 'webrick'
-gem 'git'

--- a/scripts/Gemfile
+++ b/scripts/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem 'git', '~> 2.3'

--- a/scripts/committers.rb
+++ b/scripts/committers.rb
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
-# Run with: bundle exec --gemfile=scripts/Gemfile ruby scripts/committers.rb TAG_FROM TAG_TO
-# Or from scripts directory: bundle exec ruby committers.rb TAG_FROM TAG_TO
+# Run with: bundle exec --gemfile=scripts/Gemfile ruby ./committers.rb TAG_FROM TAG_TO
+# Or from scripts directory: bundle exec ./committers.rb TAG_FROM TAG_TO
 require 'tmpdir'
 require 'git'
 require 'optparse'

--- a/scripts/committers.rb
+++ b/scripts/committers.rb
@@ -1,4 +1,6 @@
 #!/usr/bin/env ruby
+# Run with: bundle exec --gemfile=scripts/Gemfile ruby scripts/committers.rb TAG_FROM TAG_TO
+# Or from scripts directory: bundle exec ruby committers.rb TAG_FROM TAG_TO
 require 'tmpdir'
 require 'git'
 require 'optparse'

--- a/scripts/committers.rb
+++ b/scripts/committers.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/ruby
+#!/usr/bin/env ruby
 require 'tmpdir'
 require 'git'
 require 'optparse'


### PR DESCRIPTION
The script was failing when run directly due to the wrong Ruby interpreter in the shebang.

**Changes:**
- **Change shebang to use Ruby from PATH** - Changed from `#!/usr/bin/ruby` to `#!/usr/bin/env ruby` to respect the user's Ruby installation (rbenv, rvm, etc.)
- **Add usage instructions** - Added comments explaining how to run the script using the existing `scripts/Gemfile`

**Usage:**
```bash
bundle exec --gemfile=scripts/Gemfile ruby scripts/committers.rb TAG_FROM TAG_TO
```

The `git` gem dependency is managed in `scripts/Gemfile` (not the main Gemfile) to keep script dependencies separate from website building dependencies.