### PR TITLE
Add Volkswagen AG to who_uses.md

### DIFF
--- a/who_uses.md
+++ b/who_uses.md
@@ -26,3 +26,4 @@ The list is in alphabetical order.
 * [Sixt SE](https://www.sixt.com)
 * [ThinkIT Data Solutions](http://thinkitdata.com/)
 * [Tipsport.net](https://www.tipsport.cz)
+* [Volkswagen AG](https://www.volkswagen-group.com/)


### PR DESCRIPTION
This pull request adds an entry for Volkswagen AG to who_uses.md and includes a link to the official company website: https://www.volkswagen-group.com/.

Volkswagen AG has been using The Foreman for several years, and we would be pleased to be included in the “Who uses Foreman” list.