### PR TITLE
Add release notes for Foreman 3.16.2

### DIFF
--- a/_includes/manuals/3.16/1.2_release_notes.md
+++ b/_includes/manuals/3.16/1.2_release_notes.md
@@ -30,6 +30,36 @@
 #### UI Component Phase-Outs
 - **Legacy AngularJS Pages** - Continued elimination of AngularJS-based UI components as part of All Hosts redesign
 
+### Release notes for {{page.version}}.2
+#### Foreman - Security
+* CVE-2025-9572: GraphQL API permission bypass leads to information disclosure ([#38913](https://projects.theforeman.org/issues/38913))
+
+#### Installer - Foreman modules
+* Add support for foreman_ovirt plugin ([#38921](https://projects.theforeman.org/issues/38921))
+
+*A full list of changes in 3.16.2 is available via [Redmine](https://projects.theforeman.org/issues?set_filter=1&sort=id%3Adesc&status_id=closed&f[]=cf_12&op[cf_12]=%3D&v[cf_12]=2007)*
+
+### Release notes for {{page.version}}.1
+#### Foreman
+* generate report datepicker overlapping ([#38715](https://projects.theforeman.org/issues/38715))
+
+#### Foreman - API
+* Backend system status widget does not display all plugins ([#38667](https://projects.theforeman.org/issues/38667))
+
+#### Foreman - Internationalization
+* Setting descriptions aren't translated anymore ([#38735](https://projects.theforeman.org/issues/38735))
+
+#### Foreman - Security
+* CVE-2025-10622: OS command injection via ct_location and fcct_location parameters ([#38885](https://projects.theforeman.org/issues/38885))
+
+#### Foreman - Settings
+* Settings - Update value from response ([#38795](https://projects.theforeman.org/issues/38795))
+
+#### Foreman - Users, Roles and Permissions
+* Handle invalid scope filter in UI ([#38655](https://projects.theforeman.org/issues/38655))
+
+*A full list of changes in 3.16.1 is available via [Redmine](https://projects.theforeman.org/issues?set_filter=1&sort=id%3Adesc&status_id=closed&f[]=cf_12&op[cf_12]=%3D&v[cf_12]=1991)*
+
 ### Release notes for {{page.version}}.0
 #### Foreman
 * Use GPG key for SLES during host registration ([#38608](https://projects.theforeman.org/issues/38608))
@@ -176,29 +206,6 @@
 * LDAP group membership ([#38611](https://projects.theforeman.org/issues/38611))
 
 *A full list of changes in 3.16.0 is available via [Redmine](https://projects.theforeman.org/issues?set_filter=1&sort=id%3Adesc&status_id=closed&f[]=cf_12&op[cf_12]=%3D&v[cf_12]=1964)*
-
-### Release notes for {{page.version}}.1
-#### Foreman
-* generate report datepicker overlapping ([#38715](https://projects.theforeman.org/issues/38715))
-
-#### Foreman - API
-* Backend system status widget does not display all plugins ([#38667](https://projects.theforeman.org/issues/38667))
-
-#### Foreman - Internationalization
-* Setting descriptions aren't translated anymore ([#38735](https://projects.theforeman.org/issues/38735))
-
-#### Foreman - Security
-* CVE-2025-10622: OS command injection via ct_location and fcct_location parameters ([#38885](https://projects.theforeman.org/issues/38885))
-
-#### Foreman - Settings
-* Settings - Update value from response ([#38795](https://projects.theforeman.org/issues/38795))
-
-#### Foreman - Users, Roles and Permissions
-* Handle invalid scope filter in UI ([#38655](https://projects.theforeman.org/issues/38655))
-
-*A full list of changes in 3.16.1 is available via [Redmine](https://projects.theforeman.org/issues?set_filter=1&sort=id%3Adesc&status_id=closed&f[]=cf_12&op[cf_12]=%3D&v[cf_12]=1991)*
-
-
 
 ### Contributors
 


### PR DESCRIPTION
This PR adds release notes for Foreman 3.16.2 and reorders existing notes to match the order of release notes on docs.theforeman.org.