### PR TITLE
Fix malformed cf_12 filter in release notes Redmine link

### DIFF
--- a/scripts/release_notes.rb
+++ b/scripts/release_notes.rb
@@ -88,7 +88,7 @@ grouped_issues.each do |category, issues|
   puts
 end
 
-puts "*A full list of changes in #{@current_release_name} is available via [Redmine](https://projects.theforeman.org/issues?set_filter=1&sort=id%3Adesc&status_id=closed&f[]=cf_12&op[cf_12]=%3D&v[cf_12]=#{@current_release_id})*"
+puts "*A full list of changes in #{@current_release_name} is available via [Redmine](https://projects.theforeman.org/issues?set_filter=1&sort=id%3Adesc&status_id=closed&f[]=cf_12&op[cf_12]=%3D&v[cf_12][]=#{@current_release_id})*"
 
 puts "\n----------[End of notes]----------\n"
 


### PR DESCRIPTION
## Summary
- \`scripts/release_notes.rb\` builds a Redmine link for the full issue list, but used \`v[cf_12]=\` instead of the array form \`v[cf_12][]=\` used by the actual API query a few lines above.
- Redmine expects the array form for this filter; the malformed param gets silently dropped, so opening the link shows an empty Filters section instead of the intended cf_12 filter.

## Test plan
- [x] Run \`./scripts/release_notes.rb foreman <version>\` and confirm the printed Redmine link shows the cf_12 filter applied when opened in a browser