### PR TITLE
Migrate installer Dockerfile from Puppet to OpenVox

### DIFF
--- a/scripts/installer/Dockerfile
+++ b/scripts/installer/Dockerfile
@@ -1,6 +1,6 @@
 FROM quay.io/centos/centos:stream9
 
-RUN dnf -y install https://yum.puppetlabs.com/puppet8-release-el-9.noarch.rpm
+RUN dnf -y install https://yum.voxpupuli.org/openvox8-release-el-9.noarch.rpm
 
 ARG FOREMAN_VERSION
 RUN dnf -y install https://yum.theforeman.org/releases/$FOREMAN_VERSION/el9/x86_64/foreman-release.rpm


### PR DESCRIPTION
Updates the installer Dockerfile to use OpenVox 8 repository instead of Puppet 8, continuing the ongoing migration to OpenVox.