### PR TITLE
Fix Jeykyll warnings in 2020 Ansible-related post

### DIFF
--- a/_posts/2020-10-05-how-to-write-a-new-foreman-ansible-module-in-20-lines-of-code.md
+++ b/_posts/2020-10-05-how-to-write-a-new-foreman-ansible-module-in-20-lines-of-code.md
@@ -111,6 +111,7 @@ To write a test, just drop a new playbook into `tests/test_playbooks/` called `<
 
 For the HTTP Proxy module, the tasks file looks like this:
 
+{% raw %}
 ```yaml
 ---
 - name: "Create/Update/Delete HTTP Proxy"
@@ -136,6 +137,7 @@ For the HTTP Proxy module, the tasks file looks like this:
   when: expected_change is defined
 ...
 ```
+{% endraw %}
 
 In this task file, there are two tasks. The first one calls the `http_proxy` module, passing in the connection information and the module-specific parameters, most of which have `default(omit)` specified, which means these parameters won't be passed to the module if the variable isn't set -- super useful when you need to test the module with different sets of parameters. And the second one that ensures that the module reported the `changed` attribute correctly.
 


### PR DESCRIPTION
Jeykyll complains:
```
    Liquid Warning: Liquid syntax error (line 116): Expected end_of_string but found open_round in "{{ http_proxy_url | default(omit) }}" in /home/ogajduse/repos/theforeman.org/_posts/2020-10-05-how-to-write-a-new-foreman-ansible-module-in-20-lines-of-code.md
    Liquid Warning: Liquid syntax error (line 117): Expected end_of_string but found open_round in "{{ http_proxy_username | default(omit) }}" in /home/ogajduse/repos/theforeman.org/_posts/2020-10-05-how-to-write-a-new-foreman-ansible-module-in-20-lines-of-code.md
    Liquid Warning: Liquid syntax error (line 118): Expected end_of_string but found open_round in "{{ http_proxy_password | default(omit) }}" in /home/ogajduse/repos/theforeman.org/_posts/2020-10-05-how-to-write-a-new-foreman-ansible-module-in-20-lines-of-code.md
    Liquid Warning: Liquid syntax error (line 119): Expected end_of_string but found open_round in "{{ http_proxy_locations | default(omit) }}" in /home/ogajduse/repos/theforeman.org/_posts/2020-10-05-how-to-write-a-new-foreman-ansible-module-in-20-lines-of-code.md
    Liquid Warning: Liquid syntax error (line 120): Expected end_of_string but found open_round in "{{ http_proxy_organizations | default(omit) }}" in /home/ogajduse/repos/theforeman.org/_posts/2020-10-05-how-to-write-a-new-foreman-ansible-module-in-20-lines-of-code.md
    Liquid Warning: Liquid syntax error (line 124): Expected end_of_string but found open_round in "{{ expected_change | default('unknown') }}" in /home/ogajduse/repos/theforeman.org/_posts/2020-10-05-how-to-write-a-new-foreman-ansible-module-in-20-lines-of-code.md
```

### Before
<img width="566" height="520" alt="image" src="https://github.com/user-attachments/assets/af4308fa-6f8b-42d9-85d6-7c78c71f467c" />

### After
<img width="566" height="532" alt="image" src="https://github.com/user-attachments/assets/03e55017-d288-4b5d-8fad-71260f930319" />
