### PR TITLE
Add Noble and Trixie release notes

### DIFF
--- a/_includes/manuals/5.0/1.2_release_notes.md
+++ b/_includes/manuals/5.0/1.2_release_notes.md
@@ -16,6 +16,9 @@ Containerized Foreman deployments (managed with `foremanctl`) now use Valkey 8 r
 
 As the container is based on Enterprise Linux 10, Enterprise Linux 10 system requirements apply, even if the host system itself is not running Enterprise Linux 10. In particular, the host needs to support the x86_64-v3 microarchitecture level. See [Exploring x86-64-v3 for Red Hat Enterprise Linux 10](https://developers.redhat.com/articles/2024/01/02/exploring-x86-64-v3-red-hat-enterprise-linux-10) for further information.
 
+#### Ubuntu 24.04 and Debian 13 support
+Foreman can now be installed on Ubuntu 24.04 (Noble) and Debian 13 (Trixie).
+
 #### Ruby 3.3 support
 Foreman can now run on Ruby 3.3.
 
@@ -116,6 +119,7 @@ If you customized these settings through `foreman-installer`, the old parameters
 * container_certs_setup snippet missing cert directories for load balancer backend hostnames ([#39193](https://projects.theforeman.org/issues/39193))
 * Subnet UI allows CIDR in Network Address causing duplicated prefix (/24/24) ([#39159](https://projects.theforeman.org/issues/39159))
 * Update host vmware form to PF5 ([#38992](https://projects.theforeman.org/issues/38992))
+* Support Foreman installation on Ubuntu 24.04 and Debian 13 ([#37520](https://projects.theforeman.org/issues/37520))
 
 #### Foreman - Authentication
 * SSO login via Apache OIDC fails with a 500 Internal Server Error on Ruby 3.2 ([#39099](https://projects.theforeman.org/issues/39099))

--- a/_includes/manuals/5.0/1.2_release_notes.md
+++ b/_includes/manuals/5.0/1.2_release_notes.md
@@ -54,6 +54,14 @@ If you customized these settings through `foreman-installer`, the old parameters
 #### Container image builds no longer drop RAILS_LOG_TO_STDOUT
 `script/foreman-rake` used a login shell (`runuser - foreman ...`), which cleared `RAILS_LOG_TO_STDOUT` during the container image build and caused install-time rake boots to write `production.log` into the image layer instead of stdout. The variable is now preserved across `runuser`, so container image logs correctly include this output.
 
+### Deprecations
+
+#### Running Foreman on Ubuntu 22.04 (Jammy) and Debian 12 (Bookworm) is deprecated
+
+Foreman supports running on Ubuntu 24.04 (Noble) and Debian 13 (Trixie), therefore running on Ubuntu 22.04 (Jammy) and Debian 12 (Bookworm) is deprecated. Support for these platforms will be removed in a future release, so users are encouraged to plan their upgrade.
+
+This is for running Foreman itself. Clients will remain supported.
+
 ### Release notes for {{page.version}}.0
 
 #### Foreman

--- a/_includes/manuals/5.0/1.2_release_notes.md
+++ b/_includes/manuals/5.0/1.2_release_notes.md
@@ -19,6 +19,8 @@ As the container is based on Enterprise Linux 10, Enterprise Linux 10 system req
 #### Ubuntu 24.04 and Debian 13 support
 Foreman can now be installed on Ubuntu 24.04 (Noble) and Debian 13 (Trixie).
 
+The `foreman_google` plugin is currently not supported on Debian 13 (Trixie) because its `grpc` gem dependency cannot be compiled. Upgrades with the plugin enabled and new installations with the plugin enabled will fail.
+
 #### Ruby 3.3 support
 Foreman can now run on Ruby 3.3.
 
@@ -58,7 +60,7 @@ If you customized these settings through `foreman-installer`, the old parameters
 
 #### Running Foreman on Ubuntu 22.04 (Jammy) and Debian 12 (Bookworm) is deprecated
 
-Foreman supports running on Ubuntu 24.04 (Noble) and Debian 13 (Trixie), therefore running on Ubuntu 22.04 (Jammy) and Debian 12 (Bookworm) is deprecated. Support for these platforms will be removed in a future release, so users are encouraged to plan their upgrade.
+Foreman supports running on Ubuntu 24.04 (Noble) and Debian 13 (Trixie), therefore running on Ubuntu 22.04 (Jammy) and Debian 12 (Bookworm) is deprecated. Users are encouraged to plan their upgrade to a newer supported platform.
 
 This is for running Foreman itself. Clients will remain supported.
 


### PR DESCRIPTION
Add Foreman 5.0 release-note and changelog entries for Ubuntu 24.04 (Noble) and Debian 13 (Trixie): https://projects.theforeman.org/issues/37520

sibbling PR: https://github.com/theforeman/foreman-documentation/pull/5307