### PR TITLE
Foreman 5.0.0 release notes - GA update

### DIFF
--- a/_includes/manuals/5.0/1.2_release_notes.md
+++ b/_includes/manuals/5.0/1.2_release_notes.md
@@ -56,6 +56,7 @@ If you customized these settings through `foreman-installer`, the old parameters
 #### Foreman
 * Rubocop/CI job fails in GitHub Actions: cap2 gem fails to compile, missing libcap-dev ([#39600](https://projects.theforeman.org/issues/39600))
 * PageLayout uses PF3 layout of Breadcrumbs instead of PF5 ([#39592](https://projects.theforeman.org/issues/39592))
+* Host::Managed audit exclusions not applied, resulting in excessive audit records in Foreman ([#39591](https://projects.theforeman.org/issues/39591))
 * Loosen upper bound on scoped_search ([#39588](https://projects.theforeman.org/issues/39588))
 * Subnet: invalid mask bypasses validation when the network address contains a CIDR suffix ([#39572](https://projects.theforeman.org/issues/39572))
 * Update eslint-plugin-rules require-ouiaid with PF5 components ([#39562](https://projects.theforeman.org/issues/39562))
@@ -207,6 +208,7 @@ If you customized these settings through `foreman-installer`, the old parameters
 #### Smart Proxy
 * Add tls_min_version and tls_ciphers to smart proxy ([#39405](https://projects.theforeman.org/issues/39405))
 * Cache global registration script in smart-proxy ([#39208](https://projects.theforeman.org/issues/39208))
+* Support Rack 3 and Sinatra 4 ([#38120](https://projects.theforeman.org/issues/38120))
 
 #### Smart Proxy - BMC
 * Expose bmc_default_provider setting via v2/features API ([#39320](https://projects.theforeman.org/issues/39320))


### PR DESCRIPTION
## Summary
- Add two missed changelog entries to the 5.0 release notes:
  - Host::Managed audit exclusions not applied, resulting in excessive audit records in Foreman ([#39591](https://projects.theforeman.org/issues/39591))
  - Support Rack 3 and Sinatra 4 ([#38120](https://projects.theforeman.org/issues/38120))