### PR TITLE
Add Containerfile using official Ruby image

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,8 +1,7 @@
-FROM docker.io/library/ruby:3.1-alpine
+FROM docker.io/library/ruby:3.4-alpine
 WORKDIR /srv/jekyll
 
 RUN apk add --no-cache build-base
-RUN gem install bundler
 
 COPY Gemfile ./
 RUN bundle install

--- a/Containerfile
+++ b/Containerfile
@@ -7,7 +7,5 @@ RUN gem install bundler
 COPY Gemfile ./
 RUN bundle install
 
-COPY . .
-
 EXPOSE 4000
 CMD ["bundle", "exec", "jekyll", "serve", "--host", "0.0.0.0", "--watch"]

--- a/Containerfile
+++ b/Containerfile
@@ -1,24 +1,13 @@
 FROM docker.io/library/ruby:3.1-alpine
-
 WORKDIR /srv/jekyll
 
-# Install build dependencies
 RUN apk add --no-cache build-base
-
-# Install bundler
 RUN gem install bundler
 
-# Copy Gemfile for dependency installation
 COPY Gemfile ./
-
-# Install gems
 RUN bundle install
 
-# Copy the rest of the site
 COPY . .
 
-# Expose Jekyll port
 EXPOSE 4000
-
-# Run Jekyll serve
 CMD ["bundle", "exec", "jekyll", "serve", "--host", "0.0.0.0", "--watch"]

--- a/Containerfile
+++ b/Containerfile
@@ -1,0 +1,24 @@
+FROM docker.io/library/ruby:3.1-alpine
+
+WORKDIR /srv/jekyll
+
+# Install build dependencies
+RUN apk add --no-cache build-base
+
+# Install bundler
+RUN gem install bundler
+
+# Copy Gemfile for dependency installation
+COPY Gemfile ./
+
+# Install gems
+RUN bundle install
+
+# Copy the rest of the site
+COPY . .
+
+# Expose Jekyll port
+EXPOSE 4000
+
+# Run Jekyll serve
+CMD ["bundle", "exec", "jekyll", "serve", "--host", "0.0.0.0", "--watch"]

--- a/README.md
+++ b/README.md
@@ -27,6 +27,11 @@ To start Jekyll server locally.
 docker run -it --rm -v `pwd`:/srv/jekyll:Z -p 4000:4000 jekyll/jekyll jekyll serve --watch
 ```
 
+For Podman (rootless), install gems first (container lacks github-pages):
+```
+podman run --rm -v "$(pwd)":/srv/jekyll:Z -p 4000:4000 jekyll/jekyll bash -c "bundle install && jekyll serve --watch"
+```
+
 Navigate to http://localhost:4000
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -21,18 +21,21 @@ to generate your site in the \_site directory, or
 
 To start Jekyll server locally.
 
-### With Docker
+### With Docker/Podman
 
+Build the container image:
 ```
-docker run -it --rm -v `pwd`:/srv/jekyll:Z -p 4000:4000 jekyll/jekyll jekyll serve --watch
+podman build -t theforeman-org .
 ```
 
-For Podman (rootless), install gems first (container lacks github-pages):
+Run the container:
 ```
-podman run --rm -v "$(pwd)":/srv/jekyll:Z -p 4000:4000 jekyll/jekyll bash -c "bundle install && jekyll serve --watch"
+podman run --rm -v "$(pwd)":/srv/jekyll:Z -p 4000:4000 theforeman-org
 ```
 
 Navigate to http://localhost:4000
+
+**Note:** Replace `podman` with `docker` if using Docker.
 
 ## Contributing
 


### PR DESCRIPTION
Adds Containerfile using official Ruby image instead of unmaintained jekyll/jekyll.

Build once, then run:
```bash
podman build -t theforeman-org .
podman run --rm -v "$(pwd)":/srv/jekyll:Z -p 4000:4000 theforeman-org
```

Works with Docker too (replace `podman` with `docker`).